### PR TITLE
Tests variant item selection

### DIFF
--- a/examples/ahiqar-arabic-karshuni-with-variants-local.html
+++ b/examples/ahiqar-arabic-karshuni-with-variants-local.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>TIDO</title>
-
+<head><title>TIDO</title>
   <meta charset="utf-8">
-  <meta name="description" content="<%= htmlWebpackPlugin.options.productDescription %>">
+  <meta name="description" content="">
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
-  <meta name="viewport" content="initial-scale=1, maximum-scale=5, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>">
+  <meta name="viewport" content="initial-scale=1,maximum-scale=5,minimum-scale=1,width=device-width">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="dist/tido.css">
   <style>
     html, body {
       margin: 0;
@@ -17,17 +17,15 @@
     }
   </style>
 </head>
-
 <body>
-<noscript>
-  <strong>We're sorry but this app doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
-</noscript>
-<div id="app"></div>
+<noscript><strong>We're sorry but TIDO doesn't work properly without JavaScript enabled. Please enable it to
+  continue.</strong></noscript>
 
-<script type="module" src="/src/main.js"></script>
+<div id="app"></div>
+<script src="dist/tido.js"></script>
 <script>
-  window.addEventListener('load', function () {
-    window.tido = new window.Tido({
+window.addEventListener('load', function () {
+  window.tido = new window.Tido({
     "collection": "http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json",
     "labels": {
       "item": "Sheet",
@@ -105,67 +103,59 @@
         ]
       },
       {
-        "label": "annotations",
-        "views": [
-          {
-            "id": "annotations1",
-            "label": "Editorial",
-            "connector": {
-              "id": 5,
-              "options": {
-                "types": [
-                  {
-                    "name": "Person",
-                    "icon": "person"
-                  },
-                  {
-                    "name": "Place",
-                    "icon": "marker"
-                  },
-                  {
-                    "name": "Editorial Comment",
-                    "icon": "chat"
-                  },
-                  {
-                    "name": "Reference",
-                    "icon": "externalLink"
-                  }
-                ]
+          "label": "annotations",
+          "views": [
+            {
+              "id": "annotations1",
+              "label": "Editorial",
+              "connector": {
+                "id": 5,
+                "options": {
+                  "types": [
+                    {
+                      "name": "Person",
+                      "icon": "biPersonFill"
+                    },
+                    {
+                      "name": "Place",
+                      "icon": "biGeoAltFill"
+                    },
+                    {
+                      "name": "Editorial Comment",
+                      "icon": "biChatFill"
+                    },
+                    {
+                      "name": "Reference",
+                      "icon": "biBoxArrowUpRight"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "annotations2",
+              "label": "Motif",
+              "connector": {
+                "id": 5,
+                "options": {
+                  "types": [
+                    {
+                      "name": "Motif",
+                      "icon": "biPenFill"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "annotations3",
+              "label": "Variants",
+              "connector": {
+                "id": 6
               }
             }
-          },
-          {
-            "id": "annotations2",
-            "label": "Motif",
-            "connector": {
-              "id": 5,
-              "options": {
-                "types": [
-                  {
-                    "name": "Motif",
-                    "icon": "pen"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "id": "annotations3",
-            "label": "Variants",
-            "connector": {
-              "id": 5,
-              "options": {
-                "types": [
-                  {
-                    "name": "Variant",
-                    "icon": "pen"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }
+          ]
+        }
     ],
     "translations": {
       "en": {
@@ -173,7 +163,7 @@
       }
     }
   });
-  });
-  </script>
+});
+</script>
 </body>
 </html>

--- a/src/components/panels/Panel.vue
+++ b/src/components/panels/Panel.vue
@@ -360,12 +360,10 @@ export default {
       });
 
       const actions = [{
-        component: 'PanelCheckAction',
         props: {
           selected: selectedAll,
           label: t('select_all'),
-        },
-        events: eventsSelectAll,
+        }
       }, {
         component: 'PanelToggleAction',
         props: {

--- a/tests/cypress/e2e/annotation.cy.js
+++ b/tests/cypress/e2e/annotation.cy.js
@@ -1,17 +1,5 @@
-import { commonSelectors } from '../support/globals';
+import { commonSelectors, ahiqarSelectors, gflSelectors } from '../support/globals';
 
-const ahiqarSelectors = {
-  list: '.panels-wrapper > .panel:nth-child(4) [role="tablist"] .annotations-list',
-  listItem: '.panels-wrapper > .panel:nth-child(4) [role="tablist"] .annotations-list .item',
-  listOfSecondTab: '.panels-wrapper > .panel:nth-child(4) [role="tabpanel"]:nth-child(2) .annotations-list',
-  tab: '.panels-wrapper > .panel:nth-child(4) [role="tablist"] [data-pc-section="nav"] [data-pc-name="tabpanel"]',
-  text: '.panels-wrapper > .panel:nth-child(3) #text-content',
-  annotationPanelActionCheckbox: '.panel-header .actions > div:first-child #panel-check-action',
-}
-
-const gflSelectors = {
-  listItem: '.panels-wrapper > .panel:nth-child(3) [role="tablist"] .annotations-list .item',
-}
 
 const selectors = {
   ...commonSelectors,

--- a/tests/cypress/e2e/variants.cy.js
+++ b/tests/cypress/e2e/variants.cy.js
@@ -1,0 +1,77 @@
+import { commonSelectors, ahiqarSelectors, gflSelectors } from '../support/globals';
+
+const selectors = {
+    ...commonSelectors,
+    ...ahiqarSelectors,
+  }
+
+  describe('VariantsAnnotation', () => {
+
+    beforeEach(() => {
+      cy
+      .visit(`/ahiqar-arabic-karshuni-with-variants-local.html?tido=m20_i1_p0.0-1.0-2.0-3.2`)
+    })
+
+    describe('Variants items selection', () => {
+      it('select (unselect) a variant item', () => {
+        // should select a variant item and add its witness after the highlighted text + the highlighted text should become light blue
+        cy
+          .get(selectors.list)
+          .children()
+          .eq(0)
+          .click()
+          .should('have.class', 'active') // the variant item is selected 
+          .get('div#MD12675N1l4l2l6l4l40')
+          .find('span.witnesses')
+          .find('span').contains('DFM 614') // the witness is added
+          .parent()
+          .next()
+          .invoke('attr', 'data-annotation-level')
+          .should('eq', '1')    // highlighted text should become light blue 
+
+          // --- select sequentially another variant item ---
+          .get(selectors.list)
+          .children()
+          .eq(1)
+          .click()
+          .should('have.class', 'active') // the variant item is selected 
+          .get('div#MD12675N1l4l2l6l4l40')
+          .find('span.witnesses')
+          .find('span').contains('Ming. syr. 258') // the witness is added
+          .parent()
+          .children().should('have.length',2)
+          .parent()
+          .next()
+          .invoke('attr', 'data-annotation-level')
+          .should('eq', '1')    // highlighted text should stay light blue
+
+          // ---- unselect the first variant item -----
+          .get(selectors.list)
+          .children()
+          .eq(0)
+          .click()
+          .should('not.have.class', 'active')
+          .get('div#MD12675N1l4l2l6l4l40')
+          .find('span.witnesses')
+          .children()
+          .should('have.length', 1) .contains('Ming. syr. 258') // remove 'DFM-614' witness
+          .parent()
+          .next()
+          .invoke('attr', 'data-annotation-level')
+          .should('eq', '1')    // highlighted text should stay light blue (we still have one witness)
+         
+          // --- unselect the second variant item
+          .get(selectors.list)
+          .children()
+          .eq(1)
+          .click()
+          .get('div#MD12675N1l4l2l6l4l40')
+          .find('span.witnesses')
+          .should('be.empty')   // remove the last remaining witness
+          .next()
+          .invoke('attr', 'data-annotation-level')
+          .should('eq', '0')   // highlighted text becomes grey
+
+      })
+    })
+  });

--- a/tests/cypress/support/globals.js
+++ b/tests/cypress/support/globals.js
@@ -17,4 +17,15 @@ export default {
   },
   ahiqarApiBaseUrl: 'http://localhost:8181/ahiqar',
   gflApiBaseUrl: 'http://localhost:8181/gfl',
+  ahiqarSelectors: {
+    list: '.panels-wrapper > .panel:nth-child(4) div[role="tablist"] .annotations-list',
+    listItem: '.panels-wrapper > .panel:nth-child(4) [role="tablist"] .annotations-list .item',
+    listOfSecondTab: '.panels-wrapper > .panel:nth-child(4) [role="tabpanel"]:nth-child(2) .annotations-list',
+    tab: '.panels-wrapper > .panel:nth-child(4) [role="tablist"] [data-pc-section="nav"] [data-pc-name="tabpanel"]',
+    text: '.panels-wrapper > .panel:nth-child(3) #text-content',
+    annotationPanelActionCheckbox: '.panel-header .actions > div:first-child #panel-check-action',
+  },
+  gflSelectors: {
+    listItem: '.panels-wrapper > .panel:nth-child(3) [role="tablist"] .annotations-list .item',
+  }
 };


### PR DESCRIPTION
In this PR mainly I add the test about Variants Item Selection
I realised that the last commit we merged in main-variants : `fix: remove select All from VariantsView` had produced a bug in the simple selection of variant item, by not making it active when clicking it for the first time. In the second time it would become active 
Therefore I fixed it in this PR also.