### PR TITLE
Clicking a target should show the correct witnesses chips / select the right variant items by considering the witnesses drop down selection

### DIFF
--- a/src/components/annotations/variants/VariantsView.vue
+++ b/src/components/annotations/variants/VariantsView.vue
@@ -41,9 +41,10 @@ const unsubscribe = TextEventBus.on('click', ({ target }) => {
 
   let ids = getAnnotationIdsFromTarget(target)
   // ids are all the annotation ids of the target, which can be in different tabs. 
-  // we need to filter only the variant ides before proceeding with adding active annotation or removing active annotation
+  // we need to filter only the variant ids before proceeding with adding active annotation or removing active annotation
   const variantAnnotations = getVariantAnnotations(annotationStore.annotations, 'Variant')
   const variantAnnotationIds = variantAnnotations.map((annotation) => annotation.id)
+  // ids now contains the ids of the target's variants independent from the witnesses drop down selection 
   ids = ids.filter((id) => variantAnnotationIds.includes(id))
 
   const annotations = annotationStore.visibleAnnotations.filter((filtered) => ids.find(id => filtered.id === id))
@@ -59,20 +60,28 @@ const unsubscribe = TextEventBus.on('click', ({ target }) => {
 
   const targetIsSelected = parseInt(target.getAttribute('data-annotation-level'), 10) > 0
 
+  // ids of the selected annotations
+  const idsSelected = annotations.map((annotation) => annotation.id)
+
+
   if (annotationStore.isSingleSelectMode) {
     if (targetIsSelected) {
-      annotationStore.removeVisibleAnnotations(ids)
-      annotationStore.deactivateAnnotationsByIds(ids)
+      annotationStore.removeVisibleAnnotations(idsSelected)
+      annotationStore.deactivateAnnotationsByIds(idsSelected)
     } else {
+      // we select the target in single select mode -> we should show all the target's variant items - ids
       annotationStore.addVisibleAnnotations(ids)
       annotationStore.activateAnnotationsByIds(ids)
     }
   } else {
+    // not in single select mode
+    // we should select/deselect the variant items which align with the witnesses drop down selection
+    // i.e in case where out of 4 witnesses drop down only 2 are chosen. When one clicks the target then one should select only the variant items for which their witness is selected
     if (targetIsSelected) {
-      annotationStore.deactivateAnnotationsByIds(ids)
+      annotationStore.deactivateAnnotationsByIds(idsSelected)
     }
     else {
-      annotationStore.activateAnnotationsByIds(ids)
+      annotationStore.activateAnnotationsByIds(idsSelected)
     }
   }
 })

--- a/tests/cypress/e2e/variants.cy.js
+++ b/tests/cypress/e2e/variants.cy.js
@@ -376,6 +376,53 @@ const selectors = {
         .next()
         .should('not.have.class', 'active')
       })
+
+      it('should consider the witnesses drop down selection when clicking the target', () => {
+        // when clicking the target should show correct witnesses chips in text Panel and select the variant items according to witnesses drop down selection 
+        cy.get(selectors.list)
+          .clickWitnessItem('4 Witnesses selected', 'Cod. Arab. 236')
+          .parent().parent()
+          .contains('DFM 614').click()
+
+        // we need to unclick the witnesses drop down, to be able to click the target
+        cy.get(selectors.panel4)
+          .contains('2 Witnesses selected')
+          .click({force: true})
+        
+        // we click at a target
+        cy.clickTarget()
+
+        // in the witnesses there should be only 2 chips
+        cy.get(selectors.panel3)
+          .find('#text-content')
+          .find('.witnesses')
+          .children()
+          .should('have.length', 2)
+          .eq(0)
+          .should('contain', 'Ming. syr. 258')
+          .next()
+          .should('contain', 'Sach. 339')
+
+        // should show 'correct number of variants selected'
+
+        cy.get(selectors.panel4)
+          .find('#variants-top-bar')
+          .find('span')
+          .contains('2 Variants selected')
+
+        // only the variant items controled by the witnesses filter and referring to the target should be selected - 3rd and 4th variant item
+        cy.get(selectors.list)
+        .children()
+        .should('have.length', 6)
+        .eq(0).should('contain','Ming. syr. 258').and('not.have.class','active')
+        .next().should('contain','Sach. 339').and('not.have.class','active')    // eq(1)
+        .next().should('contain','Ming. syr. 258').and('have.class','active')    // eq(2)
+        .next().should('contain','Sach. 339').and('have.class','active')
+        .next().should('contain','Ming. syr. 258').and('not.have.class','active')
+        .next().should('contain','Sach. 339').and('not.have.class','active')
+      })
+
+
     })
 
     describe('Single select mode', () => {


### PR DESCRIPTION
Bug: deselecting two witnesses from witnesses drop down and then clicking at the target, the number in the span 'x Variants selected'  is shown wrong. 

reason: clicking a target should show the correct witnesses chips / select the right variant items by considering the witnesses drop down selection