### PR TITLE
Dynamic collections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import PanelsWrapper from './components/PanelsWrapper'
 import { FC } from 'react'
 import { configStore } from '@/store/ConfigStore.tsx'
 
+import TopBar from '@/components/TopBar'
+
 interface AppProps {
   customConfig: Config
 }
@@ -12,6 +14,7 @@ const App: FC<AppProps> = ({ customConfig }) => {
 
   return (
     <div className="tido t-flex t-flex-col">
+      <TopBar />
       <PanelsWrapper />
     </div>
   )

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -1,7 +1,8 @@
 import { FC, ReactNode, useState } from 'react'
 
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Popover, PopoverContent, PopoverTrigger, ClosePopover } from '@/components/ui/popover'
 import TreeView from '@/components/TreeView'
+
 
 interface LocalTreeProps {
     TriggerButton: ReactNode
@@ -15,15 +16,9 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
 
     function handleSelectClick(e) {
         // TODO: check whether input text is provided or an item is clicked
-
-
+        // add a class hidden to ref div PopoverContent, in order to close the pop up
+        console.log('click select button')
     }
-
-    const selectButton =  
-          <button className="t-bg-blue-500 t-text-white t-rounded t-flex t-text-center t-pl-2 t-ml-[80%] t-mt-10 t-items-center t-justify-items-center t-w-16 t-h-10"
-                onClick={(e) => handleSelectClick(e)}>
-            Select
-        </button>
 
     return <div className="local-tree-modal"> 
             <Popover>
@@ -35,10 +30,16 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                         <span className="t-font-bold">Enter a collection/manifest Url</span>
                         <input className="t-border-solid t-border-[1.5px] t-w-[200px] t-h-[30px] t-mb-[10px]" />
                         <span>Or choose:</span>
+
                         <TreeView />
+
                         <div className="t-pb-4">
-                           {selectButton}
+                            <ClosePopover className='t-bg-blue-500 t-text-white t-rounded t-flex t-text-center t-pl-2 t-ml-[80%] t-mt-10 t-items-center t-justify-items-center t-w-16 t-h-10'
+                                onClick = {(e) => handleSelectClick(e)}>
+                                    Select
+                            </ClosePopover>
                         </div>
+                       
                     </div>
                 </PopoverContent>
             </Popover>

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -25,10 +25,8 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
     const addNewPanel = configStore((state) => state.addNewPanel)
 
     const inputCollectionRef = useRef(null);
-
-    const [selectClicked, setSelectClicked] = useState(false)
-
-    // check for the state temp variable of newCollection - if we have a new collection there -> if so then we retrieve that value and add a new panel in Configstore
+    const selectButtonRef = useRef(null)
+    
 
     function handleSelectClick(e) {
         // TODO: check whether a value is provided for newCollectionUrl in the data store
@@ -36,6 +34,11 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                  // if yes, then add the new panel in config store with this new entrypoint AND set the newCollectionUrl as empty value
         
         let manifestIndex: number | undefined, itemIndex: number | undefined, collectionUrl: string | undefined
+
+        if (!clickedItemUrl && inputCollectionRef.current.value === '') {
+            selectButtonRef.current.disabled = true
+            return
+        }
 
         if (clickedItemUrl) {
             const data = getClickedItemIndices(clickedItemUrl, treeNodes)
@@ -54,8 +57,9 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                   },
                 manifestIndex: manifestIndex,
                 itemIndex: itemIndex
-            }
+             }
             )
+            return
         }
 
         if (inputCollectionRef.current.value !== '') {
@@ -67,9 +71,11 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                     url: collectionUrl,
                     type: "collection",
                   }
-            }
+              }
             )
+            return
         }
+
     }
 
     return <div className="local-tree-modal"> 

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -6,7 +6,7 @@ import { configStore } from '@/store/ConfigStore'
 import { Popover, PopoverContent, PopoverTrigger, ClosePopover } from '@/components/ui/popover'
 import TreeView from '@/components/TreeView'
 
