### PR TITLE
Selecting/Deselecting an annotated text

### DIFF
--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -160,7 +160,9 @@ function isOnlyThisVariantActive(witness) {
 }
 
 function pickVariantItemsSelection() {
-  // we pick the variant items selection, based on whether we have an active annotation or not
+  // we use this function in order to distinguish the state of variant items selection, before clicking on a certain variant item: either
+  //   a) no variant item is selected - initial state, variantItemsSelection copies the value of initVariantItemsSelection (every variant item has false value)
+  //   b) the variant item belongs to an active annotation - use the store computed property : 'activeAnnotSelectVariantItems'
   // if we have active annotation - we use the value of 'activeAnnotSelectVariantItems' property in the annotation store
   // else: we use the initial variant items selection - all false values
   let variantItemsSelection;

--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -35,9 +35,13 @@
 
 <script setup lang="ts">
 import { getItemColorBasedOnIndex } from '@/utils/color';
-import { reactive, watch } from 'vue';
+import { reactive, watch, computed } from 'vue';
+import { useAnnotationsStore } from '@/stores/annotations';
 import * as AnnotationUtils from '@/utils/annotations';
 
+
+const annotationStore = useAnnotationsStore();
+const activeAnnotSelectVariantItems = computed(() => annotationStore.activeAnnotSelectVariantItems);
 
 export interface Props {
   annotation: Annotation,
@@ -51,47 +55,80 @@ const props = withDefaults(defineProps<Props>(), {
   toggle: () => null,
 })
 
-let variantItemsSelection = reactive({})
+let initVariantItemsSelection = {}
 let variantItemsColors = {}
 
 
-watch(() => props.annotation, () => { 
+function initializeSelectionOfVariantItem() {
   props.annotation.body.value.forEach((variantItem) => {
     const witness = variantItem.witness
-    variantItemsSelection[witness] = false
+    initVariantItemsSelection[witness] = false
   })
+
+}
+
+initializeSelectionOfVariantItem()
+
+  
+watch(() => props.annotation, () => { 
+  
+  props.annotation.body.value.forEach((variantItem) => {
+    console.log('initializing the variant items selection')
+    const witness = variantItem.witness
+    initVariantItemsSelection[witness] = false
+  })
+  
+
+  console.log('id of annotation')
  })
+ 
 
 
 
 function handleClick(witness: string, i: number) {
   // if at least one variant item is selected, then we don't toggle this annotation
   // for each variant item: we should save a state of selected or not, so that to show the icon or not...
+  
   const witnessColor = getItemColorBasedOnIndex(i)
   if (witness in variantItemsColors === false) variantItemsColors[witness] = witnessColor
 
+  const variantItemsSelection = pickVariantItemsSelection()
+  //console.log('init variant items selection', variantItemsSelection)
+
   if (!isAtLeastOneVariantItemClicked()) {
     // for the first variant item of each variant object
+    console.log('toggle() - 1')
     props.toggle(props.annotation)
-    
   }
+
   if ((isOnlyThisVariantActive(witness)) && (isVariantItemActive(witness))) {
     // when we have only one variant item of a certain variant object selected and then we deselect it -> remove the blue highlight from the text 
+    console.log('toggle() - 2')
     props.toggle(props.annotation)
   }
   // update the state of 'false' or 'true' whether this variant item is selected or not
-  variantItemsSelection[witness] = !variantItemsSelection[witness] 
+  //variantItemsSelection[witness] = !variantItemsSelection[witness] 
+
+  variantItemsSelection[witness] = !variantItemsSelection[witness]
+  activeAnnotSelectVariantItems.value[props.annotation.id] = [props.annotation, variantItemsSelection]
+  //activeAnnotSelectVariantItems.value[props.annotation.id][1][witness] = !activeAnnotSelectVariantItems.value[props.annotation.id][1][witness]
 
   const selector = props.annotation.target[0].selector.value
-  if (variantItemsSelection[witness] === true) {
+  if (variantItemsSelection[witness] === true) { // to change
     AnnotationUtils.addWitness(selector, witness, variantItemsColors)
   }
   else {
     AnnotationUtils.removeWitness(selector, witness)
   }
+
+  // update this entry in active annotation to incorporate its 'variantItemsSelection' dict 
+  //activeAnnotSelectVariantItems.value[props.annotation.id] = [props.annotation, variantItemsSelection]
+  console.log('activeAnnotati Select Variant items', activeAnnotSelectVariantItems.value[props.annotation.id][1] )
 }
 
 function isAtLeastOneVariantItemClicked() {
+  const variantItemsSelection = pickVariantItemsSelection()
+
   let isClicked = false
   Object.keys(variantItemsSelection).forEach((witness) => {
     if (variantItemsSelection[witness] === true) isClicked = true
@@ -99,7 +136,11 @@ function isAtLeastOneVariantItemClicked() {
   return isClicked
 }
 
+
+
 function isOnlyThisVariantActive(witness) {
+  const variantItemsSelection = pickVariantItemsSelection()
+
   let isOnlyThisVariantClicked = true
   Object.keys(variantItemsSelection).forEach((wit) => {
     if (variantItemsSelection[wit] === true && wit!== witness) isOnlyThisVariantClicked = false
@@ -107,9 +148,104 @@ function isOnlyThisVariantActive(witness) {
   return isOnlyThisVariantClicked
 }
 
-function isVariantItemActive(witness): boolean{
-  return variantItemsSelection[witness] === true
+function pickVariantItemsSelection() {
+  let variantItemsSelection;
+  console.log('init Variant Selection', initVariantItemsSelection)
+
+  if (Object.keys(activeAnnotSelectVariantItems.value).length > 0) {
+    if((props.annotation.id in activeAnnotSelectVariantItems.value) === false) {
+      console.log('1-')
+      variantItemsSelection = initVariantItemsSelection;
+    }
+    else {
+      console.log('2-')
+      variantItemsSelection = activeAnnotSelectVariantItems.value[props.annotation.id][1]
+    }
+  }
+  else {
+    //initializeSelectionOfVariantItem()
+    variantItemsSelection = { ...initVariantItemsSelection };
+  }
+
+  return variantItemsSelection
 }
+
+function isVariantItemActive(witness): boolean{
+  // Case 1: there is no active annotation: 'each variant item no highlighting'
+
+  if(Object.keys(activeAnnotSelectVariantItems.value).length > 0) {
+      if( (props.annotation.id in activeAnnotSelectVariantItems.value) === false) {
+        return false
+      }
+      else {
+        return activeAnnotSelectVariantItems.value[props.annotation.id][1][witness]
+      }
+  }
+  //if(Object.keys(activeAnnotSelectVariantItems.value).length === 0)
+  // Case 2: we select variant item -> we should update the activeAnnotSelectVariantItems[witness] (as selectedValue we get it from this store prop)
+
+
+
+  /*
+    if(Object.keys(activeAnnotSelectVariantItems.value).length > 0 ) {
+      if( props.annotation.id in activeAnnotSelectVariantItems.value) {
+        return activeAnnotSelectVariantItems.value[props.annotation.id][1][witness]
+      }
+    }
+    else {
+      variantItemsSelection = AnnotationUtils.initVariantItemsSelection(props.annotation, false)
+    }
+    */
+    return false
+}
+
+function getSelectorOfAnnotatedText() {
+  return props.annotation.target[0].selector.value
+}
+
+function areAllVariantItemsSelected() {
+  let numberSelected = 0
+  Object.keys(variantItemsSelection).forEach((wit) => {
+    if (variantItemsSelection[wit] === true) numberSelected += 1
+  })
+  return numberSelected === Object.keys(variantItemsSelection).length
+}
+
+function isTargetSelected() {
+  const selector = props.annotation.target[0].selector.value
+  const target = document.querySelector('#text-content').querySelector(selector)
+  const isTargetSelected = parseInt(target.getAttribute('data-annotation-level'), 10) > 0
+  if(isTargetSelected && !isAtLeastOneVariantItemClicked()) {
+    // selected all variant items selection to True
+    selectVariantItemsSelected()
+  }
+  return isTargetSelected
+  
+}
+
+function selectVariantItemsSelected() {
+  props.annotation.body.value.forEach((variantItem) => {
+    const witness = variantItem.witness
+    variantItemsSelection[witness] = true
+  })
+}
+
+function canVariantItemBeHighlighted(witness) {
+  
+  return (
+       (// if the target was not unclicked)
+       !isTargetUnclicked() && 
+       isVariantItemActive(witness)) // variantItem is newly clicked for that variant object 
+            || 
+            (!isAtLeastOneVariantItemClicked() && isTargetSelected()) // when we first highlight the target and previously no variant item is selected
+                         // we 
+        )
+}
+
+function isTargetUnclicked() {
+  return areAllVariantItemsSelected() && !isTargetSelected()
+}
+
 
 
 function getVariantItemsSelected(): string[] {
@@ -121,8 +257,6 @@ function getVariantItemsSelected(): string[] {
   return variantItemsSelected
 
 }
-
-
 
 </script>
 

--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -58,17 +58,6 @@ const props = withDefaults(defineProps<Props>(), {
 let initVariantItemsSelection = {}
 let variantItemsColors = {}
 
-
-function initializeSelectionOfVariantItem() {
-  props.annotation.body.value.forEach((variantItem) => {
-    const witness = variantItem.witness
-    initVariantItemsSelection[witness] = false
-  })
-
-}
-
-initializeSelectionOfVariantItem()
-
   
 watch(() => props.annotation, () => { 
   
@@ -166,76 +155,6 @@ function isVariantItemActive(witness): boolean{
 
   return false
 }
-
-
-
-
-/*
-
-// Another approach for the feature 'select text'
-
-function getSelectorOfAnnotatedText() {
-  return props.annotation.target[0].selector.value
-}
-
-function areAllVariantItemsSelected() {
-  let numberSelected = 0
-  Object.keys(variantItemsSelection).forEach((wit) => {
-    if (variantItemsSelection[wit] === true) numberSelected += 1
-  })
-  return numberSelected === Object.keys(variantItemsSelection).length
-}
-
-
-function isTargetSelected() {
-  const selector = props.annotation.target[0].selector.value
-  const target = document.querySelector('#text-content').querySelector(selector)
-  const isTargetSelected = parseInt(target.getAttribute('data-annotation-level'), 10) > 0
-  if(isTargetSelected && !isAtLeastOneVariantItemClicked()) {
-    // selected all variant items selection to True
-    selectVariantItemsSelected()
-  }
-  return isTargetSelected
-  
-}
-
-function selectVariantItemsSelected() {
-  props.annotation.body.value.forEach((variantItem) => {
-    const witness = variantItem.witness
-    variantItemsSelection[witness] = true
-  })
-}
-
-
-function canVariantItemBeHighlighted(witness) {
-  
-  return (
-       (// if the target was not unclicked)
-       !isTargetUnclicked() && 
-       isVariantItemActive(witness)) // variantItem is newly clicked for that variant object 
-            || 
-            (!isAtLeastOneVariantItemClicked() && isTargetSelected()) // when we first highlight the target and previously no variant item is selected
-                         // we 
-        )
-}
-
-function isTargetUnclicked() {
-  return areAllVariantItemsSelected() && !isTargetSelected()
-}
-
-function getVariantItemsSelected(): string[] {
-  let variantItemsSelected: string[] = []
-  Object.keys(variantItemsSelection).forEach((wit) => {
-    if (variantItemsSelection[wit] === true) variantItemsSelected.push(wit)
-  })
-
-  return variantItemsSelected
-
-}
-
-*/
-
-
 
 
 

--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -94,7 +94,7 @@ function handleClick(witness: string, i: number) {
 
   // update the state of 'false' or 'true' whether this variant item is selected or not
   variantItemsSelection[witness] = !variantItemsSelection[witness]
-  activeAnnotSelectVariantItems.value[props.annotation.id] = [props.annotation, variantItemsSelection]
+  annotationStore.updateActiveAnnotSelectVariantItems(props.annotation.id, [props.annotation, variantItemsSelection])
 
   const selector = props.annotation.target[0].selector.value
   if (variantItemsSelection[witness] === true) { // to change

--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -56,14 +56,14 @@ const props = withDefaults(defineProps<Props>(), {
   toggle: () => null,
 })
 
-let initVariantItemsSelection = {}
+let initialVariantItemsSelection = {}
 
   
 watch(() => props.annotation, () => { 
   
   props.annotation.body.value.forEach((variantItem) => {
     const witness = variantItem.witness
-    initVariantItemsSelection[witness] = false
+    initialVariantItemsSelection[witness] = false
   })
  })
  
@@ -161,7 +161,7 @@ function isOnlyThisVariantActive(witness) {
 
 function pickVariantItemsSelection() {
   // we use this function in order to distinguish the state of variant items selection, before clicking on a certain variant item: either
-  //   a) no variant item is selected - initial state, variantItemsSelection copies the value of initVariantItemsSelection (every variant item has false value)
+  //   a) no variant item is selected - initial state, variantItemsSelection copies the value of initialVariantItemsSelection (every variant item has false value)
   //   b) the variant item belongs to an active annotation - use the store computed property : 'activeAnnotSelectVariantItems'
   // if we have active annotation - we use the value of 'activeAnnotSelectVariantItems' property in the annotation store
   // else: we use the initial variant items selection - all false values
@@ -169,14 +169,14 @@ function pickVariantItemsSelection() {
 
   if (Object.keys(activeAnnotSelectVariantItems.value).length > 0) {
     if((props.annotation.id in activeAnnotSelectVariantItems.value) === false) {
-      variantItemsSelection = { ...initVariantItemsSelection };
+      variantItemsSelection = { ...initialVariantItemsSelection };
     }
     else {
       variantItemsSelection = activeAnnotSelectVariantItems.value[props.annotation.id][1]
     }
   }
   else {
-    variantItemsSelection = { ...initVariantItemsSelection };
+    variantItemsSelection = { ...initialVariantItemsSelection };
   }
 
   return variantItemsSelection

--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -121,8 +121,7 @@ function allocateWitnessColorInVariantItem(witness: string): string {
 }
 
 function getWitnessColor(witness): string {
-   // getWitnessColor
-  
+     
   let indexColor;
   if (Object.keys(variantItemsColors.value).length === 0){
     // the first variant item to be selected

--- a/src/components/annotations/AnnotationVariantItem.vue
+++ b/src/components/annotations/AnnotationVariantItem.vue
@@ -73,17 +73,11 @@ initializeSelectionOfVariantItem()
 watch(() => props.annotation, () => { 
   
   props.annotation.body.value.forEach((variantItem) => {
-    console.log('initializing the variant items selection')
     const witness = variantItem.witness
     initVariantItemsSelection[witness] = false
   })
-  
-
-  console.log('id of annotation')
  })
  
-
-
 
 function handleClick(witness: string, i: number) {
   // if at least one variant item is selected, then we don't toggle this annotation
@@ -93,25 +87,20 @@ function handleClick(witness: string, i: number) {
   if (witness in variantItemsColors === false) variantItemsColors[witness] = witnessColor
 
   const variantItemsSelection = pickVariantItemsSelection()
-  //console.log('init variant items selection', variantItemsSelection)
 
   if (!isAtLeastOneVariantItemClicked()) {
     // for the first variant item of each variant object
-    console.log('toggle() - 1')
     props.toggle(props.annotation)
   }
 
   if ((isOnlyThisVariantActive(witness)) && (isVariantItemActive(witness))) {
     // when we have only one variant item of a certain variant object selected and then we deselect it -> remove the blue highlight from the text 
-    console.log('toggle() - 2')
     props.toggle(props.annotation)
   }
-  // update the state of 'false' or 'true' whether this variant item is selected or not
-  //variantItemsSelection[witness] = !variantItemsSelection[witness] 
 
+  // update the state of 'false' or 'true' whether this variant item is selected or not
   variantItemsSelection[witness] = !variantItemsSelection[witness]
   activeAnnotSelectVariantItems.value[props.annotation.id] = [props.annotation, variantItemsSelection]
-  //activeAnnotSelectVariantItems.value[props.annotation.id][1][witness] = !activeAnnotSelectVariantItems.value[props.annotation.id][1][witness]
 
   const selector = props.annotation.target[0].selector.value
   if (variantItemsSelection[witness] === true) { // to change
@@ -120,10 +109,6 @@ function handleClick(witness: string, i: number) {
   else {
     AnnotationUtils.removeWitness(selector, witness)
   }
-
-  // update this entry in active annotation to incorporate its 'variantItemsSelection' dict 
-  //activeAnnotSelectVariantItems.value[props.annotation.id] = [props.annotation, variantItemsSelection]
-  console.log('activeAnnotati Select Variant items', activeAnnotSelectVariantItems.value[props.annotation.id][1] )
 }
 
 function isAtLeastOneVariantItemClicked() {
@@ -137,7 +122,6 @@ function isAtLeastOneVariantItemClicked() {
 }
 
 
-
 function isOnlyThisVariantActive(witness) {
   const variantItemsSelection = pickVariantItemsSelection()
 
@@ -149,21 +133,20 @@ function isOnlyThisVariantActive(witness) {
 }
 
 function pickVariantItemsSelection() {
+  // we pick the variant items selection, based on whether we have an active annotation or not
+  // if we have active annotation - we use the value of 'activeAnnotSelectVariantItems' property in the annotation store
+  // else: we use the initial variant items selection - all false values
   let variantItemsSelection;
-  console.log('init Variant Selection', initVariantItemsSelection)
 
   if (Object.keys(activeAnnotSelectVariantItems.value).length > 0) {
     if((props.annotation.id in activeAnnotSelectVariantItems.value) === false) {
-      console.log('1-')
-      variantItemsSelection = initVariantItemsSelection;
+      variantItemsSelection = { ...initVariantItemsSelection };
     }
     else {
-      console.log('2-')
       variantItemsSelection = activeAnnotSelectVariantItems.value[props.annotation.id][1]
     }
   }
   else {
-    //initializeSelectionOfVariantItem()
     variantItemsSelection = { ...initVariantItemsSelection };
   }
 
@@ -171,7 +154,6 @@ function pickVariantItemsSelection() {
 }
 
 function isVariantItemActive(witness): boolean{
-  // Case 1: there is no active annotation: 'each variant item no highlighting'
 
   if(Object.keys(activeAnnotSelectVariantItems.value).length > 0) {
       if( (props.annotation.id in activeAnnotSelectVariantItems.value) === false) {
@@ -181,23 +163,16 @@ function isVariantItemActive(witness): boolean{
         return activeAnnotSelectVariantItems.value[props.annotation.id][1][witness]
       }
   }
-  //if(Object.keys(activeAnnotSelectVariantItems.value).length === 0)
-  // Case 2: we select variant item -> we should update the activeAnnotSelectVariantItems[witness] (as selectedValue we get it from this store prop)
 
-
-
-  /*
-    if(Object.keys(activeAnnotSelectVariantItems.value).length > 0 ) {
-      if( props.annotation.id in activeAnnotSelectVariantItems.value) {
-        return activeAnnotSelectVariantItems.value[props.annotation.id][1][witness]
-      }
-    }
-    else {
-      variantItemsSelection = AnnotationUtils.initVariantItemsSelection(props.annotation, false)
-    }
-    */
-    return false
+  return false
 }
+
+
+
+
+/*
+
+// Another approach for the feature 'select text'
 
 function getSelectorOfAnnotatedText() {
   return props.annotation.target[0].selector.value
@@ -210,6 +185,7 @@ function areAllVariantItemsSelected() {
   })
   return numberSelected === Object.keys(variantItemsSelection).length
 }
+
 
 function isTargetSelected() {
   const selector = props.annotation.target[0].selector.value
@@ -230,6 +206,7 @@ function selectVariantItemsSelected() {
   })
 }
 
+
 function canVariantItemBeHighlighted(witness) {
   
   return (
@@ -246,8 +223,6 @@ function isTargetUnclicked() {
   return areAllVariantItemsSelected() && !isTargetSelected()
 }
 
-
-
 function getVariantItemsSelected(): string[] {
   let variantItemsSelected: string[] = []
   Object.keys(variantItemsSelection).forEach((wit) => {
@@ -257,6 +232,12 @@ function getVariantItemsSelected(): string[] {
   return variantItemsSelected
 
 }
+
+*/
+
+
+
+
 
 </script>
 

--- a/src/stores/annotations.ts
+++ b/src/stores/annotations.ts
@@ -291,7 +291,7 @@ export const useAnnotationsStore = defineStore('annotations', () => {
               if (targetIsSelected) {
                 removeActiveAnnotation(id)
                 if (AnnotationUtils.isVariant(annotation)) {
-                  // we need to know which witnesses belong to this annotation - so that we can remove the witnesses chips from the text
+                  // we need to know which witnesses belong to this annotation AND are selected - so that we can remove the witnesses chips from the text
                   const witnessesHtml = AnnotationUtils.getWitnessesHtmlEl(selector)
                   const witnessesList = AnnotationUtils.getWitnessesList(witnessesHtml)
                   // remove the 'witnesses chips' which are selected

--- a/src/stores/annotations.ts
+++ b/src/stores/annotations.ts
@@ -13,7 +13,8 @@ import { useConfigStore} from '@/stores/config';
 export const useAnnotationsStore = defineStore('annotations', () => {
 
     const activeTab = ref<string>('')
-    const activeAnnotations = ref<ActiveAnnotation>({} as ActiveAnnotation) 
+    const activeAnnotations = ref({}) 
+    const activeAnnotSelectVariantItems = ref({})
     const annotations = ref<Annotation[]>(null)
     const filteredAnnotations = ref<Annotation[]>([])
     const isLoading = ref<boolean>(false);
@@ -120,9 +121,13 @@ export const useAnnotationsStore = defineStore('annotations', () => {
     const removeActiveAnnotation = (id) => {
         const annotationStore = useAnnotationsStore()
         const removeAnnotation = activeAnnotations.value[id];
+
         if (!removeAnnotation) {
           return;
         }
+
+        // If removed active annotation is variant - then set all the variant items selection to false for this annotation
+
       
         const activeAnnotationsList = { ...activeAnnotations.value };
       
@@ -271,8 +276,16 @@ export const useAnnotationsStore = defineStore('annotations', () => {
             if (annotation) {
               if (targetIsSelected) {
                 removeActiveAnnotation(id)
+                if (AnnotationUtils.isVariant(annotation)) {
+                  delete activeAnnotSelectVariantItems.value[annotation.id]
+                }
               } else {
                 addActiveAnnotation(id)
+                if(AnnotationUtils.isVariant(annotation)) {
+                  const variantItemsSelect = AnnotationUtils.initVariantItemsSelection(annotation, true)
+                  activeAnnotSelectVariantItems.value[annotation.id] = [activeAnnotations.value[annotation.id], variantItemsSelect]
+                }
+                // if annotation is variant - additionally set the variant items selection to true
               }
             }
           });
@@ -321,7 +334,7 @@ export const useAnnotationsStore = defineStore('annotations', () => {
     }
 
     return {
-        activeTab, activeAnnotations, annotations, filteredAnnotations, isLoading,   // states
+        activeTab, activeAnnotations, activeAnnotSelectVariantItems, annotations, filteredAnnotations, isLoading,   // states
         isAllAnnotationSelected, isNoAnnotationSelected,                              // computed
         setActiveAnnotations, setAnnotations, updateAnnotationLoading, setFilteredAnnotations,  // functions
         addActiveAnnotation, selectFilteredAnnotations, addHighlightAttributesToText, 

--- a/src/stores/annotations.ts
+++ b/src/stores/annotations.ts
@@ -45,6 +45,14 @@ export const useAnnotationsStore = defineStore('annotations', () => {
       variantItemsColors.value = payload
     }
 
+    function setActiveAnnotSelectVariantItems(payload) {
+      activeAnnotSelectVariantItems.value = payload
+    }
+
+    function updateActiveAnnotSelectVariantItems(id, payload) {
+      activeAnnotSelectVariantItems.value[id] = payload
+    }
+
     const addActiveAnnotation = (id: string) => {
         const annotationStore = useAnnotationsStore()
         const configStore = useConfigStore()
@@ -279,12 +287,15 @@ export const useAnnotationsStore = defineStore('annotations', () => {
             // a.k.a. it exists in the current filteredAnnotations
             const annotation = filteredAnnotations.value.find((filtered) => filtered.id === id);
             const selector = annotation.target[0].selector.value
-            console.log('annotation', annotation)
             if (annotation) {
               if (targetIsSelected) {
                 removeActiveAnnotation(id)
                 if (AnnotationUtils.isVariant(annotation)) {
-                  // call a method in utils/annotations.js which will remove all the 'witnesses chips' on the current annotation variant
+                  // we need to know which witnesses belong to this annotation - so that we can remove the witnesses chips from the text
+                  const witnessesHtml = AnnotationUtils.getWitnessesHtmlEl(selector)
+                  const witnessesList = AnnotationUtils.getWitnessesList(witnessesHtml)
+                  // remove the 'witnesses chips' which are selected
+                  AnnotationUtils.removeWitnessesChipsWhenDeselectText(witnessesList, selector)
                   delete activeAnnotSelectVariantItems.value[annotation.id]
                 }
               } else {
@@ -292,9 +303,10 @@ export const useAnnotationsStore = defineStore('annotations', () => {
                 if(AnnotationUtils.isVariant(annotation)) {
                   // if annotation is variant - additionally set the variant items selection to true
                   const variantItemsSelect = AnnotationUtils.initVariantItemsSelection(annotation, true)
+
                   activeAnnotSelectVariantItems.value[annotation.id] = [activeAnnotations.value[annotation.id], variantItemsSelect]
+                  // add all the 'witnesses chips' for this annotation variant
                   AnnotationUtils.addWitnessesChipsWhenSelectText(variantItemsSelect, selector, variantItemsColors.value)
-                  // call a method in utils/annotations.js which will add all the 'witnesses chips' for this annotation variant
                 }
               }
             }
@@ -346,8 +358,8 @@ export const useAnnotationsStore = defineStore('annotations', () => {
     return {
         activeTab, activeAnnotations, activeAnnotSelectVariantItems, annotations, filteredAnnotations, isLoading, variantItemsColors,  // states
         isAllAnnotationSelected, isNoAnnotationSelected,                              // computed
-        setActiveAnnotations, setAnnotations, updateAnnotationLoading, setFilteredAnnotations, setVariantItemsColors,  // functions
-        addActiveAnnotation, selectFilteredAnnotations, addHighlightAttributesToText, 
+        setActiveAnnotations, setAnnotations, updateAnnotationLoading, setFilteredAnnotations, setActiveAnnotSelectVariantItems, setVariantItemsColors,  // functions
+        addActiveAnnotation, selectFilteredAnnotations, addHighlightAttributesToText, updateActiveAnnotSelectVariantItems,
         annotationLoaded, removeActiveAnnotation, resetAnnotations, initAnnotations,
         addHighlightHoverListeners, addHighlightClickListeners, getNearestParentAnnotation,
         selectAll, selectNone, discoverParentAnnotationIds, discoverChildAnnotationIds

--- a/src/stores/annotations.ts
+++ b/src/stores/annotations.ts
@@ -293,7 +293,7 @@ export const useAnnotationsStore = defineStore('annotations', () => {
                   // if annotation is variant - additionally set the variant items selection to true
                   const variantItemsSelect = AnnotationUtils.initVariantItemsSelection(annotation, true)
                   activeAnnotSelectVariantItems.value[annotation.id] = [activeAnnotations.value[annotation.id], variantItemsSelect]
-                  AnnotationUtils.addWitnessesChipsWhenSelectText(variantItemsSelect, selector)
+                  AnnotationUtils.addWitnessesChipsWhenSelectText(variantItemsSelect, selector, variantItemsColors.value)
                   // call a method in utils/annotations.js which will add all the 'witnesses chips' for this annotation variant
                 }
               }

--- a/src/stores/annotations.ts
+++ b/src/stores/annotations.ts
@@ -15,6 +15,7 @@ export const useAnnotationsStore = defineStore('annotations', () => {
     const activeTab = ref<string>('')
     const activeAnnotations = ref({}) 
     const activeAnnotSelectVariantItems = ref({})
+    const variantItemsColors = ref({})
     const annotations = ref<Annotation[]>(null)
     const filteredAnnotations = ref<Annotation[]>([])
     const isLoading = ref<boolean>(false);
@@ -38,6 +39,10 @@ export const useAnnotationsStore = defineStore('annotations', () => {
 
     function setFilteredAnnotations(payload: Annotation[]) {
         filteredAnnotations.value = payload
+    }
+
+    function setVariantItemsColors(payload) {
+      variantItemsColors.value = payload
     }
 
     const addActiveAnnotation = (id: string) => {
@@ -273,19 +278,24 @@ export const useAnnotationsStore = defineStore('annotations', () => {
             // We need to check here if the right annotations panel tab is active
             // a.k.a. it exists in the current filteredAnnotations
             const annotation = filteredAnnotations.value.find((filtered) => filtered.id === id);
+            const selector = annotation.target[0].selector.value
+            console.log('annotation', annotation)
             if (annotation) {
               if (targetIsSelected) {
                 removeActiveAnnotation(id)
                 if (AnnotationUtils.isVariant(annotation)) {
+                  // call a method in utils/annotations.js which will remove all the 'witnesses chips' on the current annotation variant
                   delete activeAnnotSelectVariantItems.value[annotation.id]
                 }
               } else {
                 addActiveAnnotation(id)
                 if(AnnotationUtils.isVariant(annotation)) {
+                  // if annotation is variant - additionally set the variant items selection to true
                   const variantItemsSelect = AnnotationUtils.initVariantItemsSelection(annotation, true)
                   activeAnnotSelectVariantItems.value[annotation.id] = [activeAnnotations.value[annotation.id], variantItemsSelect]
+                  AnnotationUtils.addWitnessesChipsWhenSelectText(variantItemsSelect, selector)
+                  // call a method in utils/annotations.js which will add all the 'witnesses chips' for this annotation variant
                 }
-                // if annotation is variant - additionally set the variant items selection to true
               }
             }
           });
@@ -334,9 +344,9 @@ export const useAnnotationsStore = defineStore('annotations', () => {
     }
 
     return {
-        activeTab, activeAnnotations, activeAnnotSelectVariantItems, annotations, filteredAnnotations, isLoading,   // states
+        activeTab, activeAnnotations, activeAnnotSelectVariantItems, annotations, filteredAnnotations, isLoading, variantItemsColors,  // states
         isAllAnnotationSelected, isNoAnnotationSelected,                              // computed
-        setActiveAnnotations, setAnnotations, updateAnnotationLoading, setFilteredAnnotations,  // functions
+        setActiveAnnotations, setAnnotations, updateAnnotationLoading, setFilteredAnnotations, setVariantItemsColors,  // functions
         addActiveAnnotation, selectFilteredAnnotations, addHighlightAttributesToText, 
         annotationLoaded, removeActiveAnnotation, resetAnnotations, initAnnotations,
         addHighlightHoverListeners, addHighlightClickListeners, getNearestParentAnnotation,

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -2,6 +2,7 @@ import * as Utils from '@/utils/index';
 import { getIcon } from '@/utils/icons';
 import { i18n } from '@/i18n';
 
+
 // utility functions that we can use as generic way for perform tranformation on annotations.
 
 export function addHighlightToElements(selector, root, annotationId) {
@@ -306,6 +307,18 @@ export function unselectVariantItems(variantItemsSelection) {
     newVariantItemsSelection[wit] = false
   })
   return newVariantItemsSelection
+}
+
+export function addWitnessesChipsWhenSelectText(variantItemsSelection, selector) {
+  // variantItemsSelection: JSON object of 'witness name': 'true' 
+  // this function aims to add all witnesses on the highlighted text when we click on the text 
+
+  // get the text content html element: 
+  const textPanelEl = document.querySelector('#text-content')
+  // iterate through each witness
+  Object.keys(variantItemsSelection).forEach((variantItem) => {
+    addWitness(selector, witness, variantItemsColors)
+  })
 }
 
 export function isVariant(annotation) {

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -240,7 +240,7 @@ export function addWitness(selector, witness, variantItemsColors) {
   const parentEl = targetHtmlEl.parentElement
   const indexOfTarget = [].slice.call(parentEl.children).indexOf(targetHtmlEl)
   
-  
+
   const witHtml = createCurrWitHtml(witness, variantItemsColors[witness])
   
   if(!parentEl.children[indexOfTarget-1].classList.contains("witnesses")) { 
@@ -289,7 +289,7 @@ export function removeWitness(selector, witness) {
   witHtml[0].remove()  
 }
 
-function getWitnessesHtmlEl(selector) {
+export function getWitnessesHtmlEl(selector) {
   // selector represents the target text of a certain variant item
   // we aim to get the html element which contains the 'witnesses chips' related to the target. 
   // this html element which contains the 'witnesses chips' is located before the target element
@@ -299,6 +299,15 @@ function getWitnessesHtmlEl(selector) {
   const witnessesHtmlEl = parentEl.children[indexOfTarget-1]
 
   return witnessesHtmlEl
+}
+
+export function getWitnessesList(witnessesHtml) {
+  // returns the list of witnesses(<string>) which are already selected
+  let witnessesList= []
+  Array.from(witnessesHtml.children).forEach((witnessHtml) => {
+    witnessesList.push(witnessHtml.innerHTML)
+  })
+  return witnessesList
 }
 
 export function unselectVariantItems(variantItemsSelection) {
@@ -313,11 +322,14 @@ export function addWitnessesChipsWhenSelectText(variantItemsSelection, selector,
   // variantItemsSelection: JSON object of 'witness name': 'true' 
   // this function aims to add all witnesses on the highlighted text when we click on the text 
 
-  // get the text content html element: 
-  const textPanelEl = document.querySelector('#text-content')
-  // iterate through each witness
   Object.keys(variantItemsSelection).forEach((witness) => {
     addWitness(selector, witness, variantItemsColors)
+  })
+}
+
+export function removeWitnessesChipsWhenDeselectText(witnessesList, selector) {
+  witnessesList.forEach((witness) => {
+    removeWitness(selector, witness)
   })
 }
 

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -240,6 +240,7 @@ export function addWitness(selector, witness, variantItemsColors) {
   const parentEl = targetHtmlEl.parentElement
   const indexOfTarget = [].slice.call(parentEl.children).indexOf(targetHtmlEl)
   
+  
   const witHtml = createCurrWitHtml(witness, variantItemsColors[witness])
   
   if(!parentEl.children[indexOfTarget-1].classList.contains("witnesses")) { 
@@ -285,7 +286,6 @@ export function removeWitness(selector, witness) {
 
   const witnessesHtmlEl = getWitnessesHtmlEl(selector)
   const witHtml = Array.from(witnessesHtmlEl.children).filter(item => item.innerHTML === witness)  
-  console.log('witHtml', witHtml)
   witHtml[0].remove()  
 }
 
@@ -309,14 +309,14 @@ export function unselectVariantItems(variantItemsSelection) {
   return newVariantItemsSelection
 }
 
-export function addWitnessesChipsWhenSelectText(variantItemsSelection, selector) {
+export function addWitnessesChipsWhenSelectText(variantItemsSelection, selector, variantItemsColors) {
   // variantItemsSelection: JSON object of 'witness name': 'true' 
   // this function aims to add all witnesses on the highlighted text when we click on the text 
 
   // get the text content html element: 
   const textPanelEl = document.querySelector('#text-content')
   // iterate through each witness
-  Object.keys(variantItemsSelection).forEach((variantItem) => {
+  Object.keys(variantItemsSelection).forEach((witness) => {
     addWitness(selector, witness, variantItemsColors)
   })
 }

--- a/src/utils/annotations.js
+++ b/src/utils/annotations.js
@@ -284,6 +284,7 @@ export function removeWitness(selector, witness) {
 
   const witnessesHtmlEl = getWitnessesHtmlEl(selector)
   const witHtml = Array.from(witnessesHtmlEl.children).filter(item => item.innerHTML === witness)  
+  console.log('witHtml', witHtml)
   witHtml[0].remove()  
 }
 
@@ -299,6 +300,26 @@ function getWitnessesHtmlEl(selector) {
   return witnessesHtmlEl
 }
 
+export function unselectVariantItems(variantItemsSelection) {
+  let newVariantItemsSelection = {}
+  Object.keys(variantItemsSelection).forEach((wit) => {
+    newVariantItemsSelection[wit] = false
+  })
+  return newVariantItemsSelection
+}
+
+export function isVariant(annotation) {
+  return annotation.body['x-content-type'] === 'Variant';
+}
+
+export function initVariantItemsSelection(annotation, value) {
+  // initialize with the boolean of 'value' variable
+  let variantItemsSelection = {}
+  annotation.body.value.forEach((variantItem) => {
+    variantItemsSelection[variantItem.witness] = value
+  } )
+  return variantItemsSelection
+}
 
 export function getAnnotationListElement(id, container) {
   return [...container.querySelectorAll('.q-item')].find((annotationItem) => {


### PR DESCRIPTION
In this PR I address the following features:
- integrate together the functioning of selecting/deselecting a variant item in the Annotations panel and selecting/deselecting the annotated text in the Text Panel
- selecting an annotated text -> the witnesses 'chips' of that variant object should be shown in the text
- deselecting an annotated text -> remove the witnesses 'chips' from the text
- deal with the coloring of the witnesses chips 