### PR TITLE
Show the annotation icons in Text and Annotation Panels based on the User Config

### DIFF
--- a/src/components/annotations/AnnotationsList.vue
+++ b/src/components/annotations/AnnotationsList.vue
@@ -17,7 +17,7 @@
         @click="isText(annotation) ? ()=>{} : toggle(annotation)"
       >
         <AnnotationIcon
-          v-if="!isText(annotation)"
+          v-if="!isText(annotation) && showAnnotationUtils"
           :name="getIconName(annotation.body['x-content-type'])"
         />
         <span
@@ -34,6 +34,7 @@
 import { computed } from 'vue';
 import AnnotationIcon from '@/components/annotations/AnnotationIcon.vue';
 import {useAnnotationsStore} from "@/stores/annotations";
+import {useConfigStore} from "@/stores/config";
 
 interface AnnotationTypesMapping {
   [key: string]: string | 'annotation'
@@ -45,6 +46,7 @@ export interface Props {
 }
 
 const annotationStore = useAnnotationsStore();
+const configStore = useConfigStore()
 
 const props = withDefaults(defineProps<Props>(), {
   annotations: () => <Annotation[]> [],
@@ -52,6 +54,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const activeAnnotations = computed<ActiveAnnotation>(() => annotationStore.activeAnnotations);
 const filteredAnnotations = computed<Annotation[]>(() => annotationStore.filteredAnnotations);
+const showAnnotationUtils = computed<boolean>(() => configStore.config.showAnnotationIcons);
 
 const annotationTypesMapping = computed<AnnotationTypesMapping>(() => (
   // it returns an object with a varying number of 'key', 'value' pairs

--- a/src/stores/annotations.ts
+++ b/src/stores/annotations.ts
@@ -1,11 +1,12 @@
 import {defineStore} from 'pinia'
 import { ref, reactive } from 'vue';
 
+import {useConfigStore} from '@/stores/config';
+
 import * as AnnotationUtils from '@/utils/annotations';
 import {request} from '@/utils/http';
 import * as Utils from '@/utils';
 import {scrollIntoViewIfNeeded} from '@/utils';
-import {useConfigStore} from '@/stores/config';
 import TextEventBus from '@/utils/TextEventBus';
 
 import { getItemColorBasedOnIndex } from '@/utils/color';
@@ -99,8 +100,9 @@ export const useAnnotationsStore = defineStore('annotations', () => {
 
   const addSimpleAnnotation = (targetElement: HTMLElement, annotation: Annotation) => {
     const configStore = useConfigStore()
+
     const iconName: string = configStore.getIconByType(annotation.body['x-content-type']);
-    Utils.addIcon(targetElement, annotation, iconName);
+    if (configStore.config.showAnnotationIcons) Utils.addIcon(targetElement, annotation, iconName);
   }
 
   const addVariantAnnotation = (targetElement: HTMLElement, annotation: Annotation) => {
@@ -272,7 +274,8 @@ export const useAnnotationsStore = defineStore('annotations', () => {
   };
 
   const removeSimpleAnnotation = (annotation: Annotation) => {
-    AnnotationUtils.removeIcon(annotation);
+    const configStore = useConfigStore()
+    if (configStore.config.showAnnotationIcons) AnnotationUtils.removeIcon(annotation);
   }
 
   const removeVariantAnnotation = (selector: string, annotation: Annotation) => {
@@ -282,12 +285,13 @@ export const useAnnotationsStore = defineStore('annotations', () => {
   }
 
   const resetAnnotations = () => {
+    const configStore = useConfigStore()
     if (annotations.value !== null) {
       annotations.value.forEach((annotation) => {
         const selector = AnnotationUtils.generateTargetSelector(annotation);
         if (selector) {
           AnnotationUtils.highlightTargets(selector, {level: -1});
-          AnnotationUtils.removeIcon(annotation);
+          if (configStore.config.showAnnotationIcons) AnnotationUtils.removeIcon(annotation);
           if (AnnotationUtils.isVariant(annotation)) {
             annotation.body.value.witnesses.forEach(witness => {
               AnnotationUtils.removeWitness(selector, witness);

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -15,6 +15,7 @@ import { i18n } from '@/i18n';
         collection: '',
         manifest: '',
         item: '',
+        showAnnotationIcons: false,
         panels: [
           {
             label: 'contents',
@@ -254,6 +255,11 @@ import { i18n } from '@/i18n';
       return !!(value);
     }
 
+    function validateAnnotationIcons(value: boolean) {
+        if (typeof value === 'boolean') return value
+        return false;
+    }
+
     function validateHeader(value, defaultValue) {
       if (!value) return false;
 
@@ -384,11 +390,12 @@ import { i18n } from '@/i18n';
 
     function discoverCustomConfig(customConfig, defaultConfig)  {
         const {
-          container, translations, collection, manifest, item, panels, lang, colors, header, labels
+          container, translations, collection, manifest, item, panels, lang, colors, header, labels, showAnnotationIcons
         } = customConfig;
 
         return {
           ...(validateContainer(container) && { container }),
+          ...(validateAnnotationIcons(showAnnotationIcons) && { showAnnotationIcons }),
           ...(validateCollection(collection) && { collection }),
           ...(validateManifest(manifest) && { manifest }),
           ...(validateItem(item) && { item }),


### PR DESCRIPTION
The user should provide a boolean value to `showAnnotationIcons` in the config. 
When no value is given for this attribute no annotation icons are shown.

Closes #560 