-import { getClickedItemIndices } from '@/utils/tree'
+import { getItemIndices } from '@/utils/tree'
 
 
 interface LocalTreeProps {
@@ -41,7 +41,7 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
         setInputGiven(true)
 
         if (clickedItemUrl) {
-            const data = getClickedItemIndices(clickedItemUrl, treeNodes)
+            const data = getItemIndices(clickedItemUrl, treeNodes)
             if (!data) {
                 console.error('Indices of clicked item could not be found')
                 return 
@@ -77,7 +77,7 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
         setClickedItemUrl('')
         setInputGiven(false)
         setClickedButton(false)
-        
+
         return
 
     }

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -7,9 +7,6 @@ import { Popover, PopoverContent, PopoverTrigger, ClosePopover } from '@/compone
 import TreeView from '@/components/TreeView'
 
 import { getClickedItemIndices } from '@/utils/tree'
-import { tree } from '@/utils/icons'
-
-
 
 
 interface LocalTreeProps {
@@ -21,24 +18,27 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
     // TODO: add a [loading, setLoading] => which shows the pop over when the tree has been loaded -> TreeView Component updates the loading of its parent
 
     const clickedItemUrl = dataStore((state) => state.clickedItemUrl)
+    const setClickedItemUrl = dataStore(state => state.setClickedItemUrl)
     const treeNodes = dataStore((state) => state.treeNodes)
     const addNewPanel = configStore((state) => state.addNewPanel)
+    const [inputGiven, setInputGiven] = useState(false)
+
+    const [clickedButton, setClickedButton] = useState(false)
 
     const inputCollectionRef = useRef(null);
-    const selectButtonRef = useRef(null)
-    
+
 
     function handleSelectClick(e) {
-        // TODO: check whether a value is provided for newCollectionUrl in the data store
-                 // if not, then ask the user to provide a value
-                 // if yes, then add the new panel in config store with this new entrypoint AND set the newCollectionUrl as empty value
         
         let manifestIndex: number | undefined, itemIndex: number | undefined, collectionUrl: string | undefined
 
         if (!clickedItemUrl && inputCollectionRef.current.value === '') {
-            selectButtonRef.current.disabled = true
+            setClickedButton(true)
+            e.preventDefault();
             return
         }
+
+        setInputGiven(true)
 
         if (clickedItemUrl) {
             const data = getClickedItemIndices(clickedItemUrl, treeNodes)
@@ -50,6 +50,7 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
             collectionUrl = data?.collectionUrl
             manifestIndex = data?.manifestIndex
             itemIndex = data?.itemIndex
+
             addNewPanel({
                 entrypoint: {
                     url: collectionUrl,
@@ -59,13 +60,11 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                 itemIndex: itemIndex
              }
             )
-            return
         }
 
         if (inputCollectionRef.current.value !== '') {
-            console.log('entering the input collectionRef if statement')
-            console.log('inputCollectionRef.current', inputCollectionRef.current)
             collectionUrl =  inputCollectionRef.current?.value
+
             addNewPanel({
                 entrypoint: {
                     url: collectionUrl,
@@ -73,8 +72,13 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                   }
               }
             )
-            return
         }
+
+        setClickedItemUrl('')
+        setInputGiven(false)
+        setClickedButton(false)
+        
+        return
 
     }
 
@@ -85,6 +89,7 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                 </PopoverTrigger>
                 <PopoverContent className="t-bg-white t-absolute t-z-10">
                     <div className="t-flex t-flex-col t-pt-4 t-pl-3 t-w-[500px] t-shadow-md t-border-[1px] t-border-solid t-border-gray-300 t-rounded-md">
+                        <div className="t-text-red-400" style={{display: !inputGiven && clickedButton && !clickedItemUrl  ? 'block': 'none'}}> Please do provide a way to open a new collection</div>
                         <span className="t-font-bold">Enter a collection/manifest Url</span>
                         <input ref={inputCollectionRef}  className="t-border-solid t-border-[1.5px] t-w-[200px] t-h-[30px] t-mb-[10px]" />
                         <span>Or choose:</span>

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -38,7 +38,6 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
         let manifestIndex: number | undefined, itemIndex: number | undefined, collectionUrl: string | undefined
 
         if (clickedItemUrl) {
-            console.log('clickedItem Url', clickedItemUrl)
             const data = getClickedItemIndices(clickedItemUrl, treeNodes)
             if (!data) {
                 console.error('Indices of clicked item could not be found')
@@ -55,7 +54,8 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                   },
                 manifestIndex: manifestIndex,
                 itemIndex: itemIndex
-            })
+            }
+            )
         }
 
         if (inputCollectionRef.current.value !== '') {

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -74,6 +74,7 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
             )
         }
 
+        // lines below serve mainly for showing the error message. Error message appears when a user does not provide input for opening a new a collection/panel
         setClickedItemUrl('')
         setInputGiven(false)
         setClickedButton(false)

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -1,0 +1,48 @@
+import { FC, ReactNode, useState } from 'react'
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import TreeView from '@/components/TreeView'
+
+interface LocalTreeProps {
+    TriggerButton: ReactNode
+}
+
+const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
+    
+    // TODO: add a [loading, setLoading] => which shows the pop over when the tree has been loaded -> TreeView Component updates the loading of its parent
+
+    const [selectClicked, setSelectClicked] = useState(false)
+
+    function handleSelectClick(e) {
+        // TODO: check whether input text is provided or an item is clicked
+
+
+    }
+
+    const selectButton =  
+          <button className="t-bg-blue-500 t-text-white t-rounded t-flex t-text-center t-pl-2 t-ml-[80%] t-mt-10 t-items-center t-justify-items-center t-w-16 t-h-10"
+                onClick={(e) => handleSelectClick(e)}>
+            Select
+        </button>
+
+    return <div className="local-tree-modal"> 
+            <Popover>
+                <PopoverTrigger className="open-tree-button t-h-8 t-w-10 t-relative">
+                    { TriggerButton }
+                </PopoverTrigger>
+                <PopoverContent className="t-bg-white t-absolute t-z-10">
+                    <div className="t-flex t-flex-col t-pt-4 t-pl-3 t-w-[500px] t-shadow-md t-border-[1px] t-border-solid t-border-gray-300 t-rounded-md">
+                        <span className="t-font-bold">Enter a collection/manifest Url</span>
+                        <input className="t-border-solid t-border-[1.5px] t-w-[200px] t-h-[30px] t-mb-[10px]" />
+                        <span>Or choose:</span>
+                        <TreeView />
+                        <div className="t-pb-4">
+                           {selectButton}
+                        </div>
+                    </div>
+                </PopoverContent>
+            </Popover>
+            </div>
+}
+
+export default LocalTreeModal

