### PR TITLE
tests: add example for annotation type Variant

### DIFF
--- a/tests/mocks/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183a/latest/annotationCollection.json
+++ b/tests/mocks/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183a/latest/annotationCollection.json
@@ -1,1 +1,8 @@
-{"@context": "http://www.w3.org/ns/anno.jsonld", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/annotationCollection/3r176/183a", "type": "AnnotationCollection", "label": "Ahiqar annotations for textgrid:3r176: Brit.Mus. cod. Add. 7209, page 183a", "x-creator": "Dr. Aly Elrefaei", "first": "http://localhost:8181/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183a/latest/annotationPage.json"}
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "http://ahiqar.uni-goettingen.de/ns/annotations/annotationCollection/3r176/183a",
+  "type": "AnnotationCollection",
+  "label": "Ahiqar annotations for textgrid:3r176: Brit.Mus. cod. Add. 7209, page 183a",
+  "x-creator": "Dr. Aly Elrefaei",
+  "first": "http://localhost:8181/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183a/latest/annotationPage.json"
+}

--- a/tests/mocks/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183a/latest/annotationPage.json
+++ b/tests/mocks/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183a/latest/annotationPage.json
@@ -1,1 +1,410 @@
-{"@context": "http://www.w3.org/ns/anno.jsonld", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/annotationPage/arabic-karshuni/3r176-183a", "type": "AnnotationPage", "partOf": {"id": "http://ahiqar.uni-goettingen.de/ns/annotations/annotationCollection/3r176", "label": "Ahiqar annotations for textgrid:3r176: Brit.Mus. cod. Add. 7209"}, "next": "http://localhost:8181/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183b/latest/annotationPage.json", "prev": "http://localhost:8181/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/182b/latest/annotationPage.json", "items": [{"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0722\u0710\u0715\u0722"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l6l4l58l2"}, "language": "karshuni", "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l58l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0722\u0710\u0715\u0722"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l6l4l62l2"}, "language": "karshuni", "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l62l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0722\u0710\u0715\u0722"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l6l4l72l2"}, "language": "karshuni", "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l72l2"}, {"body": {"x-content-type": "Editorial Comment", "type": "TextualBody", "format": "text/plain", "value": "correction of faulty text. original: \u0718\u0710\u0720\u0726\u0720\u0710\u0723\u0726\u0717, corrected by the editor to: \u0718\u0710\u0720\u0726\u0720\u0723\u0726\u0717"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l6l4l76l2"}, "language": "karshuni", "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l76l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0723\u0722\u071a\u0710\u072a\u071d\u0712"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l6l4l78l2"}, "language": "karshuni", "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l78l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u071a\u071d\u0729\u072a"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l6l4l80l2"}, "language": "karshuni", "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l80l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0646\u0627\u062f\u0646"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l4l4l60l2"}, "language": "ara", "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l60l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0646\u0627\u062f\u0646"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l4l4l64l2"}, "language": "ara", "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l64l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0646\u0627\u062f\u0646"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l4l4l74l2"}, "language": "ara", "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l74l2"}, {"body": {"x-content-type": "Editorial Comment", "type": "TextualBody", "format": "text/plain", "value": "correction of faulty text. original: \u0648\u0627\u0644\u0641\u0644\u0627\u0633\u0641\u0647, corrected by the editor to: \u0648\u0627\u0644\u0641\u0644\u0633\u0641\u0629"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l4l4l78l2"}, "language": "ara", "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l78l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u0633\u0646\u062d\u0627\u0631\u064a\u0628"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l4l4l80l2"}, "language": "ara", "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l80l2"}, {"body": {"x-content-type": "Person", "type": "TextualBody", "format": "text/plain", "value": "\u062d\u064a\u0642\u0631"}, "target": [{"selector": {"type": "CssSelector", "value": "#MD12675N1l4l2l4l4l82l2"}, "language": "ara", "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html", "format": "text/xml"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l82l2"}, {"body": {"x-content-type": "Motif", "type": "TextualBody", "format": "text/plain", "value": "Loyal obligation (gods)"}, "target": [{"selector": {"type": "CssSelector", "value": "#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l45l4_1,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l45l4_2,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l45l4_3,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l47l2_1,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l47l2_2,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l47l2_3"}, "source": "PLACEHOLDER \u2192 TARGET CONTENT HTML IRI"}], "type": "Annotation", "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l44l2"}]}
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "http://ahiqar.uni-goettingen.de/ns/annotations/annotationPage/arabic-karshuni/3r176-183a",
+  "type": "AnnotationPage",
+  "partOf": {
+    "id": "http://ahiqar.uni-goettingen.de/ns/annotations/annotationCollection/3r176",
+    "label": "Ahiqar annotations for textgrid:3r176: Brit.Mus. cod. Add. 7209"
+  },
+  "next": "http://localhost:8181/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/183b/latest/annotationPage.json",
+  "prev": "http://localhost:8181/ahiqar/annotations/ahiqar/arabic-karshuni/3r176/182b/latest/annotationPage.json",
+  "items": [
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0722\u0710\u0715\u0722"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l6l4l58l2"
+          },
+          "language": "karshuni",
+          "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l58l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0722\u0710\u0715\u0722"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l6l4l62l2"
+          },
+          "language": "karshuni",
+          "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l62l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0722\u0710\u0715\u0722"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l6l4l72l2"
+          },
+          "language": "karshuni",
+          "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l72l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Editorial Comment",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "correction of faulty text. original: \u0718\u0710\u0720\u0726\u0720\u0710\u0723\u0726\u0717, corrected by the editor to: \u0718\u0710\u0720\u0726\u0720\u0723\u0726\u0717"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l6l4l76l2"
+          },
+          "language": "karshuni",
+          "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l76l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0723\u0722\u071a\u0710\u072a\u071d\u0712"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l6l4l78l2"
+          },
+          "language": "karshuni",
+          "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l78l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u071a\u071d\u0729\u072a"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l6l4l80l2"
+          },
+          "language": "karshuni",
+          "source": "http://localhost:8181/ahiqar/content/transliteration/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l6l4l80l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0646\u0627\u062f\u0646"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l4l4l60l2"
+          },
+          "language": "ara",
+          "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l60l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0646\u0627\u062f\u0646"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l4l4l64l2"
+          },
+          "language": "ara",
+          "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l64l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0646\u0627\u062f\u0646"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l4l4l74l2"
+          },
+          "language": "ara",
+          "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l74l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Editorial Comment",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "correction of faulty text. original: \u0648\u0627\u0644\u0641\u0644\u0627\u0633\u0641\u0647, corrected by the editor to: \u0648\u0627\u0644\u0641\u0644\u0633\u0641\u0629"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l4l4l78l2"
+          },
+          "language": "ara",
+          "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l78l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u0633\u0646\u062d\u0627\u0631\u064a\u0628"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l4l4l80l2"
+          },
+          "language": "ara",
+          "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l80l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Person",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "\u062d\u064a\u0642\u0631"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#MD12675N1l4l2l4l4l82l2"
+          },
+          "language": "ara",
+          "source": "http://localhost:8181/ahiqar/content/transcription/3r14z-183a.html",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l82l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Motif",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "Loyal obligation (gods)"
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l45l4_1,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l45l4_2,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l45l4_3,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l47l2_1,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l47l2_2,#t_Brit_Mus_Add_7209_MD17104N1l5l3l5l5l47l2_3"
+          },
+          "source": "PLACEHOLDER \u2192 TARGET CONTENT HTML IRI"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahiqar.uni-goettingen.de/ns/annotations/3r14z/annotation-MD12675N1l4l2l4l4l44l2"
+    },
+    {
+      "body": {
+        "x-content-type": "Variant",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": [
+          {
+            "witness": "Cod. Arab. 236",
+            "entry": "omisit"
+          },
+          {
+            "witness": "DFM 614",
+            "entry": "omisit"
+          },
+          {
+            "witness": "Ming. syr. 258",
+            "entry": "اللبان"
+          },
+          {
+            "witness": "Sach. 339",
+            "entry": "البان"
+          }
+        ]
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#t_Brit_Mus_Add_7209_MD17104N1l5l3l7l5l41l2_3"
+          },
+          "source": "PLACEHOLDER \u2192 TARGET CONTENT HTML IRI"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahikar.uni-goettingen.de/ns/annotations/3r14z/annotation-variants-t_Brit_Mus_Add_7209_N1l5l3l5l5l29l4_w_1"
+    },
+    {
+      "body": {
+        "x-content-type": "Variant",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": [
+          {
+            "witness": "Cod. Arab. 236",
+            "entry": "omisit"
+          },
+          {
+            "witness": "DFM 614",
+            "entry": "omisit"
+          },
+          {
+            "witness": "Ming. syr. 258",
+            "entry": "والقرفه"
+          },
+          {
+            "witness": "Sach. 339",
+            "entry": "omisit"
+          }
+        ]
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#t_Brit_Mus_Add_7209_MD17104N1l5l3l7l5l43l2_2"
+          },
+          "source": "PLACEHOLDER \u2192 TARGET CONTENT HTML IRI"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahikar.uni-goettingen.de/ns/annotations/3r14z/annotation-variants-t_Brit_Mus_Add_7209_N1l5l3l5l5l29l4_w_2"
+    },
+    {
+      "body": {
+        "x-content-type": "Variant",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": [
+          {
+            "witness": "Cod. Arab. 236",
+            "entry": "omisit"
+          },
+          {
+            "witness": "DFM 614",
+            "entry": "omisit"
+          },
+          {
+            "witness": "Ming. syr. 258",
+            "entry": "والكمكام"
+          },
+          {
+            "witness": "Sach. 339",
+            "entry": "والكمكام"
+          }
+        ]
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#t_Brit_Mus_Add_7209_MD17104N1l5l3l7l5l43l2_3"
+          },
+          "source": "PLACEHOLDER \u2192 TARGET CONTENT HTML IRI"
+        }
+      ],
+      "type": "Annotation",
+      "id": "http://ahikar.uni-goettingen.de/ns/annotations/3r14z/annotation-variants-t_Brit_Mus_Add_7209_N1l5l3l5l5l29l4_w_3"
+    }
+  ],
+  "refs": [
+    {
+      "idno": "Cod. Arab. 236",
+      "manifest": "https://api.dev.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/3r177/manifest.json"
+    },
+    {
+      "idno": "DFM 614",
+      "manifest": "https://api.dev.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/3rbm9/manifest.json"
+    },
+    {
+      "idno": "Ming. syr. 258",
+      "manifest": "https://api.dev.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/3r17c/manifest.json"
+    },
+    {
+      "idno": "Sach. 339",
+      "manifest": "https://api.dev.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/3r179/manifest.json"
+    }
+  ]
+}


### PR DESCRIPTION
this PR adds a single example containing a total of three variants.

the schema is subject to change of key names and data structure. but all the data provided in the example will be available later on.