### PR TITLE
Fix tests errors and hide the variants details button when no variant item is selected

### DIFF
--- a/src/components/annotations/variants/VariantsTopBar.vue
+++ b/src/components/annotations/variants/VariantsTopBar.vue
@@ -77,7 +77,7 @@ function toggleWitness(witness: Witness, isActive: boolean) {
         @click="witnessesDetailsDialogOpen = true"
       />
     </div>
-    <div class="t-mt-4 t-flex t-items-center">
+    <div class="t-mt-4 t-flex t-items-center" v-show="Object.keys(annotationsStore.activeAnnotations).length > 0">
       <span class="t-text-sm t-font-bold">{{ Object.keys(annotationsStore.activeAnnotations).length }} Variants selected</span>
       <BaseButton
         class="t-ml-auto"

--- a/tests/cypress/e2e/annotation.cy.js
+++ b/tests/cypress/e2e/annotation.cy.js
@@ -6,7 +6,7 @@ const ahiqarSelectors = {
   listOfSecondTab: '.panels-wrapper > .panel:nth-child(4) [role="tabpanel"]:nth-child(2) .annotations-list',
   tab: '.panels-wrapper > .panel:nth-child(4) [role="tablist"] [data-pc-section="nav"] [data-pc-name="tabpanel"]',
   text: '.panels-wrapper > .panel:nth-child(3) #text-content',
-  annotationPanelActionCheckbox: '.panel-header .actions > div:first-child #panel-toggle-action',
+  annotationPanelActionCheckbox: '.panel-header .actions > div:first-child #panel-check-action',
 }
 
 const gflSelectors = {


### PR DESCRIPTION
In the buttons: 'selectAll' and 'toggle the single select mode' a change has been introduced in the variants feature. Now the select all button has an id: 'panel-check-action', while the toggle button single-select-mode has the id: 'panel-toggle-action'.