--- a/src/components/LocalTreeModal.tsx
+++ b/src/components/LocalTreeModal.tsx
@@ -1,7 +1,15 @@
-import { FC, ReactNode, useState } from 'react'
+import { FC, ReactNode, useRef, useState } from 'react'
+
+import { dataStore } from '@/store/DataStore.tsx'
+import { configStore } from '@/store/ConfigStore'
 
 import { Popover, PopoverContent, PopoverTrigger, ClosePopover } from '@/components/ui/popover'
 import TreeView from '@/components/TreeView'
+
+import { getClickedItemIndices } from '@/utils/tree'
+import { tree } from '@/utils/icons'
+
+
 
 
 interface LocalTreeProps {
@@ -12,12 +20,56 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
     
     // TODO: add a [loading, setLoading] => which shows the pop over when the tree has been loaded -> TreeView Component updates the loading of its parent
 
+    const clickedItemUrl = dataStore((state) => state.clickedItemUrl)
+    const treeNodes = dataStore((state) => state.treeNodes)
+    const addNewPanel = configStore((state) => state.addNewPanel)
+
+    const inputCollectionRef = useRef(null);
+
     const [selectClicked, setSelectClicked] = useState(false)
 
+    // check for the state temp variable of newCollection - if we have a new collection there -> if so then we retrieve that value and add a new panel in Configstore
+
     function handleSelectClick(e) {
-        // TODO: check whether input text is provided or an item is clicked
-        // add a class hidden to ref div PopoverContent, in order to close the pop up
-        console.log('click select button')
+        // TODO: check whether a value is provided for newCollectionUrl in the data store
+                 // if not, then ask the user to provide a value
+                 // if yes, then add the new panel in config store with this new entrypoint AND set the newCollectionUrl as empty value
+        
+        let manifestIndex: number | undefined, itemIndex: number | undefined, collectionUrl: string | undefined
+
+        if (clickedItemUrl) {
+            console.log('clickedItem Url', clickedItemUrl)
+            const data = getClickedItemIndices(clickedItemUrl, treeNodes)
+            if (!data) {
+                console.error('Indices of clicked item could not be found')
+                return 
+            }
+
+            collectionUrl = data?.collectionUrl
+            manifestIndex = data?.manifestIndex
+            itemIndex = data?.itemIndex
+            addNewPanel({
+                entrypoint: {
+                    url: collectionUrl,
+                    type: "collection",
+                  },
+                manifestIndex: manifestIndex,
+                itemIndex: itemIndex
+            })
+        }
+
+        if (inputCollectionRef.current.value !== '') {
+            console.log('entering the input collectionRef if statement')
+            console.log('inputCollectionRef.current', inputCollectionRef.current)
+            collectionUrl =  inputCollectionRef.current?.value
+            addNewPanel({
+                entrypoint: {
+                    url: collectionUrl,
+                    type: "collection",
+                  }
+            }
+            )
+        }
     }
 
     return <div className="local-tree-modal"> 
@@ -28,7 +80,7 @@ const LocalTreeModal: FC <LocalTreeProps> = ({ TriggerButton }) => {
                 <PopoverContent className="t-bg-white t-absolute t-z-10">
                     <div className="t-flex t-flex-col t-pt-4 t-pl-3 t-w-[500px] t-shadow-md t-border-[1px] t-border-solid t-border-gray-300 t-rounded-md">
                         <span className="t-font-bold">Enter a collection/manifest Url</span>
-                        <input className="t-border-solid t-border-[1.5px] t-w-[200px] t-h-[30px] t-mb-[10px]" />
+                        <input ref={inputCollectionRef}  className="t-border-solid t-border-[1.5px] t-w-[200px] t-h-[30px] t-mb-[10px]" />
                         <span>Or choose:</span>
 
                         <TreeView />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, MouseEvent, useState } from 'react'
 
 
 import LocalTreeModal from '@/components/LocalTreeModal'
@@ -12,7 +12,7 @@ const TopBar: FC = () => {
   
 
 return <div className="t-flex t-flex-row t-ml-[6%] t-mt-10">
-          <LocalTreeModal TriggerButton={addButton} />
+          <LocalTreeModal TriggerButton={addButton}  />
         </div>
   
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEvent, useState } from 'react'
+import { FC } from 'react'
 
 
 import LocalTreeModal from '@/components/LocalTreeModal'

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react'
+
+
+import LocalTreeModal from '@/components/LocalTreeModal'
+
+const TopBar: FC = () => {
+  
+  const addButton =  
+          <span className="t-bg-blue-500 t-text-white t-rounded t-flex t-pl-4 t-items-center t-justify-items-center t-w-16 t-h-10">
+            New
+        </span>
+  
+
+return <div className="t-flex t-flex-row t-ml-[6%] t-mt-10">
+          <LocalTreeModal TriggerButton={addButton} />
+        </div>
+  
+}
+
+export default TopBar

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -1,7 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 import { configStore } from '@/store/ConfigStore.tsx'
 
-
 import { createTree } from '@/utils/tree' 
 import CollectionSubtree from '@/components/tree/CollectionSubtree'
 
@@ -31,42 +30,6 @@ const Tree: FC  = () => {
 
     if (loadingTree) return <></>
 
-    function getCollectionUrl(itemLabel, treeNodes): string | null {
-
-      for (let i = 0; i < treeNodes.length ; i++) {
-        const collectionNode = treeNodes[i]
-        for (let j = 0; j < collectionNode.children.length; j++) {
-          const manifest = collectionNode.children[j]
-          if (isItemInManifest(manifest, itemLabel)) {
-            console.log('manifest found', manifest)
-            return collectionNode.url
-          }
-        }
-        //if (isItemInManifests(collectionNode.children, itemLabel)) return collectionNode.url
-      }
-
-      return null
-    }
-
-    function isItemInManifests(manifests, itemLabel) {
-      for (let i = 0; i < manifests.length ; i++) {
-        if (isItemInManifest(manifests[i], itemLabel)) return true
-      }
-
-      return false
-    }
-
-    function isItemInManifest(manifest, itemLabel) {
-      const items = manifest.children
-      for (let i = 0; i < items.length ; i++) {
-        if (items[i].url === itemLabel) return true
-      }
-
-      return false
-    }
-
-    const collectionUrl = getCollectionUrl('https://api.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/3r177/16a/latest/item.json', treeNodes) 
-    console.log('collection Url', collectionUrl)
     const tree =
     treeNodes.length > 0 &&
     treeNodes.map((collection, i) => (

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -1,5 +1,7 @@
 import { FC, useEffect, useState } from 'react'
 import { configStore } from '@/store/ConfigStore.tsx'
+import { dataStore } from '@/store/DataStore.tsx'
+
 
 import { createTree } from '@/utils/tree' 
 import CollectionSubtree from '@/components/tree/CollectionSubtree'
@@ -7,21 +9,23 @@ import CollectionSubtree from '@/components/tree/CollectionSubtree'
 const Tree: FC  = () => {
     
     const config = configStore(state => state.config)
+    const initTreeNodes = dataStore(state => state.initTreeNodes)
 
-    const [treeNodes, setTreeNodes] = useState([])
+
+    const [treeNodes, setTreeNodes] = useState<CollectionNode[]>([])
 
     const [loadingTree, setLoadingTreee] = useState(true)
 
     useEffect(() => {
         async function initTree(panels?: PanelConfig[]) {
           if (!panels) return  
-          const nodes = await createTree(panels)
+            const nodes = await createTree(panels)
             
             setTreeNodes(nodes)
             setLoadingTreee(false)
+            initTreeNodes(nodes)
         }
         initTree(config.panels)
-    
     }, [])
 
     console.log('tree', treeNodes)

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -28,10 +28,6 @@ const Tree: FC  = () => {
         initTree(config.panels)
     }, [])
 
-    console.log('tree', treeNodes)
-
-    
-
     if (loadingTree) return <></>
 
     const tree =

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -1,0 +1,88 @@
+import { FC, useEffect, useState } from 'react'
+import { configStore } from '@/store/ConfigStore.tsx'
+
+
+import { createTree } from '@/utils/tree' 
+import CollectionSubtree from '@/components/tree/CollectionSubtree'
+
+const Tree: FC  = () => {
+    
+    const config = configStore(state => state.config)
+
+    const [treeNodes, setTreeNodes] = useState([])
+
+    const [loadingTree, setLoadingTreee] = useState(true)
+
+    useEffect(() => {
+        async function initTree(panels?: PanelConfig[]) {
+          if (!panels) return  
+          const nodes = await createTree(panels)
+            
+            setTreeNodes(nodes)
+            setLoadingTreee(false)
+        }
+        initTree(config.panels)
+    
+    }, [])
+
+    console.log('tree', treeNodes)
+
+    
+
+    if (loadingTree) return <></>
+
+    function getCollectionUrl(itemLabel, treeNodes): string | null {
+
+      for (let i = 0; i < treeNodes.length ; i++) {
+        const collectionNode = treeNodes[i]
+        for (let j = 0; j < collectionNode.children.length; j++) {
+          const manifest = collectionNode.children[j]
+          if (isItemInManifest(manifest, itemLabel)) {
+            console.log('manifest found', manifest)
+            return collectionNode.url
+          }
+        }
+        //if (isItemInManifests(collectionNode.children, itemLabel)) return collectionNode.url
+      }
+
+      return null
+    }
+
+    function isItemInManifests(manifests, itemLabel) {
+      for (let i = 0; i < manifests.length ; i++) {
+        if (isItemInManifest(manifests[i], itemLabel)) return true
+      }
+
+      return false
+    }
+
+    function isItemInManifest(manifest, itemLabel) {
+      const items = manifest.children
+      for (let i = 0; i < items.length ; i++) {
+        if (items[i].url === itemLabel) return true
+      }
+
+      return false
+    }
+
+    const collectionUrl = getCollectionUrl('https://api.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/3r177/16a/latest/item.json', treeNodes) 
+    console.log('collection Url', collectionUrl)
+    const tree =
+    treeNodes.length > 0 &&
+    treeNodes.map((collection, i) => (
+      <div
+        key={i}
+        className=""
+      >
+        <CollectionSubtree collectionData={collection} />
+      </div>
+    ))
+
+
+
+    return <div className="tree t-h-96 t-overflow-hidden t-overflow-y-auto"> 
+                {tree}
+           </div>
+}
+
+export default Tree

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -28,6 +28,7 @@ const Panel: FC<Props> = ({ config }) => {
     const collectionUrl = config.entrypoint.url
     const init = async () => {
       try {
+
         setLoading(true)
         const collection = await initCollection(collectionUrl)
         const manifest = await apiRequest<Manifest>(collection.sequence[config.manifestIndex ?? 0].id)

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -17,6 +17,7 @@ interface Props {
 
 const Panel: FC<Props> = ({ config }) => {
   const initCollection = dataStore(state => state.initCollection)
+  const getCollection = dataStore(state => state.getCollection)
   const addPanelContent = contentStore((state) => state.addPanelContent)
 
   const [error, setError] = useState<boolean | string>(false)
@@ -30,7 +31,8 @@ const Panel: FC<Props> = ({ config }) => {
       try {
 
         setLoading(true)
-        const collection = await initCollection(collectionUrl)
+        const collection = await getCollection(collectionUrl)
+
         const manifest = await apiRequest<Manifest>(collection.sequence[config.manifestIndex ?? 0].id)
         const item = await apiRequest<Item>(manifest.sequence[config.itemIndex ?? 0].id)
         const contentTypes: string[] = getContentTypes(item.content)

--- a/src/components/tree/CollectionSubtree.tsx
+++ b/src/components/tree/CollectionSubtree.tsx
@@ -10,7 +10,7 @@ interface CollectionSubtreeProps {
 
 const CollectionSubtree: FC<CollectionSubtreeProps>  = ({ collectionData }) => {
 
-    const manifestSubTree = collectionData.children.length > 0 
+    const collectionSubTree = collectionData.children.length > 0 
                 &&  
                 collectionData.children.map((manifest: ManifestNode, i: number) => (
                     <ManifestSubtree key={i} manifestData={manifest} />
@@ -20,7 +20,7 @@ const CollectionSubtree: FC<CollectionSubtreeProps>  = ({ collectionData }) => {
     
           {collectionData.title}
            <div className="t-ml-[5px]">
-                { manifestSubTree}
+                { collectionSubTree}
             </div>         
       </div>
 }

--- a/src/components/tree/CollectionSubtree.tsx
+++ b/src/components/tree/CollectionSubtree.tsx
@@ -12,7 +12,7 @@ const CollectionSubtree: FC<CollectionSubtreeProps>  = ({ collectionData }) => {
 
     const manifestSubTree = collectionData.children.length > 0 
                 &&  
-                collectionData.children.map((manifest, i) => (
+                collectionData.children.map((manifest: ManifestNode, i: number) => (
                     <ManifestSubtree key={i} manifestData={manifest} />
                   ))
 

--- a/src/components/tree/CollectionSubtree.tsx
+++ b/src/components/tree/CollectionSubtree.tsx
@@ -1,0 +1,28 @@
+
+
+import { FC } from 'react'
+import ManifestSubtree from '@/components/tree/ManifestSubtree'
+
+
+interface CollectionSubtreeProps {
+    collectionData: any
+}
+
+const CollectionSubtree: FC<CollectionSubtreeProps>  = ({ collectionData }) => {
+
+    const manifestSubTree = collectionData.children.length > 0 
+                &&  
+                collectionData.children.map((manifest, i) => (
+                    <ManifestSubtree key={i} manifestData={manifest} />
+                  ))
+
+    return <div className="collection-subtree"> 
+    
+          {collectionData.title}
+           <div className="t-ml-[5px]">
+                { manifestSubTree}
+            </div>         
+      </div>
+}
+
+export default CollectionSubtree

--- a/src/components/tree/Item.tsx
+++ b/src/components/tree/Item.tsx
@@ -2,6 +2,7 @@
 
 import { FC, MouseEvent, useState } from 'react'
 
+import { dataStore } from '@/store/DataStore.tsx'
 
 interface ItemProps {
     label: string,
@@ -13,8 +14,13 @@ const ItemTree: FC<ItemProps>  = ({ label, url }) => {
     const [active, setActive] = useState(false)
     const [itemUrl] = useState(url)
 
+    const setClickedItemUrl = dataStore(state => state.setClickedItemUrl)
+
     function handleClick(e: MouseEvent<HTMLButtonElement, MouseEvent>) {
+        console.log('clicked item url in ITemTree', itemUrl)
         e.preventDefault()
+        if (!active) setClickedItemUrl(itemUrl)
+
         setActive(prevState => !prevState)
 
         // 

--- a/src/components/tree/Item.tsx
+++ b/src/components/tree/Item.tsx
@@ -15,20 +15,17 @@ const ItemTree: FC<ItemProps>  = ({ label, url }) => {
     const [itemUrl] = useState(url)
 
     const setClickedItemUrl = dataStore(state => state.setClickedItemUrl)
+    const clickedItemUrl = dataStore(state => state.clickedItemUrl)
 
     function handleClick(e: MouseEvent<HTMLButtonElement, MouseEvent>) {
-        console.log('clicked item url in ITemTree', itemUrl)
         e.preventDefault()
         if (!active) setClickedItemUrl(itemUrl)
 
         setActive(prevState => !prevState)
-
-        // 
-        // find the collectionUrl based on itemUrl
     }
 
     return <div>
-            <button className="t-w-full t-text-left hover:t-bg-gray-200 t-cursor-pointer" style={{backgroundColor: !active ? 'white': '#0284c7'}}
+            <button className="t-w-full t-text-left hover:t-bg-gray-200 t-cursor-pointer" style={{backgroundColor: url === clickedItemUrl ? '#0284c7': 'white'}}
                     onClick={(e) => handleClick(e)}>
                   { label }
             </button>

--- a/src/components/tree/Item.tsx
+++ b/src/components/tree/Item.tsx
@@ -1,6 +1,6 @@
 
 
-import { FC, useState } from 'react'
+import { FC, MouseEvent, useState } from 'react'
 
 
 interface ItemProps {
@@ -13,10 +13,11 @@ const ItemTree: FC<ItemProps>  = ({ label, url }) => {
     const [active, setActive] = useState(false)
     const [itemUrl] = useState(url)
 
-    function handleClick(
-        e) {
+    function handleClick(e: MouseEvent<HTMLButtonElement, MouseEvent>) {
         e.preventDefault()
         setActive(prevState => !prevState)
+
+        // 
         // find the collectionUrl based on itemUrl
     }
 

--- a/src/components/tree/Item.tsx
+++ b/src/components/tree/Item.tsx
@@ -1,0 +1,31 @@
+
+
+import { FC, useState } from 'react'
+
+
+interface ItemProps {
+    label: string,
+    url: string
+}
+
+const ItemTree: FC<ItemProps>  = ({ label, url }) => {
+
+    const [active, setActive] = useState(false)
+    const [itemUrl] = useState(url)
+
+    function handleClick(
+        e) {
+        e.preventDefault()
+        setActive(prevState => !prevState)
+        // find the collectionUrl based on itemUrl
+    }
+
+    return <div>
+            <button className="t-w-full t-text-left hover:t-bg-gray-200 t-cursor-pointer" style={{backgroundColor: !active ? 'white': '#0284c7'}}
+                    onClick={(e) => handleClick(e)}>
+                  { label }
+            </button>
+        </div>
+}
+
+export default ItemTree

--- a/src/components/tree/ManifestSubtree.tsx
+++ b/src/components/tree/ManifestSubtree.tsx
@@ -1,0 +1,27 @@
+
+
+import { FC } from 'react'
+import ItemTree from '@/components/tree/Item'
+
+interface ManifestSubtreeProps {
+    manifestData: any
+}
+
+const ManifestSubtree: FC<ManifestSubtreeProps>  = ({ manifestData }) => {
+
+    const itemsLabels = manifestData.children.length > 0 
+                &&  
+                manifestData.children.map((item: Sequence, i) => (
+                    <ItemTree label={item.label} url = {item.id} key={i}/>
+                  ))
+
+    return <div className="manifest-subtree"> 
+    
+          {manifestData.label}
+           <div className="t-ml-[5px] t-flex t-flex-col">
+                { itemsLabels}
+            </div>         
+      </div>
+}
+
+export default ManifestSubtree

--- a/src/components/tree/ManifestSubtree.tsx
+++ b/src/components/tree/ManifestSubtree.tsx
@@ -11,8 +11,8 @@ const ManifestSubtree: FC<ManifestSubtreeProps>  = ({ manifestData }) => {
 
     const itemsLabels = manifestData.children.length > 0 
                 &&  
-                manifestData.children.map((item: Sequence, i) => (
-                    <ItemTree label={item.label} url = {item.id} key={i}/>
+                manifestData.children.map((item: ItemNode, i: number) => (
+                    <ItemTree label={item.label} url = {item.url} key={i}/>
                   ))
 
     return <div className="manifest-subtree"> 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -23,5 +23,6 @@ const PopoverContent = React.forwardRef<
       />
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
+const ClosePopover = PopoverPrimitive.Close
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverContent, ClosePopover }

--- a/src/store/ConfigStore.tsx
+++ b/src/store/ConfigStore.tsx
@@ -2,12 +2,19 @@ import { create } from 'zustand'
 
 interface ConfigStoreType {
   config: Config,
-  addCustomConfig: (customConfig: Config) => void
+  addCustomConfig: (customConfig: Config) => void,
+  addNewPanel: (newPanel: PanelConfig) => void
 }
 
-export const configStore = create<ConfigStoreType>((set) => ({
+export const configStore = create<ConfigStoreType>((set, get) => ({
   config: {},
   addCustomConfig: (customConfig: Config) => {
     set({ config: customConfig })
+  },
+  addNewPanel: (newPanel: PanelConfig) => {
+    let newConfig = {...get().config} 
+    newConfig.panels?.push(newPanel)
+
+    set({config: newConfig})
   }
 }))

--- a/src/store/DataStore.tsx
+++ b/src/store/DataStore.tsx
@@ -6,17 +6,31 @@ interface CollectionMap {
 }
 
 interface DataStoreType {
-  collections: CollectionMap
+  collections: CollectionMap,
+  treeNodes: CollectionNode[],
+  clickedItemUrl: string,
   initCollection: (url: string) => Promise<Collection>
+  initTreeNodes: (newTreeNodes: CollectionNode[]) => void,
+  setClickedItemUrl: (newUrl: string) => void
 }
 
 export const dataStore = create<DataStoreType>((set, get) => ({
   collections: {},
+  treeNodes: [],
+  clickedItemUrl: '',
   initCollection: async (url: string) => {
     const collection = await apiRequest<Collection>(url)
     const collections: CollectionMap = { ...get().collections }
     collections[collection.id] = collection
     set({ collections })
     return collection
+  },
+  initTreeNodes: (newTreeNodes: CollectionNode[]) => {
+    set({ treeNodes: newTreeNodes})
+  },
+
+  setClickedItemUrl: (newUrl: string) => {
+    set({clickedItemUrl: newUrl})
   }
+
 }))

--- a/src/store/DataStore.tsx
+++ b/src/store/DataStore.tsx
@@ -11,7 +11,9 @@ interface DataStoreType {
   clickedItemUrl: string,
   initCollection: (url: string) => Promise<Collection>
   initTreeNodes: (newTreeNodes: CollectionNode[]) => void,
-  setClickedItemUrl: (newUrl: string) => void
+  setClickedItemUrl: (newUrl: string) => void,
+  getCollection: (collectionUrl: string) => Promise<Collection>
+
 }
 
 export const dataStore = create<DataStoreType>((set, get) => ({
@@ -31,6 +33,12 @@ export const dataStore = create<DataStoreType>((set, get) => ({
 
   setClickedItemUrl: (newUrl: string) => {
     set({clickedItemUrl: newUrl})
-  }
+  },
 
+  async getCollection(collectionUrl: string): Promise<Collection> {
+    if (collectionUrl in get().collections) return get().collections[collectionUrl]
+    
+    const collection = await get().initCollection(collectionUrl)
+    return collection
+  }
 }))

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -265,6 +265,31 @@ declare global {
   }
 
   type HttpResponse<T> = SuccessResponse<T> | ErrorResponse
+
+
+// tree types
+
+interface ItemNode {
+  key: string,
+  label: string,
+  url: string
 }
+
+interface ManifestNode {
+  key: string,
+  label: string,
+  children: ItemNode[]
+}
+
+interface CollectionNode {
+  key: number,
+  title: string,
+  url: string,
+  children: ManifestNode
+}
+
+}
+
+
 
 export {}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -210,9 +210,9 @@ declare global {
   }
   interface PanelConfig {
     entrypoint: Entrypoint
-    colors: Colors
-    manifestIndex: number
-    itemIndex: number
+    color?: Colors
+    manifestIndex?: number
+    itemIndex?: number
   }
 
   type RangeSelector = {

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -81,6 +81,8 @@ export function getItemIndices(itemUrl: string, treeNodes: CollectionNode[]): It
 
         const manifest = collectionNode.children[j]
 
+        if (!manifest.children || manifest.children.length === 0) continue
+
         const itemIndex = getItemIndex(manifest, itemUrl)
         if (itemIndex !== null) {
             return {
@@ -96,11 +98,6 @@ export function getItemIndices(itemUrl: string, treeNodes: CollectionNode[]): It
   }
 
 
-  function getItemIndex(manifest, itemUrl: string): number | null {
-    const items = manifest.children
-    for (let i = 0; i < items.length ; i++) {
-      if (items[i].url === itemUrl) return i
-    }
-
-    return null
+  function getItemIndex(manifest, itemUrl: string): number {
+    return manifest.children.findIndex((item: ItemNode) => item.url === itemUrl)
   }

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -64,14 +64,13 @@ function getItemsNodes(parentKey: string, items: Sequence[]) {
     return nodes
 }
 
-interface ClickedItemIndices {
+interface ItemIndices {
     collectionUrl: string,
     manifestIndex: number,
     itemIndex: number
 }
 
-export function getClickedItemIndices(itemUrl: string, treeNodes: CollectionNode[]): ClickedItemIndices | null{
-    // find the collection url when clicking an item in local tree
+export function getItemIndices(itemUrl: string, treeNodes: CollectionNode[]): ItemIndices | null{
     
     for (let i = 0; i < treeNodes.length ; i++) {
       const collectionNode = treeNodes[i]
@@ -92,8 +91,6 @@ export function getClickedItemIndices(itemUrl: string, treeNodes: CollectionNode
         }
       }
     }
-
-    console.log('----')
 
     return null
   }

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -64,32 +64,46 @@ function getItemsNodes(parentKey: string, items: Sequence[]) {
     return nodes
 }
 
+interface ClickedItemIndices {
+    collectionUrl: string,
+    manifestIndex: number,
+    itemIndex: number
+}
 
-export function getCollectionUrl(itemUrl: string, treeNodes): string | null {
+export function getClickedItemIndices(itemUrl: string, treeNodes: CollectionNode[]): ClickedItemIndices | null{
     // find the collection url when clicking an item in local tree
     
     for (let i = 0; i < treeNodes.length ; i++) {
       const collectionNode = treeNodes[i]
 
+      if (!collectionNode.children || collectionNode.children.length === 0) return null
+
       for (let j = 0; j < collectionNode.children.length; j++) {
 
         const manifest = collectionNode.children[j]
 
-        if (isItemInManifest(manifest, itemUrl)) {
-          return collectionNode.url
+        const itemIndex = getItemIndex(manifest, itemUrl)
+        if (itemIndex !== null) {
+            return {
+                collectionUrl: collectionNode.url,
+                manifestIndex: j,
+                itemIndex: itemIndex
+            }
         }
       }
     }
+
+    console.log('----')
 
     return null
   }
 
 
-  function isItemInManifest(manifest, itemUrl: string) {
+  function getItemIndex(manifest, itemUrl: string): number | null {
     const items = manifest.children
     for (let i = 0; i < items.length ; i++) {
-      if (items[i].url === itemUrl) return true
+      if (items[i].url === itemUrl) return i
     }
 
-    return false
+    return null
   }

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -7,7 +7,7 @@ export async function createTree(panels: PanelConfig[]) {
     const nodes: CollectionNode[] = []
     
     for (let i = 0; i< panels.length; i++) {
-        const collectionNode = await createCollectionNode(panels[i].entrypoint.url, i).then((node) => {
+         await createCollectionNode(panels[i].entrypoint.url, i).then((node) => {
             nodes.push(node)
         })
     }
@@ -98,6 +98,6 @@ export function getItemIndices(itemUrl: string, treeNodes: CollectionNode[]): It
   }
 
 
-  function getItemIndex(manifest, itemUrl: string): number {
+  function getItemIndex(manifest: ManifestNode, itemUrl: string): number {
     return manifest.children.findIndex((item: ItemNode) => item.url === itemUrl)
   }

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -84,7 +84,7 @@ export function getItemIndices(itemUrl: string, treeNodes: CollectionNode[]): It
         if (!manifest.children || manifest.children.length === 0) continue
 
         const itemIndex = getItemIndex(manifest, itemUrl)
-        if (itemIndex !== null) {
+        if (itemIndex !== -1) {
             return {
                 collectionUrl: collectionNode.url,
                 manifestIndex: j,

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -4,7 +4,7 @@ import { request } from '@/utils/http'
 export async function createTree(panels: PanelConfig[]) {
     if (!panels || panels.length === 0) return [] 
 
-    const nodes = []
+    const nodes: CollectionNode[] = []
     
     for (let i = 0; i< panels.length; i++) {
         const collectionNode = await createCollectionNode(panels[i].entrypoint.url, i).then((node) => {
@@ -18,7 +18,7 @@ export async function createTree(panels: PanelConfig[]) {
 
 
 async function createCollectionNode(url: string, key: number) {
-  const node = {}
+  const node: CollectionNode = {}
   const response = await request<Collection>(url)
   if (!response.success) return node
   const collectionTitle = response.data.title[0].title
@@ -40,7 +40,7 @@ async function getManifestNodes(parentNode, manifests) {
 
     for (let i = 0; i < manifests.length; i++) {
       // here node refers to manifestNode
-      const node = {}
+      const node: ManifestNode = {}
       node['key'] = collectionNode.key + '-' + i.toString()
       node['label'] = manifests[i].label 
       

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -63,3 +63,33 @@ function getItemsNodes(parentKey: string, items: Sequence[]) {
     }
     return nodes
 }
+
+
+export function getCollectionUrl(itemUrl: string, treeNodes): string | null {
+    // find the collection url when clicking an item in local tree
+    
+    for (let i = 0; i < treeNodes.length ; i++) {
+      const collectionNode = treeNodes[i]
+
+      for (let j = 0; j < collectionNode.children.length; j++) {
+
+        const manifest = collectionNode.children[j]
+
+        if (isItemInManifest(manifest, itemUrl)) {
+          return collectionNode.url
+        }
+      }
+    }
+
+    return null
+  }
+
+
+  function isItemInManifest(manifest, itemUrl: string) {
+    const items = manifest.children
+    for (let i = 0; i < items.length ; i++) {
+      if (items[i].url === itemUrl) return true
+    }
+
+    return false
+  }

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -1,0 +1,65 @@
+
+import { request } from '@/utils/http'
+
+export async function createTree(panels: PanelConfig[]) {
+    if (!panels || panels.length === 0) return [] 
+
+    const nodes = []
+    
+    for (let i = 0; i< panels.length; i++) {
+        const collectionNode = await createCollectionNode(panels[i].entrypoint.url, i).then((node) => {
+            nodes.push(node)
+        })
+    }
+
+    return nodes
+}
+
+
+
+async function createCollectionNode(url: string, key: number) {
+  const node = {}
+  const response = await request<Collection>(url)
+  if (!response.success) return node
+  const collectionTitle = response.data.title[0].title
+
+  node['url'] = url
+  node['key'] = key
+  node['title'] = collectionTitle
+  node['children'] = await getManifestNodes(node, response.data.sequence)
+
+  return node
+}
+
+async function getManifestNodes(parentNode, manifests) {
+    // items: 'sequence items' of collection 
+    if (!manifests || manifests.length === 0) return []
+
+    const collectionNode = { ...parentNode }
+    collectionNode['children'] = []
+
+    for (let i = 0; i < manifests.length; i++) {
+      // here node refers to manifestNode
+      const node = {}
+      node['key'] = collectionNode.key + '-' + i.toString()
+      node['label'] = manifests[i].label 
+      
+      // getItemsTitles
+      const response = await request<Manifest>(manifests[i].id)
+      if (!response.success) continue
+
+      const data = response.data
+      node['children'] = getItemsNodes(node['key'], data.sequence)
+      
+      collectionNode['children'].push(node)
+    }
+    return collectionNode['children']
+  }
+
+function getItemsNodes(parentKey: string, items: Sequence[]) {
+    const nodes = []
+    for (let i = 0; i < items.length ; i++) {
+        nodes.push({ label: items[i].label, key: parentKey + '-' + i, url: items[i].id })
+    }
+    return nodes
+}


### PR DESCRIPTION
This PR aims to accomplish the following goals:

- Open a new modal when clicking `Add` Button 
- Create the Tree View of the currently opened panels and show it in the Modal
- Add a new panel dynamically when either entering a collection url or clicking at a tree item
- Showing an error message when the user has not provided a way to open a new collection dynamically
