### PR TITLE
feat: add sync panel scrolling feature - example TextAPI data, target…

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,15 +45,31 @@
           panels: [
             {
               entrypoint: {
-                url: "https://api.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/syriac/collection.json",
+                url: "http://localhost:8181/example/textapi/collection.json",
                 type: "collection",
               },
+              manifestIndex: 0,
             },
             {
               entrypoint: {
-                url: "https://api.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/collection.json",
+                url: "http://localhost:8181/example/textapi/collection.json",
                 type: "collection",
               },
+              manifestIndex: 1,
+            },
+            {
+              entrypoint: {
+                url: "http://localhost:8181/example/textapi/collection.json",
+                type: "collection",
+              },
+              manifestIndex: 2,
+            },
+            {
+              entrypoint: {
+                url: "http://localhost:8181/example/textapi/collection.json",
+                type: "collection",
+              },
+              manifestIndex: 3,
             },
           ],
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,10 @@
       "name": "tido",
       "version": "4.3.0",
       "license": "AGPL-3.0-or-later",
-      "dependencies": {
+      "devDependencies": {
         "@eslint/js": "^9.16.0",
         "@radix-ui/react-popover": "^1.1.4",
-        "@radix-ui/react-slot": "^1.1.1"
-      },
-      "devDependencies": {
+        "@radix-ui/react-slot": "^1.1.1",
         "@types/openseadragon": "^3.0.10",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -877,6 +875,7 @@
       "version": "9.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
       "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -906,6 +905,7 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
       "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.8"
       }
@@ -914,6 +914,7 @@
       "version": "1.6.12",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
       "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "dev": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
         "@floating-ui/utils": "^0.2.8"
@@ -923,6 +924,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
       "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dev": true,
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -934,7 +936,8 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "dev": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -1213,12 +1216,14 @@
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
-      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "dev": true
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
       "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
       },
@@ -1241,6 +1246,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
       "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1255,6 +1261,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
       "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1269,6 +1276,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz",
       "integrity": "sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
@@ -1295,6 +1303,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
       "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1309,6 +1318,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
       "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-primitive": "2.0.1",
@@ -1333,6 +1343,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
       "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
@@ -1350,6 +1361,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.4.tgz",
       "integrity": "sha512-aUACAkXx8LaFymDma+HQVji7WhvEhpFJ7+qPz17Nf4lLZqtreGOFRiNQWQmhzp7kEWg9cOyyQJpdIMUMPc/CPw==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
@@ -1386,6 +1398,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
       "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "dev": true,
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@radix-ui/react-arrow": "1.1.1",
@@ -1417,6 +1430,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
       "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-use-layout-effect": "1.1.0"
@@ -1440,6 +1454,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
       "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-use-layout-effect": "1.1.0"
@@ -1463,6 +1478,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
       "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-slot": "1.1.1"
       },
@@ -1485,6 +1501,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
       "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1"
       },
@@ -1502,6 +1519,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
       "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1516,6 +1534,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
       "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.0"
       },
@@ -1533,6 +1552,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
       "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.0"
       },
@@ -1550,6 +1570,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
       "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1564,6 +1585,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
       "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/rect": "1.1.0"
       },
@@ -1581,6 +1603,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
       "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dev": true,
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.0"
       },
@@ -1597,7 +1620,8 @@
     "node_modules/@radix-ui/rect": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
-      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
+      "dev": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.28.1",
@@ -1952,13 +1976,13 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1968,7 +1992,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2390,6 +2414,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
       "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -3529,7 +3554,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cypress": {
       "version": "13.17.0",
@@ -3809,7 +3834,8 @@
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "dev": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -4952,6 +4978,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6157,7 +6184,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6527,6 +6555,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7830,6 +7859,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7841,6 +7871,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7868,6 +7899,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
       "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "dev": true,
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
         "react-style-singleton": "^2.2.1",
@@ -7892,6 +7924,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
       "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dev": true,
       "dependencies": {
         "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
@@ -7913,6 +7946,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
       "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dev": true,
       "dependencies": {
         "get-nonce": "^1.0.0",
         "tslib": "^2.0.0"
@@ -8396,6 +8430,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -9327,7 +9362,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -9604,6 +9640,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -9624,6 +9661,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dev": true,
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   },
   "private": false,
   "devDependencies": {
+    "@eslint/js": "^9.16.0",
+    "@radix-ui/react-popover": "^1.1.4",
+    "@radix-ui/react-slot": "^1.1.1",
     "@types/openseadragon": "^3.0.10",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -91,10 +94,5 @@
   },
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "@eslint/js": "^9.16.0",
-    "@radix-ui/react-popover": "^1.1.4",
-    "@radix-ui/react-slot": "^1.1.1"
-  }
+  ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App: FC<AppProps> = ({ customConfig }) => {
   return (
     <div className="tido t-flex t-flex-col">
       <TopBar/>
-      <div className="t-flex">
+      <div className="t-flex t-overflow-hidden">
         <GlobalTree/>
         <PanelsWrapper/>
       </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -6,11 +6,10 @@ interface ModalProps {
     children: ReactNode,
     TriggerButton?: ReactNode,
     showPopover?: boolean,
-    position?: Position
 }
 
 const Modal: FC<ModalProps> = ({
-  children, TriggerButton, showPopover, position
+  children, TriggerButton, showPopover
 }) => {
 
   const [isOpen, setIsOpen] = useState(false)
@@ -21,22 +20,16 @@ const Modal: FC<ModalProps> = ({
 
   useEffect(() => {
     if (showPopover) setIsOpen(true)
-  }, [position])
+  }, [showPopover])
 
-  return <div className="local-tree-modal">
-    <Popover open={isOpen} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        {TriggerButton}
-      </PopoverTrigger>
-      <PopoverContent
-        style={{
-          top: `${position?.y + 40}px`,
-          left: `${position?.x}px`,
-        }}>
-        {children}
-      </PopoverContent>
-    </Popover>
-  </div>
+  return <Popover open={isOpen} onOpenChange={handleOpenChange}>
+    <PopoverTrigger asChild>
+      {TriggerButton}
+    </PopoverTrigger>
+    <PopoverContent>
+      {children}
+    </PopoverContent>
+  </Popover>
 }
 
 export default Modal

--- a/src/components/OpenSeaDragonViewer.tsx
+++ b/src/components/OpenSeaDragonViewer.tsx
@@ -3,14 +3,14 @@ import OpenSeadragon from 'openseadragon'
 
 import { usePanel } from '@/contexts/PanelContext'
 
-import { contentStore } from '@/store/ContentStore'
+import { panelStore } from '@/store/PanelStore.tsx'
 
 import ImageActionButtons from '@/components/ImageActionButtons'
 
 const OpenSeaDragonViewer: FC = () => {
   const { panelId } = usePanel()
 
-  const imageUrl = contentStore((state) => state.panels[panelId].item.image?.id)
+  const imageUrl = panelStore((state) => state.panels[panelId].item.image?.id)
 
   const viewerRef = useRef<OpenSeadragon.Viewer>()
   const viewerId = 'viewer-' + panelId

--- a/src/components/PanelsWrapper.tsx
+++ b/src/components/PanelsWrapper.tsx
@@ -6,9 +6,9 @@ import { configStore } from '@/store/ConfigStore.tsx'
 const PanelsWrapper: FC = () => {
   const config = configStore(state => state.config)
   const panels = config?.panels
-  return <div className="t-flex t-h-full t-ml-4 t-flex-row"> {
-    panels?.map((panelConfig, i: number) => (<Panel config={panelConfig} key={i}/>))
-  }</div>
+  return <div className="t-flex t-h-full t-flex-row t-py-4 t-space-x-4 t-overflow-x-auto">
+    { panels?.map((panelConfig, i: number) => (<Panel config={panelConfig} key={i}/>)) }
+  </div>
 }
 
 export default PanelsWrapper

--- a/src/components/SelectParallelPanels.tsx
+++ b/src/components/SelectParallelPanels.tsx
@@ -39,8 +39,9 @@ const SelectParallelPanels: FC = () => {
   }
 
   function unsync() {
-    setSelected({})
-    update(Object.keys(selected))
+    const newSelected = {}
+    setSelected(newSelected)
+    update(Object.keys(newSelected))
   }
 
   return <>
@@ -51,7 +52,7 @@ const SelectParallelPanels: FC = () => {
     </div>
 
     <Button onClick={confirm}>Confirm</Button>
-    <Button onClick={unsync}>Unsync</Button>
+    <Button onClick={unsync} className="t-ml-2">Unsync</Button>
   </>
 
 }

--- a/src/components/SelectParallelPanels.tsx
+++ b/src/components/SelectParallelPanels.tsx
@@ -1,0 +1,58 @@
+import { FC, useState } from 'react'
+import { Button } from '@/components/ui/button.tsx'
+import { panelStore } from '@/store/PanelStore.tsx'
+import { scrollStore } from '@/store/ScrollStore.tsx'
+
+const SelectParallelPanels: FC = () => {
+  const panelStates = panelStore(state => state.panels)
+  const update = scrollStore(state => state.update)
+  const scrollPanelIds = scrollStore(state => state.panelIds)
+
+  const [selected, setSelected] = useState<{ [key: string]: boolean }>(scrollPanelIds.reduce((acc, cur) => {
+    acc[cur] = true
+    return acc
+  }, {} as { [key: string]: boolean }))
+
+  function select(panelId: string) {
+    setSelected({
+      ...selected,
+      [panelId]: true
+    })
+  }
+
+  function unselect(panelId: string) {
+    const value = { ...selected }
+    delete value[panelId]
+    setSelected(value)
+  }
+
+  function toggle(panelId: string) {
+    if (selected[panelId]) {
+      unselect(panelId)
+    } else {
+      select(panelId)
+    }
+  }
+
+  async function confirm() {
+    update(Object.keys(selected))
+  }
+
+  function unsync() {
+    setSelected({})
+    update(Object.keys(selected))
+  }
+
+  return <>
+    <div className="t-flex t-space-x-2 t-mb-2">
+      { Object.keys(panelStates).map((panelId, i) =>
+        <Button key={panelId} variant={selected[panelId] ? 'secondarySelected' : 'secondary'} onClick={() => toggle(panelId)}>Panel {i}</Button>)
+      }
+    </div>
+
+    <Button onClick={confirm}>Confirm</Button>
+    <Button onClick={unsync}>Unsync</Button>
+  </>
+
+}
+export default SelectParallelPanels

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -3,12 +3,14 @@ import { FC, useState } from 'react'
 import { configStore } from '@/store/ConfigStore.tsx'
 
 import Modal from '@/components/Modal.tsx'
-import TreeSelectionModalContent from '@/components/tree-modal/TreeSelectionModalContent.tsx'
+import TreeSelectionModalContent from '@/components/tree/tree-modal/TreeSelectionModalContent.tsx'
 import IconRenderer from '@/components/base/IconRenderer.tsx'
 
 import { tree } from '@/utils/icons'
 import { cross } from '@/utils/icons'
 import { dataStore } from '@/store/DataStore.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import SelectParallelPanels from '@/components/SelectParallelPanels.tsx'
 
 
 const TopBar: FC = () => {
@@ -29,22 +31,18 @@ const TopBar: FC = () => {
     }
   }
 
-  const addButton =
-    <span
-      className="t-bg-blue-500 t-text-white t-rounded t-flex t-pl-4 t-items-center t-justify-items-center t-w-16 t-h-10">
-        New
-    </span>
-
-
-  return <div className="t-flex t-flex-row t-ml-[6%] t-mt-10">
-    <button className={`t-mr-2 toggle-global-tree ${!globalTree ? 't-hidden' : ''}`} onClick={() => toggleIcon()}>
+  return <div className="t-flex t-flex-row t-ml-6 t-mt-10 t-space-x-2">
+    <button className={`toggle-global-tree ${!globalTree ? 't-hidden' : ''}`} onClick={() => toggleIcon()}>
       <IconRenderer
         htmlString={iconHtmlString}
         width={8}
-        height={8}/>
+        height={8} />
     </button>
-    <Modal TriggerButton={addButton}>
+    <Modal TriggerButton={<Button>New</Button>}>
       <TreeSelectionModalContent/>
+    </Modal>
+    <Modal TriggerButton={<Button>Sync Panels</Button>}>
+      <SelectParallelPanels />
     </Modal>
   </div>
 }

--- a/src/components/panel/ContentTypesToggle.tsx
+++ b/src/components/panel/ContentTypesToggle.tsx
@@ -1,18 +1,18 @@
 import { FC, MouseEvent } from 'react'
 
-import { contentStore } from '@/store/ContentStore'
+import { panelStore } from '@/store/PanelStore.tsx'
 import { usePanel } from '@/contexts/PanelContext'
 
 const ContentTypesToggle: FC = () => {
   const { panelId } = usePanel()
 
-  const contentTypes = contentStore(
+  const contentTypes = panelStore(
     (state) => state.panels[panelId].contentTypes
   )
-  const activeContentTypeIndex = contentStore(
+  const activeContentTypeIndex = panelStore(
     (state) => state.panels[panelId].contentIndex
   )
-  const updateContentToggleIndex = contentStore(
+  const updateContentToggleIndex = panelStore(
     (state) => state.updateContentToggleIndex
   )
 

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -8,8 +8,10 @@ import ErrorComponent from '@/components/ErrorComponent'
 import { PanelProvider } from '@/contexts/PanelContext.tsx'
 import { dataStore } from '@/store/DataStore.tsx'
 import { apiRequest } from '@/utils/api.ts'
-import { contentStore } from '@/store/ContentStore.tsx'
+import { panelStore } from '@/store/PanelStore.tsx'
 import { getContentTypes } from '@/utils/panel.ts'
+import { scrollStore } from '@/store/ScrollStore.tsx'
+import ScrollPanelMenu from '@/components/panel/ScrollPanelMenu.tsx'
 
 interface Props {
   config: PanelConfig
@@ -17,12 +19,13 @@ interface Props {
 
 const Panel: FC<Props> = ({ config }) => {
   const getCollection = dataStore(state => state.getCollection)
-  const addPanelContent = contentStore((state) => state.addPanelContent)
+  const addPanelContent = panelStore((state) => state.addPanelContent)
+  const scrollPanelIds = scrollStore(state => state.panelIds)
 
   const [error, setError] = useState<boolean | string>(false)
   const [loading, setLoading] = useState(false)
   const [panelId, setPanelId] = useState<string | undefined>(undefined)
-
+  const [isScrollPanel, setIsScrollPanel] = useState(false)
   useEffect(() => {
     const panelId = crypto.randomUUID()
     const collectionUrl = config.entrypoint.url
@@ -35,11 +38,15 @@ const Panel: FC<Props> = ({ config }) => {
         const item = await apiRequest<Item>(manifest.sequence[config.itemIndex ?? 0].id)
         const contentTypes: string[] = getContentTypes(item.content)
 
-        addPanelContent(panelId, {
+        addPanelContent({
+          id: panelId,
+          collectionId: collection.id,
+          manifest,
           item,
           contentIndex: 0,
           viewIndex: 0,
           contentTypes,
+          activeTargetIndex: -1
         })
         setPanelId(panelId)
       } catch (e) {
@@ -52,17 +59,26 @@ const Panel: FC<Props> = ({ config }) => {
     init()
   }, [config])
 
+  useEffect(() => {
+    setIsScrollPanel(panelId ? scrollPanelIds.includes(panelId) : false)
+  }, [scrollPanelIds, panelId])
+
   if (error) {
-    return <ErrorComponent message={error}/>
+    return <ErrorComponent message={error} />
   }
 
   return (
     <div
-      className="panel t-flex t-flex-col t-w-[600px] t-mr-6 t-border-solid t-border-2 t-border-slate-200 t-rounded-lg t-mt-4 t-px-2.5 t-pt-8 t-pb-6">
-      {loading && <div> Loading data ... Please wait a sec</div>}
-      {!loading && error && <ErrorComponent message={error}/>}
-      {!loading && !error && panelId &&
+      className={
+        `panel t-relative t-flex t-flex-col t-w-[600px] t-border-solid t-border-2 t-rounded-lg t-px-2.5 t-pt-8 t-pb-6
+        ${isScrollPanel ? 't-border-amber-300 t-ring-4 t-ring-amber-50' : 't-border-slate-200' }
+      `}
+    >
+      { loading && <div> Loading data ... Please wait a sec</div> }
+      { !loading && error && <ErrorComponent message={error} /> }
+      { !loading && !error && panelId &&
         <PanelProvider id={panelId}>
+          {isScrollPanel && <ScrollPanelMenu className="t-absolute t-top-0 t-left-1/2 -t-translate-x-1/2" /> }
           <PanelTopBar/>
           <div className="t-flex t-flex-col t-items-center t-mb-6">
             <ContentTypesToggle/>

--- a/src/components/panel/ScrollPanelMenu.tsx
+++ b/src/components/panel/ScrollPanelMenu.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react'
+import { Button } from '@/components/ui/button.tsx'
+import { panelStore } from '@/store/PanelStore.tsx'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+interface Props {
+  className: string
+}
+const PanelTopBar: FC<Props> = ({ className }) => {
+  const { panelId } = usePanel()
+  const setActiveTargetIndex = panelStore(state => state.setActiveTargetIndex)
+  const activeTargetIndex = panelStore(state => state.panels[panelId].activeTargetIndex)
+
+  function onDown() {
+    setActiveTargetIndex(panelId, activeTargetIndex + 1)
+  }
+
+  function onUp() {
+    setActiveTargetIndex(panelId, activeTargetIndex - 1)
+  }
+  return (
+    <div className={`t-flex t-bg-amber-200 t-rounded-b-md ${className}`}>
+      <Button size="icon" variant="ghostAmber" onClick={onDown}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
+          <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5"
+            d="M12 4v16m0 0l6-6m-6 6l-6-6"/>
+        </svg>
+      </Button>
+      <Button size="icon" variant="ghostAmber" onClick={onUp}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
+          <path fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5"
+            d="M12 20V4m0 0l6 6m-6-6l-6 6"/>
+        </svg>
+      </Button>
+    </div>
+  )
+}
+
+export default PanelTopBar

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -1,0 +1,25 @@
+import { FC, useEffect, useRef } from 'react'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+
+interface Props {
+  htmlString: string
+}
+
+const TextRenderer: FC<Props> = ({ htmlString }) => {
+  const ref = useRef<HTMLInputElement>(null)
+  const { panelId } = usePanel()
+
+  useEffect(() => {
+    if (!ref?.current) return
+
+    const scrollContainer = ref.current as HTMLElement
+    const parent = scrollContainer.parentElement
+    if (!parent) return
+
+    scrollContainer.innerHTML = htmlString
+  }, [htmlString])
+
+  return <div data-panel={panelId} ref={ref} className="t-h-full t-overflow-auto" />
+}
+
+export default TextRenderer

--- a/src/components/panel/TextViewsToggle.tsx
+++ b/src/components/panel/TextViewsToggle.tsx
@@ -2,7 +2,7 @@ import { FC, MouseEvent } from 'react'
 import { textViewOne, textView, splitView, imageView } from '@/utils/icons'
 import CustomHTML from '@/components/CustomHTML'
 
-import { contentStore } from '@/store/ContentStore'
+import { panelStore } from '@/store/PanelStore.tsx'
 import { usePanel } from '@/contexts/PanelContext'
 
 interface IconKeys {
@@ -14,9 +14,8 @@ interface IconKeys {
 
 const TextViewsToggle: FC = () => {
   const { panelId } = usePanel()
-
-  const viewIndex = contentStore((state) => state.panels[panelId].viewIndex)
-  const updateViewIndex = contentStore((state) => state.updateViewIndex)
+  const viewIndex = panelStore((state) => state.panels[panelId].viewIndex)
+  const updateViewIndex = panelStore((state) => state.updateViewIndex)
 
   function handleTextViewClick(
     e: MouseEvent<HTMLButtonElement>,
@@ -35,7 +34,7 @@ const TextViewsToggle: FC = () => {
 
   const buttons = Object.keys(textViewsIcons).map((title, i) => (
     <button
-      className="t-px-1 t-py-1 t-w-7 t-h-7  t-rounded t-mr-3"
+      className="t-px-1 t-py-1 t-w-7 t-h-7 t-rounded t-mr-3"
       key={i}
       onClick={(e) => handleTextViewClick(e, i)}
       style={{
@@ -50,7 +49,7 @@ const TextViewsToggle: FC = () => {
   ))
 
   return (
-    <div className="text-views-toggle t-flex t-row t-ml-[40%] t-p-1 t-rounded-md t-h-8">
+    <div className="text-views-toggle t-flex t-row t-ml-auto t-p-1 t-rounded-md t-h-8">
       {buttons}
     </div>
   )

--- a/src/components/panel/views/PanelCentralContent.tsx
+++ b/src/components/panel/views/PanelCentralContent.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 
-import { contentStore } from '@/store/ContentStore'
+import { panelStore } from '@/store/PanelStore.tsx'
 import { usePanel } from '@/contexts/PanelContext'
 
 import TextViewOne from '@/components/panel/views/TextViewOne'
@@ -15,12 +15,12 @@ import { request } from '@/utils/http'
 const PanelCentralContent: FC = () => {
   const { panelId } = usePanel()
 
-  const viewIndex = contentStore((state) => state.panels[panelId].viewIndex)
-  const activeContentTypeIndex = contentStore(
+  const viewIndex = panelStore((state) => state.panels[panelId].viewIndex)
+  const activeContentTypeIndex = panelStore(
     (state) => state.panels[panelId].contentIndex
   )
   const [text, setText] = useState<string>('')
-  const content = contentStore((state) => state.panels[panelId].item.content)
+  const content = panelStore((state) => state.panels[panelId].item.content)
 
   const [error, setError] = useState<boolean | string>(false)
 

--- a/src/components/panel/views/TextView.tsx
+++ b/src/components/panel/views/TextView.tsx
@@ -1,17 +1,16 @@
 import { FC } from 'react'
-
-import CustomHTML from '@/components/CustomHTML'
+import TextRenderer from '@/components/panel/TextRenderer.tsx'
 
 interface TextViewOneProps {
   textHtml: string
 }
 
-const TextViewOne: FC<TextViewOneProps> = ({ textHtml }) => {
+const TextView: FC<TextViewOneProps> = ({ textHtml }) => {
   return (
     <div>
-      <CustomHTML textHtml={textHtml} width="100%" />
+      <TextRenderer htmlString={textHtml} />
     </div>
   )
 }
 
-export default TextViewOne
+export default TextView

--- a/src/components/panel/views/TextViewOne.tsx
+++ b/src/components/panel/views/TextViewOne.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
-
-import CustomHTML from '@/components/CustomHTML'
+import TextRenderer from '@/components/panel/TextRenderer.tsx'
 
 interface TextViewOneProps {
   textHtml: string
@@ -8,8 +7,8 @@ interface TextViewOneProps {
 
 const TextViewOne: FC<TextViewOneProps> = ({ textHtml }) => {
   return (
-    <div>
-      <CustomHTML textHtml={textHtml} width="100" />
+    <div className="t-flex-1 t-overflow-hidden">
+      <TextRenderer htmlString={textHtml} />
     </div>
   )
 }

--- a/src/components/tree/GlobalTree.tsx
+++ b/src/components/tree/GlobalTree.tsx
@@ -1,17 +1,12 @@
 import { FC, useRef, useState } from 'react'
-
 import { dataStore } from '@/store/DataStore.tsx'
-
-import Tree from '@/components/Tree.tsx'
-import Modal from '@/components/Modal.tsx'
-import GlobalTreeSelectionModalContent from '@/components/tree-modal/GlobalTreeSelectionModalContent.tsx'
-
+import Tree from '@/components/tree/Tree.tsx'
+import GlobalTreeSelectionModalContent from '@/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx'
 import { getChildren, getNodeIndices } from '@/utils/tree.ts'
 
 const GlobalTree: FC = () => {
 
   const showGlobalTree = dataStore(state => state.showGlobalTree)
-
   const selectedItemIndices = useRef({
     collectionUrl: '',
     manifestIndex: -1,
@@ -19,27 +14,30 @@ const GlobalTree: FC = () => {
   })
 
   const treeNodes = dataStore(state => state.treeNodes)
-
   const [showSelectionModal, setShowSelectionModal] = useState(false)
-  const [positionSelectedItem, setPositionSelectedItem] = useState({ x: 0, y: 0 })
+  const [selectedPosition, setSelectedPosition] = useState({ x: 0, y: 0 })
 
-
-  function onSelectNode(node: TreeNode, target) {
+  function onSelectNode(node: TreeNode, target: HTMLElement) {
     const [collectionIndex, manifestIndex, itemIndex] = getNodeIndices(node.key)
     const collectionUrl = treeNodes[collectionIndex].id
     selectedItemIndices.current = { collectionUrl: collectionUrl, manifestIndex: manifestIndex, itemIndex: itemIndex }
 
     // when we click at another item, show the modal
     setShowSelectionModal(true)
-    setPositionSelectedItem(target.getBoundingClientRect())
+    setSelectedPosition(target.getBoundingClientRect())
   }
 
-
-  return showGlobalTree && <div className="t-ml-10 t-w-92 t-mt-4 t-pt-4 t-border-r-2 t-border-gray-200">
+  return showGlobalTree && <div className="t-ml-10 t-w-92 t-mt-4 t-mr-4 t-pt-4 t-border-r-2 t-border-gray-200">
     <Tree nodes={treeNodes} onSelect={onSelectNode} getChildren={getChildren}/>
-    <Modal showPopover={showSelectionModal} position={positionSelectedItem}>
-      <GlobalTreeSelectionModalContent selectedItemIndices={selectedItemIndices.current}/>
-    </Modal>
+    { showSelectionModal && <div
+      className="t-fixed t-z-50 t-p-2 t-bg-white t-border t-border-gray-200 t-shadow-md t-rounded"
+      style={{
+        top: `${selectedPosition?.y + 40}px`,
+        left: `${selectedPosition?.x}px`,
+      }}
+    >
+      <GlobalTreeSelectionModalContent selectedItemIndices={selectedItemIndices.current} onSelect={() => setShowSelectionModal(false)} />
+    </div> }
   </div>
 }
 

--- a/src/components/tree/Tree.tsx
+++ b/src/components/tree/Tree.tsx
@@ -7,23 +7,18 @@ import TreeNode from '@/components/tree/TreeNode'
 
 interface TreeProps {
   nodes: TreeNode[],
-
-  onSelect(node: TreeNode, target): void,
-
+  onSelect(node: TreeNode, target: HTMLElement): void,
   getChildren(node: TreeNode): Promise<TreeNode[]>
 }
 
 const Tree: FC<TreeProps> = ({ nodes, onSelect, getChildren }) => {
-
-
   const tree =
-      nodes?.length > 0 &&
-      nodes.map((collection, i) => (
-        <div key={i}>
-          <TreeNode node={collection}/>
-        </div>
-      ))
-
+    nodes?.length > 0 &&
+    nodes.map((collection, i) => (
+      <div key={i}>
+        <TreeNode node={collection}/>
+      </div>
+    ))
 
   return <div className="tree t-w-96 t-h-96 t-overflow-hidden t-overflow-y-auto">
     <TreeProvider onSelect={onSelect} getChildren={getChildren}>

--- a/src/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx
+++ b/src/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx
@@ -3,16 +3,17 @@ import { configStore } from '@/store/ConfigStore.tsx'
 
 
 interface SelectedItemIndicesType {
-  collectionUrl: string,
-  manifestIndex: number,
-  itemIndex: number,
+  collectionUrl: string
+  manifestIndex: number
+  itemIndex: number
 }
 
 interface GlobalTreeSelectionModalContentProps {
-  selectedItemIndices: SelectedItemIndicesType,
+  selectedItemIndices: SelectedItemIndicesType
+  onSelect: () => void
 }
 
-const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> = ({ selectedItemIndices }) => {
+const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> = ({ selectedItemIndices, onSelect }) => {
 
   const panels = configStore(state => state.config.panels)
   const addNewPanel = configStore(state => state.addNewPanel)
@@ -27,27 +28,28 @@ const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> 
     itemIndex: selectedItemIndices.itemIndex
   }
 
+  function select(i?: number) {
+    if (i !== undefined) updatePanel(newPanelConfig, i)
+    else addNewPanel(newPanelConfig)
+    onSelect()
+  }
+
   let buttonsUpdatePanel
   if (panels && panels?.length > 0) {
     buttonsUpdatePanel = panels?.map((_, i) => <button
       className="t-bg-slate-200 t-w-20 t-h-8 t-mr-1 t-rounded-md hover:t-bg-slate-300" key={i}
-      onClick={() => updatePanel(
-        newPanelConfig
-        , i)}>Panel {i + 1}</button>)
+      onClick={() => select(i)}>Panel {i + 1}</button>)
   }
 
-
-  return (
-    <div
-      className="t-flex t-items-center t-h-12 t-border-1 t-border-gray-300 t-px-4 t-py-2 t-shadow-md t-rounded-md ">
-      <div className="buttons-update-panel t-flex">
-        {buttonsUpdatePanel}
-      </div>
-      <button className="button-new-panel t-bg-slate-200 t-w-24 t-h-8 t-mr-1 t-rounded-md hover:t-bg-slate-300"
-        onClick={() => addNewPanel(newPanelConfig)}> New
-          Panel
-      </button>
-    </div>)
+  return <div className="t-flex t-items-center t-h-12">
+    <div className="buttons-update-panel t-flex">
+      {buttonsUpdatePanel}
+    </div>
+    <button
+      className="button-new-panel t-bg-slate-200 t-w-24 t-h-8 t-mr-1 t-rounded-md hover:t-bg-slate-300"
+      onClick={() => select()}
+    >New Panel</button>
+  </div>
 }
 
 export default GlobalTreeSelectionModalContent

--- a/src/components/tree/tree-modal/TreeSelectionModalContent.tsx
+++ b/src/components/tree/tree-modal/TreeSelectionModalContent.tsx
@@ -4,7 +4,7 @@ import { configStore } from '@/store/ConfigStore'
 import { dataStore } from '@/store/DataStore'
 
 
-import Tree from '@/components/Tree.tsx'
+import Tree from '@/components/tree/Tree.tsx'
 import InputField from '@/components/base/InputField.tsx'
 import { ClosePopover } from '@/components/ui/popover'
 
@@ -12,13 +12,9 @@ import { getChildren, getNodeIndices } from '@/utils/tree.ts'
 
 
 const TreeSelectionModalContent: FC = () => {
-
   const addNewPanel = configStore(state => state.addNewPanel)
-
   const initCollection = dataStore(state => state.initCollection)
-
   const treeNodes = dataStore(state => state.treeNodes)
-
   const inputValue = useRef('')
   const clickedItemUrl = useRef('')
 
@@ -27,7 +23,6 @@ const TreeSelectionModalContent: FC = () => {
     manifestIndex: -1,
     itemIndex: -1,
   })
-
 
   function updateInputValue(newValue: string) {
     inputValue.current = newValue
@@ -78,9 +73,7 @@ const TreeSelectionModalContent: FC = () => {
   }
 
 
-  return <div
-    className="t-flex t-flex-col t-pt-4 t-pl-3 t-w-[500px] t-shadow-md t-border-[1px] t-border-solid t-border-gray-300 t-rounded-md">
-
+  return <div className="t-flex t-flex-col">
     <span className="t-font-bold t-mb-2">Enter a collection URL</span>
     <InputField width={80} updateInputValue={updateInputValue}/>
     <span>Or choose:</span>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  't-inline-flex t-items-center t-justify-center t-gap-2 t-whitespace-nowrap t-rounded-md t-text-sm t-font-medium t-ring-offset-white t-transition-colors focus-visible:t-outline-none focus-visible:t-ring-2 focus-visible:t-ring-gray-950 focus-visible:t-ring-offset-2 disabled:t-pointer-events-none disabled:t-opacity-50 [&_svg]:t-pointer-events-none [&_svg]:t-size-4 [&_svg]:t-shrink-0 dark:t-ring-offset-gray-950 dark:focus-visible:t-ring-gray-300',
+  {
+    variants: {
+      variant: {
+        default: 't-bg-gray-900 t-text-gray-50 hover:t-bg-gray-900/90 dark:t-bg-gray-50 dark:t-text-gray-900 dark:hover:t-bg-gray-50/90',
+        destructive:
+          't-bg-red-500 t-text-gray-50 hover:t-bg-red-500/90 dark:t-bg-red-900 dark:t-text-gray-50 dark:t-hover:bg-red-900/90',
+        outline:
+          't-border t-border-gray-200 t-bg-white hover:t-bg-gray-100 hover:t-text-gray-900 dark:t-border-gray-800 dark:t-bg-gray-950 dark:hover:t-bg-gray-800 dark:hover:t-text-gray-50',
+        secondary:
+          't-bg-gray-100 t-text-gray-900 hover:t-bg-gray-100/80 dark:t-bg-gray-800 dark:t-text-gray-50 dark:hover:t-bg-gray-800/80',
+        secondarySelected:
+          't-bg-gray-300 t-text-gray-900 hover:t-bg-gray-300/80 dark:t-bg-gray-700 dark:t-text-gray-50 dark:hover:t-bg-gray-700/80',
+        ghost: 'hover:t-bg-gray-100 hover:t-text-gray-900 dark:hover:t-bg-gray-800 dark:hover:t-text-gray-50',
+        ghostAmber: 't-text-amber-700 hover:t-bg-amber-300 hover:t-text-amber-800 dark:hover:t-bg-amber-800 dark:hover:t-text-gray-50',
+        link: 't-text-gray-900 t-underline-offset-4 hover:t-underline dark:t-text-gray-50',
+      },
+      size: {
+        default: 't-h-10 t-px-4 t-py-2',
+        sm: 't-h-9 t-rounded-md t-px-3',
+        lg: 't-h-11 t-rounded-md t-px-8',
+        icon: 't-h-8 t-w-8',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -16,7 +16,7 @@ const PopoverContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      't-z-50 t-absolute t-bg-white w-72 rounded-md border border-gray-200 bg-white p-4 text-gray-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50',
+      't-z-50 t-absolute t-rounded-md t-border t-border-gray-200 t-bg-white t-p-4 t-text-gray-950 t-shadow-md t-outline-none data-[state=open]:t-animate-in data-[state=closed]:t-animate-out data-[state=closed]:t-fade-out-0 data-[state=open]:t-fade-in-0 data-[state=closed]:t-zoom-out-95 data-[state=open]:t-zoom-in-95 data-[side=bottom]:t-slide-in-from-top-2 data-[side=left]:t-slide-in-from-right-2 data-[side=right]:t-slide-in-from-left-2 data-[side=top]:t-slide-in-from-bottom-2 dark:t-border-gray-800 dark:t-bg-gray-950 dark:t-text-gray-50',
       className
     )}
     {...props}

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -1,8 +1,11 @@
-import { ReactNode, createContext, useContext, useState, FC } from 'react'
+import { ReactNode, createContext, useContext, useState, FC, useEffect } from 'react'
+import { panelStore } from '@/store/PanelStore.tsx'
+import { selectSyncTargetByIndex } from '@/utils/annotations.ts'
 const PanelContext = createContext<PanelContentType | undefined>(undefined)
 
 interface PanelContentType {
   panelId: string
+  panelState: PanelState
 }
 
 interface PanelProviderProps {
@@ -12,9 +15,15 @@ interface PanelProviderProps {
 
 const PanelProvider: FC<PanelProviderProps> = ({ children, id }) => {
   const [panelId] = useState<string>(id)
+  const panelState = panelStore(state => state.panels[panelId])
+  const activeTargetIndex = panelStore(state => state.panels[panelId].activeTargetIndex)
+
+  useEffect(() => {
+    selectSyncTargetByIndex(panelId, activeTargetIndex)
+  }, [activeTargetIndex])
 
   return (
-    <PanelContext.Provider value={{ panelId }}>
+    <PanelContext.Provider value={{ panelId, panelState }}>
       {children}
     </PanelContext.Provider>
   )

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -19,7 +19,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, id }) => {
   const activeTargetIndex = panelStore(state => state.panels[panelId].activeTargetIndex)
 
   useEffect(() => {
-    selectSyncTargetByIndex(panelId, activeTargetIndex)
+    if (activeTargetIndex > -1) selectSyncTargetByIndex(panelId, activeTargetIndex)
   }, [activeTargetIndex])
 
   return (

--- a/src/contexts/TreeContext.tsx
+++ b/src/contexts/TreeContext.tsx
@@ -3,22 +3,17 @@ import { ReactNode, createContext, useContext, FC } from 'react'
 const TreeContext = createContext<TreeType | undefined>(undefined)
 
 interface TreeType {
-  onSelect(node: TreeNode, target): void
-
+  onSelect(node: TreeNode, target: HTMLElement): void
   getChildren(node: TreeNode): Promise<TreeNode[]>
 }
 
 interface TreeProviderProps {
   children?: ReactNode
-
-  onSelect(node: TreeNode, target): void
-
+  onSelect(node: TreeNode, target: HTMLElement): void
   getChildren(node: TreeNode): Promise<TreeNode[]>
 }
 
 const TreeProvider: FC<TreeProviderProps> = ({ children, onSelect, getChildren }) => {
-
-
   return (
     <TreeContext.Provider value={{ onSelect, getChildren }}>
       {children}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+.tido {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}

--- a/src/store/PanelStore.tsx
+++ b/src/store/PanelStore.tsx
@@ -4,9 +4,10 @@ interface PanelStates {
   [id: string]: PanelState
 }
 
-interface ContentStoreTypes {
+interface PanelStoreTypes {
   panels: PanelStates // or panels: each panel has one opened item
-  addPanelContent: (id: string, newPanel: PanelState) => void
+  activeTargetIndex: number
+  addPanelContent: (newPanel: PanelState) => void
   updatePanels: (panelId: string, updatedItem: PanelState) => void
   updateContentToggleIndex: (
     panelIndex: string,
@@ -14,13 +15,15 @@ interface ContentStoreTypes {
   ) => void
   updateViewIndex: (panelId: string, newViewIndex: number) => void
   getPanel: (panelId: string) => PanelState | null
+  setActiveTargetIndex: (panelId: string, index: number) => void
 }
 
-export const contentStore = create<ContentStoreTypes>((set, get) => ({
+export const panelStore = create<PanelStoreTypes>((set, get) => ({
   panels: {},
-  addPanelContent: (id: string, newPanel: PanelState) => {
+  activeTargetIndex: -1,
+  addPanelContent: (newPanel: PanelState) => {
     const newPanels = { ...get().panels }
-    newPanels[id] = newPanel
+    newPanels[newPanel.id] = newPanel
     set({ panels: newPanels })
   },
 
@@ -50,4 +53,9 @@ export const contentStore = create<ContentStoreTypes>((set, get) => ({
     if (!(panelId in get().panels)) return null
     return get().panels[panelId]
   },
+  setActiveTargetIndex: (panelId: string, index: number) => {
+    const panelState = get().panels[panelId]
+    panelState.activeTargetIndex = index
+    get().updatePanels(panelId, panelState)
+  }
 }))

--- a/src/store/ScrollStore.tsx
+++ b/src/store/ScrollStore.tsx
@@ -1,0 +1,53 @@
+import { create } from 'zustand'
+import { setupScrollPanels } from '@/utils/annotations.ts'
+
+interface ListenerItem {
+  element: HTMLElement
+  eventName: string
+  listener: () => void
+}
+interface ListenersMap {
+  [key: string]: ListenerItem[]
+}
+interface ScrollStoreType {
+  panelIds: string[]
+  listenersMap: ListenersMap
+  update: (panelIds: string[]) => void
+  registerListener: (panelId: string, item: ListenerItem) => void
+}
+
+export const scrollStore = create<ScrollStoreType>((set, get) => ({
+  panelIds: [],
+  listenersMap: {},
+  update: (panelIds: string[]) => {
+    set({ panelIds })
+
+    const oldListenerMap = get().listenersMap
+
+    Object.keys(oldListenerMap)
+      .forEach(key => {
+        const items = oldListenerMap[key]
+        items.forEach(({ element, eventName, listener }) => {
+          element.removeEventListener(eventName, listener)
+        })
+      })
+
+    set({
+      panelIds,
+      listenersMap: {}
+    })
+
+    setupScrollPanels(panelIds)
+  },
+  registerListener: (panelId: string, item: ListenerItem) => {
+    item.element.addEventListener(item.eventName, item.listener)
+
+    const oldListenerMap = get().listenersMap
+    set({
+      listenersMap: {
+        ...oldListenerMap,
+        [panelId]: [...(oldListenerMap[panelId] ?? []), item]
+      }
+    })
+  }
+}))

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,6 +11,13 @@ declare global {
     idref?: Idref[]
   }
 
+  interface AnnotationCollection {
+    id: string
+    first: string
+    label: string
+    type: string
+  }
+
   interface AnnotationPage {
     items: Annotation[]
     refs: Witness[]
@@ -138,12 +145,16 @@ declare global {
   }
 
   interface PanelState {
+    id: string
+    collectionId: string
+    manifest: Manifest
     item: Item
     texts?: string[]
     contentTypes?: string[]
     contentIndex: number
     viewIndex: number
     imageUrl?: string
+    activeTargetIndex: number
   }
 
   type ItemType = 'section' | 'page' | 'full'

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,0 +1,220 @@
+import {
+  scrollToElement,
+  setAutoScrolling,
+  isAutoScrolling,
+  syncScrollPosition,
+  removeAutoScrolling
+} from '@/utils/scroll.ts'
+import { panelStore } from '@/store/PanelStore.tsx'
+import { dataStore } from '@/store/DataStore.tsx'
+import { scrollStore } from '@/store/ScrollStore.tsx'
+
+
+function getTargetSelectorsInPanel(panelState: PanelState, annotations: Annotation[]) {
+  const targetSelectors: string[] = []
+  annotations
+    .forEach((annotation) => {
+      const { target } = annotation
+      target.forEach(({ source, selector }) => {
+        const [manifestId, itemId] = source.split('_')
+        if (manifestId === panelState.manifest.id && itemId === panelState.item.id) {
+          targetSelectors.push((selector as CssSelector).value)
+        }
+      })
+    })
+  return targetSelectors
+}
+
+function scrollToTarget(scrollContainer: HTMLElement, targetSelector: string) {
+  const el = scrollContainer.querySelector(targetSelector) as HTMLElement
+  if (!el) return
+  setAutoScrolling(scrollContainer)
+  scrollToElement(scrollContainer, el)
+}
+
+function setHighlightingOnTarget(el: HTMLElement) {
+  el.setAttribute('data-scroll-target', 'true')
+  el.classList.add('t-bg-gray-200', 't-cursor-pointer')
+}
+
+function setAnnotationIdOnTarget(el: HTMLElement, annotation: Annotation) {
+  el.setAttribute('data-annotation-id', annotation.id)
+}
+
+function setSelectedHighlightingOnTarget(el: HTMLElement) {
+  el.classList.remove('t-bg-gray-200')
+  el.classList.add('t-bg-blue-200')
+}
+
+function resetHighlighting(container: HTMLElement, targetSelectors: string[]) {
+  targetSelectors.forEach(selector => {
+    const el = container.querySelector(selector) as HTMLElement
+    if (!el) return
+    setHighlightingOnTarget(el)
+  })
+}
+
+function selectSyncTargetByIndex(panelId: string, index: number) {
+  const panelStates = panelStore.getState().panels
+  const panelState = panelStates[panelId]
+  if (!panelState) return
+
+  const annotations = dataStore.getState().annotations[panelState.collectionId]
+  if (!annotations) return
+
+  const scrollContainer = document.querySelector(`[data-panel="${panelState.id}"]`) as HTMLElement
+
+  const otherPanelStates = scrollStore.getState().panelIds
+    .filter(p => p !== panelId)
+    .map(id => panelStates[id])
+
+  const targets = getTargetSelectorsInPanel(panelState, annotations)
+
+  const el = scrollContainer.querySelector(targets[index]) as HTMLElement
+  if (!el) return
+
+  scrollToTarget(scrollContainer, targets[index])
+  selectSyncTarget(el, panelState, otherPanelStates)
+}
+
+function getSyncClickListener(el: HTMLElement, panelState: PanelState, otherPanelStates: PanelState[]) {
+  return function() {
+    selectSyncTarget(el, panelState, otherPanelStates)
+  }
+}
+
+function selectSyncTarget(el: HTMLElement, panelState: PanelState, otherPanelStates: PanelState[]) {
+
+  const annotationId = el.getAttribute('data-annotation-id')
+  const annotations = dataStore.getState().annotations[panelState.collectionId]
+  if (!annotations) return
+
+  const annotation = annotations.find(a => a.id === annotationId)
+  if (!annotation) return
+
+  const targetSelectors = getTargetSelectorsInPanel(panelState, annotations)
+  const scrollContainer = document.querySelector(`[data-panel="${panelState.id}"]`) as HTMLElement
+  resetHighlighting(scrollContainer, targetSelectors)
+  setSelectedHighlightingOnTarget(el)
+  panelStore.getState().setActiveTargetIndex(panelState.id, getIndexOnTarget(el))
+
+  otherPanelStates.forEach(otherPanelState => {
+    const otherScrollContainer = document.querySelector(`[data-panel="${otherPanelState.id}"]`) as HTMLElement
+    annotation.target.forEach(({ source, selector }) => {
+      const [manifestId, itemId] = source.split('_')
+      if (manifestId === otherPanelState.manifest.id && itemId === otherPanelState.item.id) {
+        scrollToTarget(otherScrollContainer, (selector as CssSelector).value)
+      }
+    })
+  })
+}
+
+function setHighlighting(panelState: PanelState, annotations: Annotation[]) {
+  const container = document.querySelector(`[data-panel="${panelState.id}"]`) as HTMLElement
+  if (!container) return
+
+  let index = -1
+  annotations.forEach(annotation => {
+    const { target } = annotation
+    target.forEach(({ source, selector }) => {
+      const [manifestId, itemId] = source.split('_')
+      if (manifestId === panelState.manifest.id && itemId === panelState.item.id) {
+        const el = container.querySelector((selector as CssSelector).value) as HTMLElement
+        if (!el) return
+        index++
+        setHighlightingOnTarget(el)
+        setAnnotationIdOnTarget(el, annotation)
+        setIndexOnTarget(el, index)
+      }
+    })
+  })
+}
+
+function setIndexOnTarget(el: HTMLElement, index: number) {
+  el.setAttribute('data-target-index', index.toString())
+}
+
+function getIndexOnTarget(el: HTMLElement) {
+  const value = el.getAttribute('data-target-index')
+  return value ? parseInt(value) : -1
+}
+
+function setClickListeners(panelState: PanelState, annotations: Annotation[]) {
+  const targets = getTargetSelectorsInPanel(panelState, annotations)
+  const otherPanelStates = scrollStore.getState().panelIds
+    .map(panelId => panelStore.getState().panels[panelId])
+
+  targets.forEach(target => {
+    const el = document.querySelector(target) as HTMLElement
+    if (!el) return
+
+    const listener = getSyncClickListener(el, panelState, otherPanelStates)
+    scrollStore.getState().registerListener(panelState.id, {
+      element: el,
+      eventName: 'click',
+      listener
+    })
+  })
+}
+
+function setupScrollPanel(panelState: PanelState) {
+  const annotations = dataStore.getState().annotations[panelState.collectionId]
+  if (!annotations) return
+
+  setHighlighting(panelState, annotations)
+  setClickListeners(panelState, annotations)
+}
+
+function setupSyncScrolling(panelStates: PanelState[]) {
+  panelStates.forEach(panelState => {
+    const scrollContainer = document.querySelector(`[data-panel="${panelState.id}"]`) as HTMLElement
+    if (!scrollContainer) return
+
+    const wheelListener = getSyncWheelListener(scrollContainer)
+    scrollStore.getState().registerListener(panelState.id, {
+      element: scrollContainer,
+      eventName: 'wheel',
+      listener: wheelListener
+    })
+
+    const otherPanelStates = panelStates.filter(p => p.id !== panelState.id)
+
+    const scrollListener = getSyncScrollListener(scrollContainer, otherPanelStates)
+    scrollStore.getState().registerListener(panelState.id, {
+      element: scrollContainer,
+      eventName: 'scroll',
+      listener: scrollListener
+    })
+  })
+}
+
+function getSyncScrollListener(container: HTMLElement, otherPanelStates: PanelState[]) {
+  return function () {
+    if (isAutoScrolling(container)) return
+    otherPanelStates.forEach(otherPanelState => {
+      const otherScrollContainer = document.querySelector(`[data-panel="${otherPanelState.id}"]`) as HTMLElement
+      if (!otherScrollContainer) return
+      syncScrollPosition(container, otherScrollContainer)
+    })
+  }
+}
+
+function getSyncWheelListener(container: HTMLElement) {
+  return function () {
+    removeAutoScrolling(container)
+  }
+}
+
+function setupScrollPanels(panelIds: string[]) {
+  const panelStates = Object.keys(panelStore.getState().panels)
+    .filter(key => panelIds.includes(key))
+    .map(key => panelStore.getState().panels[key])
+
+  panelStates.forEach(panelState => setupScrollPanel(panelState))
+  setupSyncScrolling(panelStates)
+}
+
+export {
+  setupScrollPanels,
+  selectSyncTargetByIndex
+}

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -1,0 +1,33 @@
+const AUTO_SCROLLING_ATTR_NAME = 'data-auto-scrolling'
+
+function syncScrollPosition(source: HTMLElement, target: HTMLElement) {
+  setAutoScrolling(target)
+  target.scrollTop = (source.scrollTop ?? 0) + 20
+}
+
+function isAutoScrolling(container: HTMLElement) {
+  return container.hasAttribute(AUTO_SCROLLING_ATTR_NAME)
+}
+
+function setAutoScrolling(el: HTMLElement) {
+  el.setAttribute(AUTO_SCROLLING_ATTR_NAME, '')
+}
+
+function removeAutoScrolling(el: HTMLElement) {
+  el.removeAttribute(AUTO_SCROLLING_ATTR_NAME)
+}
+
+function scrollToElement(container: HTMLElement, target: HTMLElement) {
+  container.scrollTo({
+    top: target.offsetTop - container.offsetTop,
+    behavior: 'smooth'
+  })
+}
+
+export {
+  setAutoScrolling,
+  scrollToElement,
+  syncScrollPosition,
+  isAutoScrolling,
+  removeAutoScrolling
+}

--- a/tests/mocks/example/annotations/annotationCollection.json
+++ b/tests/mocks/example/annotations/annotationCollection.json
@@ -1,0 +1,7 @@
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "example/annotationCollection",
+  "type": "AnnotationCollection",
+  "label": "Synopsis connections",
+  "first": "http://localhost:8181/example/annotations/annotationPage.json"
+}

--- a/tests/mocks/example/annotations/annotationPage.json
+++ b/tests/mocks/example/annotations/annotationPage.json
@@ -1,0 +1,101 @@
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "id": "example/annotationPage",
+  "type": "AnnotationPage",
+  "partOf": {
+    "id": "example/annotationCollection",
+    "label": "Synopsis connections"
+  },
+  "next": null,
+  "prev": null,
+  "items": [
+    {
+      "body": {
+        "x-content-type": "Edit",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "Vivamus ut purus quis arcu faucibus fermentum."
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-1-item-1-scroll-1"
+          },
+          "source": "example/manifest-1_example/manifest-1/item-1",
+          "format": "text/xml"
+        },
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-2-item-1-scroll-1"
+          },
+          "source": "example/manifest-2_example/manifest-2/item-1",
+          "format": "text/xml"
+        },
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-3-item-1-scroll-1"
+          },
+          "source": "example/manifest-3_example/manifest-3/item-1",
+          "format": "text/xml"
+        },
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-4-item-1-scroll-1"
+          },
+          "source": "example/manifest-4_example/manifest-4/item-1",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "example/manifest-1/item-1/annotation-1"
+    },
+    {
+      "body": {
+        "x-content-type": "Edit",
+        "type": "TextualBody",
+        "format": "text/plain",
+        "value": "Vivamus ut purus quis arcu faucibus fermentum."
+      },
+      "target": [
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-1-item-1-scroll-2"
+          },
+          "source": "example/manifest-1_example/manifest-1/item-1",
+          "format": "text/xml"
+        },
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-2-item-1-scroll-2"
+          },
+          "source": "example/manifest-2_example/manifest-2/item-1",
+          "format": "text/xml"
+        },
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-3-item-1-scroll-2"
+          },
+          "source": "example/manifest-3_example/manifest-3/item-1",
+          "format": "text/xml"
+        },
+        {
+          "selector": {
+            "type": "CssSelector",
+            "value": "#manifest-4-item-1-scroll-2"
+          },
+          "source": "example/manifest-4_example/manifest-4/item-1",
+          "format": "text/xml"
+        }
+      ],
+      "type": "Annotation",
+      "id": "example/manifest-1/item-1/annotation-2"
+    }
+  ]
+}

--- a/tests/mocks/example/content/transcription/manifest-1-item-1.html
+++ b/tests/mocks/example/content/transcription/manifest-1-item-1.html
@@ -1,0 +1,115 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>Vestibulum vehicula ex eu nisi fringilla, non sollicitudin libero pellentesque.</p>
+<p>Phasellus finibus eros ut leo scelerisque, ac hendrerit lacus euismod.</p>
+<p>Sed et urna eu ex cursus consequat sit amet a libero.</p>
+<p>Integer vitae erat ut nisi suscipit interdum non sed elit.</p>
+<p id="manifest-1-item-1-scroll-1">(scroll-1) Curabitur luctus nunc ut libero hendrerit, at pulvinar ligula dapibus.</p>
+<p>Aliquam dictum sem vel justo fermentum, nec cursus sapien placerat.</p>
+<p>Aenean ullamcorper mauris ac diam aliquam, in tincidunt augue vestibulum.</p>
+<p>Morbi a erat at tortor tincidunt vestibulum id ac orci.</p>
+<p>Duis accumsan nisl at turpis convallis, id hendrerit velit luctus.</p>
+<p>Suspendisse scelerisque sem in tortor laoreet, et aliquam elit vehicula.</p>
+<p>Donec auctor turpis id mi aliquet, at pharetra turpis vulputate.</p>
+<p>Nam volutpat est at eros mollis, sed sodales erat efficitur.</p>
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+<p>Ut id justo nec tortor gravida fringilla.</p>
+<p>Quisque et neque nec libero convallis porttitor.</p>
+<p>Vivamus suscipit purus a ante molestie, ut tempus libero tristique.</p>
+<p>Nunc et metus sed justo ultricies tincidunt nec a lorem.</p>
+<p>Etiam sed magna nec purus sagittis euismod.</p>
+<p>Fusce mollis justo in magna malesuada, sed ultricies augue fermentum.</p>
+<p>Praesent viverra urna nec justo dictum suscipit.</p>
+<p>Phasellus interdum lectus vel odio lacinia, at fermentum ligula dictum.</p>
+<p>Nulla facilisi.</p>
+<p>Ut tristique metus a enim gravida, ac tincidunt dui auctor.</p>
+<p>Morbi aliquam neque non libero pharetra pellentesque.</p>
+<p>Aenean facilisis ex id enim facilisis, et rhoncus lectus lacinia.</p>
+<p>Nam condimentum velit ac nibh pretium, et convallis magna sagittis.</p>
+<p>Sed quis libero ac nisl luctus fermentum vel id lacus.</p>
+<p>Mauris feugiat massa in ligula vestibulum, sed tincidunt ipsum dapibus.</p>
+<p>Integer rhoncus sapien a magna iaculis, ac consectetur felis cursus.</p>
+<p>Nam rhoncus leo non massa volutpat, sed suscipit lectus tincidunt.</p>
+<p>Vestibulum sed eros in sapien elementum fermentum at non felis.</p>
+<p>Pellentesque a turpis id metus malesuada facilisis.</p>
+<p>Donec eu turpis eu erat sagittis posuere at vitae orci.</p>
+<p>Aliquam erat volutpat.</p>
+<p id="manifest-1-item-1-scroll-2">(scroll-2) Vivamus ut purus quis arcu faucibus fermentum.</p>
+<p>Suspendisse vitae neque at erat porttitor hendrerit sed id velit.</p>
+<p>Nulla at libero vitae augue consequat consequat.</p>
+<p>Sed auctor sapien ut odio posuere, a pharetra metus luctus.</p>
+<p id="manifest-1-item-1-scroll-3">Curabitur et ipsum vel turpis tincidunt consectetur ut sit amet ligula.</p>
+<p>Etiam et nulla et tortor hendrerit tincidunt.</p>
+<p>Nam suscipit sem at ante fringilla, id aliquet lorem tincidunt.</p>
+<p>Maecenas pharetra arcu non risus suscipit fringilla.</p>
+<p>Morbi tincidunt odio vel justo lacinia sagittis.</p>
+<p>Nullam congue eros sed nibh vehicula tincidunt.</p>
+<p>Donec accumsan nulla id sapien blandit, vitae consequat arcu dapibus.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Quisque vitae felis et est congue venenatis.</p>
+<p>Proin ultricies erat at dolor dignissim, id interdum libero interdum.</p>
+<p id="manifest-1-item-1-scroll-4">Mauris sit amet risus euismod, vulputate sapien in, facilisis enim.</p>
+<p>Ut nec lorem in neque lacinia pretium sit amet quis lorem.</p>
+<p>Integer et velit id lectus bibendum accumsan sit amet ut lorem.</p>
+<p>Cras non turpis a elit sagittis varius at non odio.</p>
+<p>Suspendisse potenti.</p>
+<p>Etiam facilisis mi a libero fermentum cursus.</p>
+<p>Aliquam convallis est eget magna elementum congue.</p>
+<p>In varius risus vel felis dapibus, id egestas arcu eleifend.</p>
+<p>Nullam ullamcorper magna a magna euismod dictum.</p>
+<p>Morbi convallis velit ut mi tristique, ut tincidunt ligula bibendum.</p>
+<p>Duis bibendum quam at libero rutrum, at tristique lacus rhoncus.</p>
+<p>Donec vitae libero consectetur, pulvinar est sit amet, venenatis turpis.</p>
+<p>Nunc vel ligula sed ipsum fermentum porttitor id vel ex.</p>
+<p>Praesent suscipit erat vitae dolor luctus, id auctor elit consectetur.</p>
+<p>Quisque id libero eget turpis scelerisque efficitur at vel justo.</p>
+<p>Donec nec elit fringilla, suscipit arcu vel, tincidunt metus.</p>
+<p>Ut consequat odio sit amet est tincidunt, id malesuada orci fermentum.</p>
+<p>Fusce aliquam quam nec libero tristique sollicitudin.</p>
+<p>Praesent facilisis nunc eget elit tincidunt, vel laoreet velit sagittis.</p>
+<p>Vivamus feugiat magna nec quam fermentum, et lacinia ligula cursus.</p>
+<p>Aenean suscipit ex vel turpis sagittis vestibulum.</p>
+<p>Donec sit amet lacus nec magna ultricies tempor.</p>
+<p>Phasellus non velit id risus bibendum malesuada.</p>
+<p>Sed nec eros in odio consequat condimentum eu id lectus.</p>
+<p>Integer a magna vel arcu rutrum tristique.</p>
+<p>Cras dictum mi id neque laoreet, sit amet sodales libero pharetra.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Ut feugiat sapien nec sem fermentum fermentum.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Donec consectetur justo vel odio cursus, non vulputate metus consequat.</p>
+<p>Ut facilisis nisi ac nisi sollicitudin, a consectetur enim facilisis.</p>
+<p>Sed vulputate justo et massa convallis, at eleifend magna cursus.</p>
+<p>In dignissim nunc ut ante fermentum, id tristique nisl faucibus.</p>
+<p>Vivamus quis elit in lorem mollis facilisis.</p>
+<p>Nullam dapibus magna vel metus venenatis, vel scelerisque lacus cursus.</p>
+<p>Aenean fringilla augue ac sapien fermentum, quis consequat libero pellentesque.</p>
+<p>Maecenas pretium libero et lorem consequat, quis aliquet nulla scelerisque.</p>
+<p>Cras euismod risus a augue vestibulum feugiat.</p>
+<p>Quisque sit amet orci nec mauris feugiat porttitor a vel justo.</p>
+<p>Donec id leo sed felis dignissim tincidunt in nec nunc.</p>
+<p>Suspendisse eget massa nec lectus volutpat tincidunt sed id enim.</p>
+<p>Morbi vestibulum lorem in justo cursus, nec cursus lectus facilisis.</p>
+<p>Pellentesque vehicula lacus sit amet tortor tincidunt volutpat.</p>
+<p>Nam lacinia justo nec ex pellentesque, nec feugiat ipsum dictum.</p>
+<p>Vivamus ut eros vitae tortor consequat fermentum.</p>
+<p>Nulla nec neque non lorem ultrices tempor a sit amet turpis.</p>
+<p>Integer pharetra libero ac lectus dapibus, ut venenatis nisl iaculis.</p>
+<p>Phasellus scelerisque metus in libero euismod, id congue mi condimentum.</p>
+<p>Pellentesque ut odio nec justo venenatis dignissim.</p>
+<p>Donec dapibus nisi a justo convallis, quis euismod neque interdum.</p>
+<p>Aenean fermentum augue at nulla suscipit consequat.</p>
+<p>Ut egestas augue eu augue mollis, in gravida nunc elementum.</p>
+<p>Praesent tristique justo vel risus rhoncus, quis dapibus nunc tempor.</p>
+<p>Integer malesuada nulla sit amet purus ultricies tempor.</p>
+<p>Phasellus non lorem eget mi convallis consequat.</p>
+<p>Quisque tristique urna id lacus aliquam eleifend.</p>
+<p>Vestibulum a massa a mi finibus gravida id at est.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Nam sit amet eros nec lorem suscipit condimentum sed sit amet magna.</p>
+<p>Donec id elit nec lacus bibendum pretium.</p>
+<p>Integer eget risus id velit sodales pharetra vel ac neque.</p>
+<p>Pellentesque quis ante a lorem sollicitudin aliquam.</p>
+<p>Morbi nec erat id est egestas faucibus.</p>
+<p>Curabitur pellentesque lorem at magna dapibus, nec dictum nisi dapibus.</p>
+<p>Proin in eros vel nulla convallis pharetra.</p>
+<p>Nullam et lectus eu eros sollicitudin pretium sit amet id lorem.</p>

--- a/tests/mocks/example/content/transcription/manifest-2-item-1.html
+++ b/tests/mocks/example/content/transcription/manifest-2-item-1.html
@@ -1,0 +1,115 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>Vestibulum vehicula ex eu nisi fringilla, non sollicitudin libero pellentesque.</p>
+<p>Phasellus finibus eros ut leo scelerisque, ac hendrerit lacus euismod.</p>
+<p>Sed et urna eu ex cursus consequat sit amet a libero.</p>
+<p>Integer vitae erat ut nisi suscipit interdum non sed elit.</p>
+<p>Curabitur luctus nunc ut libero hendrerit, at pulvinar ligula dapibus.</p>
+<p>Aliquam dictum sem vel justo fermentum, nec cursus sapien placerat.</p>
+<p>Aenean ullamcorper mauris ac diam aliquam, in tincidunt augue vestibulum.</p>
+<p>Duis accumsan nisl at turpis convallis, id hendrerit velit luctus.</p>
+<p>Suspendisse scelerisque sem in tortor laoreet, et aliquam elit vehicula.</p>
+<p>Donec auctor turpis id mi aliquet, at pharetra turpis vulputate.</p>
+<p>Nam volutpat est at eros mollis, sed sodales erat efficitur.</p>
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+<p>Ut id justo nec tortor gravida fringilla.</p>
+<p>Quisque et neque nec libero convallis porttitor.</p>
+<p>Vivamus suscipit purus a ante molestie, ut tempus libero tristique.</p>
+<p>Nunc et metus sed justo ultricies tincidunt nec a lorem.</p>
+<p>Etiam sed magna nec purus sagittis euismod.</p>
+<p>Fusce mollis justo in magna malesuada, sed ultricies augue fermentum.</p>
+<p>Praesent viverra urna nec justo dictum suscipit.</p>
+<p>Phasellus interdum lectus vel odio lacinia, at fermentum ligula dictum.</p>
+<p>Nulla facilisi.</p>
+<p>Ut tristique metus a enim gravida, ac tincidunt dui auctor.</p>
+<p>Morbi aliquam neque non libero pharetra pellentesque.</p>
+<p>Aenean facilisis ex id enim facilisis, et rhoncus lectus lacinia.</p>
+<p>Nam condimentum velit ac nibh pretium, et convallis magna sagittis.</p>
+<p>Sed quis libero ac nisl luctus fermentum vel id lacus.</p>
+<p>Mauris feugiat massa in ligula vestibulum, sed tincidunt ipsum dapibus.</p>
+<p>Integer rhoncus sapien a magna iaculis, ac consectetur felis cursus.</p>
+<p>Nam rhoncus leo non massa volutpat, sed suscipit lectus tincidunt.</p>
+<p>Vestibulum sed eros in sapien elementum fermentum at non felis.</p>
+<p>Pellentesque a turpis id metus malesuada facilisis.</p>
+<p>Donec eu turpis eu erat sagittis posuere at vitae orci.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Vivamus ut purus quis arcu faucibus fermentum.</p>
+<p>Suspendisse vitae neque at erat porttitor hendrerit sed id velit.</p>
+<p>Nulla at libero vitae augue consequat consequat.</p>
+<p>Sed auctor sapien ut odio posuere, a pharetra metus luctus.</p>
+<p>Curabitur et ipsum vel turpis tincidunt consectetur ut sit amet ligula.</p>
+<p>Etiam et nulla et tortor hendrerit tincidunt.</p>
+<p>Nam suscipit sem at ante fringilla, id aliquet lorem tincidunt.</p>
+<p>Maecenas pharetra arcu non risus suscipit fringilla.</p>
+<p>Morbi tincidunt odio vel justo lacinia sagittis.</p>
+<p>Nullam congue eros sed nibh vehicula tincidunt.</p>
+<p>Donec accumsan nulla id sapien blandit, vitae consequat arcu dapibus.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Quisque vitae felis et est congue venenatis.</p>
+<p>Proin ultricies erat at dolor dignissim, id interdum libero interdum.</p>
+<p>Mauris sit amet risus euismod, vulputate sapien in, facilisis enim.</p>
+<p>Ut nec lorem in neque lacinia pretium sit amet quis lorem.</p>
+<p>Integer et velit id lectus bibendum accumsan sit amet ut lorem.</p>
+<p>Cras non turpis a elit sagittis varius at non odio.</p>
+<p>Suspendisse potenti.</p>
+<p>Etiam facilisis mi a libero fermentum cursus.</p>
+<p>Aliquam convallis est eget magna elementum congue.</p>
+<p>In varius risus vel felis dapibus, id egestas arcu eleifend.</p>
+<p>Nullam ullamcorper magna a magna euismod dictum.</p>
+<p>Morbi convallis velit ut mi tristique, ut tincidunt ligula bibendum.</p>
+<p>Duis bibendum quam at libero rutrum, at tristique lacus rhoncus.</p>
+<p>Donec vitae libero consectetur, pulvinar est sit amet, venenatis turpis.</p>
+<p>Nunc vel ligula sed ipsum fermentum porttitor id vel ex.</p>
+<p>Praesent suscipit erat vitae dolor luctus, id auctor elit consectetur.</p>
+<p>Quisque id libero eget turpis scelerisque efficitur at vel justo.</p>
+<p>Donec nec elit fringilla, suscipit arcu vel, tincidunt metus.</p>
+<p>Ut consequat odio sit amet est tincidunt, id malesuada orci fermentum.</p>
+<p>Fusce aliquam quam nec libero tristique sollicitudin.</p>
+<p>Praesent facilisis nunc eget elit tincidunt, vel laoreet velit sagittis.</p>
+<p>Vivamus feugiat magna nec quam fermentum, et lacinia ligula cursus.</p>
+<p>Aenean suscipit ex vel turpis sagittis vestibulum.</p>
+<p>Donec sit amet lacus nec magna ultricies tempor.</p>
+<p>Phasellus non velit id risus bibendum malesuada.</p>
+<p>Sed nec eros in odio consequat condimentum eu id lectus.</p>
+<p>Integer a magna vel arcu rutrum tristique.</p>
+<p>Cras dictum mi id neque laoreet, sit amet sodales libero pharetra.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Ut feugiat sapien nec sem fermentum fermentum.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Donec consectetur justo vel odio cursus, non vulputate metus consequat.</p>
+<p>Ut facilisis nisi ac nisi sollicitudin, a consectetur enim facilisis.</p>
+<p>Sed vulputate justo et massa convallis, at eleifend magna cursus.</p>
+<p>In dignissim nunc ut ante fermentum, id tristique nisl faucibus.</p>
+<p>Vivamus quis elit in lorem mollis facilisis.</p>
+<p>Nullam dapibus magna vel metus venenatis, vel scelerisque lacus cursus.</p>
+<p>Aenean fringilla augue ac sapien fermentum, quis consequat libero pellentesque.</p>
+<p>Maecenas pretium libero et lorem consequat, quis aliquet nulla scelerisque.</p>
+<p>Cras euismod risus a augue vestibulum feugiat.</p>
+<p>Quisque sit amet orci nec mauris feugiat porttitor a vel justo.</p>
+<p>Donec id leo sed felis dignissim tincidunt in nec nunc.</p>
+<p>Suspendisse eget massa nec lectus volutpat tincidunt sed id enim.</p>
+<p>Morbi vestibulum lorem in justo cursus, nec cursus lectus facilisis.</p>
+<p>Pellentesque vehicula lacus sit amet tortor tincidunt volutpat.</p>
+<p>Nam lacinia justo nec ex pellentesque, nec feugiat ipsum dictum.</p>
+<p>Vivamus ut eros vitae tortor consequat fermentum.</p>
+<p>Nulla nec neque non lorem ultrices tempor a sit amet turpis.</p>
+<p>Integer pharetra libero ac lectus dapibus, ut venenatis nisl iaculis.</p>
+<p>Phasellus scelerisque metus in libero euismod, id congue mi condimentum.</p>
+<p>Pellentesque ut odio nec justo venenatis dignissim.</p>
+<p>Donec dapibus nisi a justo convallis, quis euismod neque interdum.</p>
+<p>Aenean fermentum augue at nulla suscipit consequat.</p>
+<p>Ut egestas augue eu augue mollis, in gravida nunc elementum.</p>
+<p>Praesent tristique justo vel risus rhoncus, quis dapibus nunc tempor.</p>
+<p>Integer malesuada nulla sit amet purus ultricies tempor.</p>
+<p>Phasellus non lorem eget mi convallis consequat.</p>
+<p>Quisque tristique urna id lacus aliquam eleifend.</p>
+<p>Vestibulum a massa a mi finibus gravida id at est.</p>
+<p>Aliquam erat volutpat.</p>
+<p id="manifest-2-item-1-scroll-1">(scroll-1) Morbi a erat at tortor tincidunt vestibulum id ac orci.</p>
+<p>Nam sit amet eros nec lorem suscipit condimentum sed sit amet magna.</p>
+<p>Donec id elit nec lacus bibendum pretium.</p>
+<p id="manifest-2-item-1-scroll-2">(scroll-2) Integer eget risus id velit sodales pharetra vel ac neque.</p>
+<p>Pellentesque quis ante a lorem sollicitudin aliquam.</p>
+<p>Morbi nec erat id est egestas faucibus.</p>
+<p>Curabitur pellentesque lorem at magna dapibus, nec dictum nisi dapibus.</p>
+<p>Proin in eros vel nulla convallis pharetra.</p>
+<p>Nullam et lectus eu eros sollicitudin pretium sit amet id lorem.</p>

--- a/tests/mocks/example/content/transcription/manifest-3-item-1.html
+++ b/tests/mocks/example/content/transcription/manifest-3-item-1.html
@@ -1,0 +1,115 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>Vestibulum vehicula ex eu nisi fringilla, non sollicitudin libero pellentesque.</p>
+<p>Phasellus finibus eros ut leo scelerisque, ac hendrerit lacus euismod.</p>
+<p>Sed et urna eu ex cursus consequat sit amet a libero.</p>
+<p id="manifest-3-item-1-scroll-2">(scroll-2) Integer vitae erat ut nisi suscipit interdum non sed elit.</p>
+<p>Curabitur luctus nunc ut libero hendrerit, at pulvinar ligula dapibus.</p>
+<p>Aliquam dictum sem vel justo fermentum, nec cursus sapien placerat.</p>
+<p>Aenean ullamcorper mauris ac diam aliquam, in tincidunt augue vestibulum.</p>
+<p>Duis accumsan nisl at turpis convallis, id hendrerit velit luctus.</p>
+<p>Suspendisse scelerisque sem in tortor laoreet, et aliquam elit vehicula.</p>
+<p>Donec auctor turpis id mi aliquet, at pharetra turpis vulputate.</p>
+<p>Nam volutpat est at eros mollis, sed sodales erat efficitur.</p>
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+<p>Ut id justo nec tortor gravida fringilla.</p>
+<p>Quisque et neque nec libero convallis porttitor.</p>
+<p id="manifest-3-item-1-scroll-3">(scroll-3) Vivamus suscipit purus a ante molestie, ut tempus libero tristique.</p>
+<p>Nunc et metus sed justo ultricies tincidunt nec a lorem.</p>
+<p>Etiam sed magna nec purus sagittis euismod.</p>
+<p>Fusce mollis justo in magna malesuada, sed ultricies augue fermentum.</p>
+<p>Praesent viverra urna nec justo dictum suscipit.</p>
+<p>Phasellus interdum lectus vel odio lacinia, at fermentum ligula dictum.</p>
+<p>Nulla facilisi.</p>
+<p>Ut tristique metus a enim gravida, ac tincidunt dui auctor.</p>
+<p>Morbi aliquam neque non libero pharetra pellentesque.</p>
+<p>Aenean facilisis ex id enim facilisis, et rhoncus lectus lacinia.</p>
+<p>Nam condimentum velit ac nibh pretium, et convallis magna sagittis.</p>
+<p>Sed quis libero ac nisl luctus fermentum vel id lacus.</p>
+<p>Mauris feugiat massa in ligula vestibulum, sed tincidunt ipsum dapibus.</p>
+<p>Integer rhoncus sapien a magna iaculis, ac consectetur felis cursus.</p>
+<p>Nam rhoncus leo non massa volutpat, sed suscipit lectus tincidunt.</p>
+<p>Vestibulum sed eros in sapien elementum fermentum at non felis.</p>
+<p>Pellentesque a turpis id metus malesuada facilisis.</p>
+<p>Donec eu turpis eu erat sagittis posuere at vitae orci.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Vivamus ut purus quis arcu faucibus fermentum.</p>
+<p>Suspendisse vitae neque at erat porttitor hendrerit sed id velit.</p>
+<p>Nulla at libero vitae augue consequat consequat.</p>
+<p>Sed auctor sapien ut odio posuere, a pharetra metus luctus.</p>
+<p>Curabitur et ipsum vel turpis tincidunt consectetur ut sit amet ligula.</p>
+<p>Etiam et nulla et tortor hendrerit tincidunt.</p>
+<p>Nam suscipit sem at ante fringilla, id aliquet lorem tincidunt.</p>
+<p>Maecenas pharetra arcu non risus suscipit fringilla.</p>
+<p>Morbi tincidunt odio vel justo lacinia sagittis.</p>
+<p>Nullam congue eros sed nibh vehicula tincidunt.</p>
+<p>Donec accumsan nulla id sapien blandit, vitae consequat arcu dapibus.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Quisque vitae felis et est congue venenatis.</p>
+<p>Proin ultricies erat at dolor dignissim, id interdum libero interdum.</p>
+<p>Mauris sit amet risus euismod, vulputate sapien in, facilisis enim.</p>
+<p>Ut nec lorem in neque lacinia pretium sit amet quis lorem.</p>
+<p>Integer et velit id lectus bibendum accumsan sit amet ut lorem.</p>
+<p>Cras non turpis a elit sagittis varius at non odio.</p>
+<p>Suspendisse potenti.</p>
+<p>Etiam facilisis mi a libero fermentum cursus.</p>
+<p>Aliquam convallis est eget magna elementum congue.</p>
+<p>In varius risus vel felis dapibus, id egestas arcu eleifend.</p>
+<p>Nullam ullamcorper magna a magna euismod dictum.</p>
+<p>Morbi convallis velit ut mi tristique, ut tincidunt ligula bibendum.</p>
+<p>Duis bibendum quam at libero rutrum, at tristique lacus rhoncus.</p>
+<p>Donec vitae libero consectetur, pulvinar est sit amet, venenatis turpis.</p>
+<p>Nunc vel ligula sed ipsum fermentum porttitor id vel ex.</p>
+<p>Praesent suscipit erat vitae dolor luctus, id auctor elit consectetur.</p>
+<p>Quisque id libero eget turpis scelerisque efficitur at vel justo.</p>
+<p>Donec nec elit fringilla, suscipit arcu vel, tincidunt metus.</p>
+<p>Ut consequat odio sit amet est tincidunt, id malesuada orci fermentum.</p>
+<p>Fusce aliquam quam nec libero tristique sollicitudin.</p>
+<p>Praesent facilisis nunc eget elit tincidunt, vel laoreet velit sagittis.</p>
+<p>Vivamus feugiat magna nec quam fermentum, et lacinia ligula cursus.</p>
+<p>Aenean suscipit ex vel turpis sagittis vestibulum.</p>
+<p>Donec sit amet lacus nec magna ultricies tempor.</p>
+<p>Phasellus non velit id risus bibendum malesuada.</p>
+<p>Sed nec eros in odio consequat condimentum eu id lectus.</p>
+<p>Integer a magna vel arcu rutrum tristique.</p>
+<p>Cras dictum mi id neque laoreet, sit amet sodales libero pharetra.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p id="manifest-3-item-1-scroll-4">(scroll-4) Ut feugiat sapien nec sem fermentum fermentum.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Donec consectetur justo vel odio cursus, non vulputate metus consequat.</p>
+<p>Ut facilisis nisi ac nisi sollicitudin, a consectetur enim facilisis.</p>
+<p>Sed vulputate justo et massa convallis, at eleifend magna cursus.</p>
+<p>In dignissim nunc ut ante fermentum, id tristique nisl faucibus.</p>
+<p>Vivamus quis elit in lorem mollis facilisis.</p>
+<p>Nullam dapibus magna vel metus venenatis, vel scelerisque lacus cursus.</p>
+<p>Aenean fringilla augue ac sapien fermentum, quis consequat libero pellentesque.</p>
+<p>Maecenas pretium libero et lorem consequat, quis aliquet nulla scelerisque.</p>
+<p id="manifest-3-item-1-scroll-1">(scroll-1) Cras euismod risus a augue vestibulum feugiat.</p>
+<p>Quisque sit amet orci nec mauris feugiat porttitor a vel justo.</p>
+<p>Donec id leo sed felis dignissim tincidunt in nec nunc.</p>
+<p>Suspendisse eget massa nec lectus volutpat tincidunt sed id enim.</p>
+<p>Morbi vestibulum lorem in justo cursus, nec cursus lectus facilisis.</p>
+<p>Pellentesque vehicula lacus sit amet tortor tincidunt volutpat.</p>
+<p>Nam lacinia justo nec ex pellentesque, nec feugiat ipsum dictum.</p>
+<p>Vivamus ut eros vitae tortor consequat fermentum.</p>
+<p>Nulla nec neque non lorem ultrices tempor a sit amet turpis.</p>
+<p>Integer pharetra libero ac lectus dapibus, ut venenatis nisl iaculis.</p>
+<p>Phasellus scelerisque metus in libero euismod, id congue mi condimentum.</p>
+<p>Pellentesque ut odio nec justo venenatis dignissim.</p>
+<p>Donec dapibus nisi a justo convallis, quis euismod neque interdum.</p>
+<p>Aenean fermentum augue at nulla suscipit consequat.</p>
+<p>Ut egestas augue eu augue mollis, in gravida nunc elementum.</p>
+<p>Praesent tristique justo vel risus rhoncus, quis dapibus nunc tempor.</p>
+<p>Integer malesuada nulla sit amet purus ultricies tempor.</p>
+<p>Phasellus non lorem eget mi convallis consequat.</p>
+<p>Quisque tristique urna id lacus aliquam eleifend.</p>
+<p>Vestibulum a massa a mi finibus gravida id at est.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Morbi a erat at tortor tincidunt vestibulum id ac orci.</p>
+<p>Nam sit amet eros nec lorem suscipit condimentum sed sit amet magna.</p>
+<p>Donec id elit nec lacus bibendum pretium.</p>
+<p>Integer eget risus id velit sodales pharetra vel ac neque.</p>
+<p>Pellentesque quis ante a lorem sollicitudin aliquam.</p>
+<p>Morbi nec erat id est egestas faucibus.</p>
+<p>Curabitur pellentesque lorem at magna dapibus, nec dictum nisi dapibus.</p>
+<p>Proin in eros vel nulla convallis pharetra.</p>
+<p>Nullam et lectus eu eros sollicitudin pretium sit amet id lorem.</p>

--- a/tests/mocks/example/content/transcription/manifest-4-item-1.html
+++ b/tests/mocks/example/content/transcription/manifest-4-item-1.html
@@ -1,0 +1,115 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>Vestibulum vehicula ex eu nisi fringilla, non sollicitudin libero pellentesque.</p>
+<p>Phasellus finibus eros ut leo scelerisque, ac hendrerit lacus euismod.</p>
+<p>Sed et urna eu ex cursus consequat sit amet a libero.</p>
+<p>Integer vitae erat ut nisi suscipit interdum non sed elit.</p>
+<p>Curabitur luctus nunc ut libero hendrerit, at pulvinar ligula dapibus.</p>
+<p>Aliquam dictum sem vel justo fermentum, nec cursus sapien placerat.</p>
+<p>Aenean ullamcorper mauris ac diam aliquam, in tincidunt augue vestibulum.</p>
+<p>Duis accumsan nisl at turpis convallis, id hendrerit velit luctus.</p>
+<p>Suspendisse scelerisque sem in tortor laoreet, et aliquam elit vehicula.</p>
+<p>Donec auctor turpis id mi aliquet, at pharetra turpis vulputate.</p>
+<p>Nam volutpat est at eros mollis, sed sodales erat efficitur.</p>
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+<p>Ut id justo nec tortor gravida fringilla.</p>
+<p>Quisque et neque nec libero convallis porttitor.</p>
+<p>Vivamus suscipit purus a ante molestie, ut tempus libero tristique.</p>
+<p>Nunc et metus sed justo ultricies tincidunt nec a lorem.</p>
+<p>Etiam sed magna nec purus sagittis euismod.</p>
+<p>Fusce mollis justo in magna malesuada, sed ultricies augue fermentum.</p>
+<p>Praesent viverra urna nec justo dictum suscipit.</p>
+<p>Phasellus interdum lectus vel odio lacinia, at fermentum ligula dictum.</p>
+<p>Nulla facilisi.</p>
+<p>Ut tristique metus a enim gravida, ac tincidunt dui auctor.</p>
+<p>Morbi aliquam neque non libero pharetra pellentesque.</p>
+<p>Aenean facilisis ex id enim facilisis, et rhoncus lectus lacinia.</p>
+<p>Nam condimentum velit ac nibh pretium, et convallis magna sagittis.</p>
+<p>Sed quis libero ac nisl luctus fermentum vel id lacus.</p>
+<p>Mauris feugiat massa in ligula vestibulum, sed tincidunt ipsum dapibus.</p>
+<p>Integer rhoncus sapien a magna iaculis, ac consectetur felis cursus.</p>
+<p id="manifest-4-item-1-scroll-1">(scroll-1) Nam rhoncus leo non massa volutpat, sed suscipit lectus tincidunt.
+Vestibulum sed eros in sapien elementum fermentum at non felis.
+Pellentesque a turpis id metus malesuada facilisis.
+Donec eu turpis eu erat sagittis posuere at vitae orci.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Vivamus ut purus quis arcu faucibus fermentum.</p>
+<p>Suspendisse vitae neque at erat porttitor hendrerit sed id velit.</p>
+<p>Nulla at libero vitae augue consequat consequat.</p>
+<p>Sed auctor sapien ut odio posuere, a pharetra metus luctus.</p>
+<p>Curabitur et ipsum vel turpis tincidunt consectetur ut sit amet ligula.</p>
+<p>Etiam et nulla et tortor hendrerit tincidunt.</p>
+<p>Nam suscipit sem at ante fringilla, id aliquet lorem tincidunt.</p>
+<p>Maecenas pharetra arcu non risus suscipit fringilla.</p>
+<p>Morbi tincidunt odio vel justo lacinia sagittis.</p>
+<p>Nullam congue eros sed nibh vehicula tincidunt.</p>
+<p>Donec accumsan nulla id sapien blandit, vitae consequat arcu dapibus.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Quisque vitae felis et est congue venenatis.</p>
+<p>Proin ultricies erat at dolor dignissim, id interdum libero interdum.</p>
+<p>Mauris sit amet risus euismod, vulputate sapien in, facilisis enim.</p>
+<p>Ut nec lorem in neque lacinia pretium sit amet quis lorem.</p>
+<p>Integer et velit id lectus bibendum accumsan sit amet ut lorem.</p>
+<p>Cras non turpis a elit sagittis varius at non odio.</p>
+<p>Suspendisse potenti.</p>
+<p>Etiam facilisis mi a libero fermentum cursus.</p>
+<p>Aliquam convallis est eget magna elementum congue.</p>
+<p>In varius risus vel felis dapibus, id egestas arcu eleifend.</p>
+<p>Nullam ullamcorper magna a magna euismod dictum.</p>
+<p>Morbi convallis velit ut mi tristique, ut tincidunt ligula bibendum.</p>
+<p>Duis bibendum quam at libero rutrum, at tristique lacus rhoncus.</p>
+<p>Donec vitae libero consectetur, pulvinar est sit amet, venenatis turpis.</p>
+<p>Nunc vel ligula sed ipsum fermentum porttitor id vel ex.</p>
+<p>Praesent suscipit erat vitae dolor luctus, id auctor elit consectetur.</p>
+<p id="manifest-4-item-1-scroll-2">(scroll-2) Quisque id libero eget turpis scelerisque efficitur at vel justo.</p>
+<p>Donec nec elit fringilla, suscipit arcu vel, tincidunt metus.</p>
+<p>Ut consequat odio sit amet est tincidunt, id malesuada orci fermentum.</p>
+<p>Fusce aliquam quam nec libero tristique sollicitudin.</p>
+<p>Praesent facilisis nunc eget elit tincidunt, vel laoreet velit sagittis.</p>
+<p>Vivamus feugiat magna nec quam fermentum, et lacinia ligula cursus.</p>
+<p>Aenean suscipit ex vel turpis sagittis vestibulum.</p>
+<p>Donec sit amet lacus nec magna ultricies tempor.</p>
+<p>Phasellus non velit id risus bibendum malesuada.</p>
+<p>Sed nec eros in odio consequat condimentum eu id lectus.</p>
+<p>Integer a magna vel arcu rutrum tristique.</p>
+<p>Cras dictum mi id neque laoreet, sit amet sodales libero pharetra.</p>
+<p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae.</p>
+<p>Ut feugiat sapien nec sem fermentum fermentum.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Donec consectetur justo vel odio cursus, non vulputate metus consequat.</p>
+<p>Ut facilisis nisi ac nisi sollicitudin, a consectetur enim facilisis.</p>
+<p>Sed vulputate justo et massa convallis, at eleifend magna cursus.</p>
+<p>In dignissim nunc ut ante fermentum, id tristique nisl faucibus.</p>
+<p>Vivamus quis elit in lorem mollis facilisis.</p>
+<p>Nullam dapibus magna vel metus venenatis, vel scelerisque lacus cursus.</p>
+<p>Aenean fringilla augue ac sapien fermentum, quis consequat libero pellentesque.</p>
+<p>Maecenas pretium libero et lorem consequat, quis aliquet nulla scelerisque.</p>
+<p>Cras euismod risus a augue vestibulum feugiat.</p>
+<p>Quisque sit amet orci nec mauris feugiat porttitor a vel justo.</p>
+<p>Donec id leo sed felis dignissim tincidunt in nec nunc.</p>
+<p>Suspendisse eget massa nec lectus volutpat tincidunt sed id enim.</p>
+<p>Morbi vestibulum lorem in justo cursus, nec cursus lectus facilisis.</p>
+<p>Pellentesque vehicula lacus sit amet tortor tincidunt volutpat.</p>
+<p>Nam lacinia justo nec ex pellentesque, nec feugiat ipsum dictum.</p>
+<p>Vivamus ut eros vitae tortor consequat fermentum.</p>
+<p>Nulla nec neque non lorem ultrices tempor a sit amet turpis.</p>
+<p>Integer pharetra libero ac lectus dapibus, ut venenatis nisl iaculis.</p>
+<p>Phasellus scelerisque metus in libero euismod, id congue mi condimentum.</p>
+<p>Pellentesque ut odio nec justo venenatis dignissim.</p>
+<p>Donec dapibus nisi a justo convallis, quis euismod neque interdum.</p>
+<p>Aenean fermentum augue at nulla suscipit consequat.</p>
+<p>Ut egestas augue eu augue mollis, in gravida nunc elementum.</p>
+<p>Praesent tristique justo vel risus rhoncus, quis dapibus nunc tempor.</p>
+<p>Integer malesuada nulla sit amet purus ultricies tempor.</p>
+<p>Phasellus non lorem eget mi convallis consequat.</p>
+<p>Quisque tristique urna id lacus aliquam eleifend.</p>
+<p>Vestibulum a massa a mi finibus gravida id at est.</p>
+<p>Aliquam erat volutpat.</p>
+<p>Morbi a erat at tortor tincidunt vestibulum id ac orci.</p>
+<p>Nam sit amet eros nec lorem suscipit condimentum sed sit amet magna.</p>
+<p>Donec id elit nec lacus bibendum pretium.</p>
+<p>Integer eget risus id velit sodales pharetra vel ac neque.</p>
+<p>Pellentesque quis ante a lorem sollicitudin aliquam.</p>
+<p>Morbi nec erat id est egestas faucibus.</p>
+<p>Curabitur pellentesque lorem at magna dapibus, nec dictum nisi dapibus.</p>
+<p>Proin in eros vel nulla convallis pharetra.</p>
+<p>Nullam et lectus eu eros sollicitudin pretium sit amet id lorem.</p>

--- a/tests/mocks/example/textapi/collection.json
+++ b/tests/mocks/example/textapi/collection.json
@@ -1,0 +1,58 @@
+{
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/collection.jsonld",
+  "id": "http://localhost:8181/example/textapi/collection.json",
+  "title": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/title.jsonld",
+      "title": "Example Collection",
+      "type": "main"
+    }
+  ],
+  "collector": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/actor.jsonld",
+      "name": "The TIDO team",
+      "role": [
+        "collector"
+      ],
+      "idref": [
+        {
+          "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/idref.jsonld",
+          "base": "http://d-nb.info/gnd/",
+          "id": "1",
+          "type": "GND"
+        }
+      ]
+    }
+  ],
+  "annotationCollection": "http://localhost:8181/example/annotations/annotationCollection.json",
+  "description": "These annotations represent connections between multiple texts",
+  "sequence": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-1/manifest.json",
+      "label": "First Manifest",
+      "type": "manifest"
+    },
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-2/manifest.json",
+      "label": "Second Manifest",
+      "type": "manifest"
+    },
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-3/manifest.json",
+      "label": "Third Manifest",
+      "type": "manifest"
+    },
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-4/manifest.json",
+      "label": "Fourth Manifest",
+      "type": "manifest"
+    }
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-1/item-1/latest/item.json
+++ b/tests/mocks/example/textapi/manifest-1/item-1/latest/item.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/item.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-1/item-1",
+  "title": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/title.jsonld",
+      "title": "This is the first page",
+      "type": "main"
+    }
+  ],
+  "type": "page",
+  "n": "1",
+  "content": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/content.jsonld",
+      "url": "http://localhost:8181/example/content/transcription/manifest-1-item-1.html",
+      "type": "application/xhtml+xml;type=transcription"
+    }
+  ],
+  "lang": [
+    "eng"
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-1/manifest.json
+++ b/tests/mocks/example/textapi/manifest-1/manifest.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/manifest.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-1",
+  "label": "First Manifest",
+  "metadata": [
+    {
+      "key": "Date of creation",
+      "value": "1417"
+    },
+    {
+      "key": "Place of origin",
+      "value": "unknown"
+    },
+    {
+      "key": "Current location",
+      "value": "Vatican Library, Vatican"
+    },
+    {
+      "key": "TEI document",
+      "value": "[via REST](https://ahikar-dev.sub.uni-goettingen.de/rest/textgrid/data/3r7k7.xml)"
+    }
+  ],
+  "sequence": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-1/item-1/latest/item.json",
+      "label": "Page 1",
+      "type": "item"
+    }
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-2/item-1/latest/item.json
+++ b/tests/mocks/example/textapi/manifest-2/item-1/latest/item.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/item.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-2/item-1",
+  "title": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/title.jsonld",
+      "title": "This is the first page",
+      "type": "main"
+    }
+  ],
+  "type": "page",
+  "n": "1",
+  "content": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/content.jsonld",
+      "url": "http://localhost:8181/example/content/transcription/manifest-2-item-1.html",
+      "type": "application/xhtml+xml;type=transcription"
+    }
+  ],
+  "lang": [
+    "eng"
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-2/manifest.json
+++ b/tests/mocks/example/textapi/manifest-2/manifest.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/manifest.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-2",
+  "label": "First Manifest",
+  "metadata": [
+    {
+      "key": "Date of creation",
+      "value": "1417"
+    },
+    {
+      "key": "Place of origin",
+      "value": "unknown"
+    },
+    {
+      "key": "Current location",
+      "value": "Vatican Library, Vatican"
+    },
+    {
+      "key": "TEI document",
+      "value": "[via REST](https://ahikar-dev.sub.uni-goettingen.de/rest/textgrid/data/3r7k7.xml)"
+    }
+  ],
+  "sequence": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-2/item-1/latest/item.json",
+      "label": "Page 1",
+      "type": "item"
+    }
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-3/item-1/latest/item.json
+++ b/tests/mocks/example/textapi/manifest-3/item-1/latest/item.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/item.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-3/item-1",
+  "title": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/title.jsonld",
+      "title": "This is the first page",
+      "type": "main"
+    }
+  ],
+  "type": "page",
+  "n": "1",
+  "content": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/content.jsonld",
+      "url": "http://localhost:8181/example/content/transcription/manifest-3-item-1.html",
+      "type": "application/xhtml+xml;type=transcription"
+    }
+  ],
+  "lang": [
+    "eng"
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-3/manifest.json
+++ b/tests/mocks/example/textapi/manifest-3/manifest.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/manifest.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-3",
+  "label": "First Manifest",
+  "metadata": [
+    {
+      "key": "Date of creation",
+      "value": "1417"
+    },
+    {
+      "key": "Place of origin",
+      "value": "unknown"
+    },
+    {
+      "key": "Current location",
+      "value": "Vatican Library, Vatican"
+    },
+    {
+      "key": "TEI document",
+      "value": "[via REST](https://ahikar-dev.sub.uni-goettingen.de/rest/textgrid/data/3r7k7.xml)"
+    }
+  ],
+  "sequence": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-3/item-1/latest/item.json",
+      "label": "Page 1",
+      "type": "item"
+    }
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-4/item-1/latest/item.json
+++ b/tests/mocks/example/textapi/manifest-4/item-1/latest/item.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/item.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-4/item-1",
+  "title": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/title.jsonld",
+      "title": "This is the first page",
+      "type": "main"
+    }
+  ],
+  "type": "page",
+  "n": "1",
+  "content": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/content.jsonld",
+      "url": "http://localhost:8181/example/content/transcription/manifest-4-item-1.html",
+      "type": "application/xhtml+xml;type=transcription"
+    }
+  ],
+  "lang": [
+    "eng"
+  ]
+}

--- a/tests/mocks/example/textapi/manifest-4/manifest.json
+++ b/tests/mocks/example/textapi/manifest-4/manifest.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/manifest.jsonld",
+  "textapi": "1.3.0",
+  "x-app-version": "11.4.3",
+  "id": "example/manifest-4",
+  "label": "Fourth Manifest",
+  "metadata": [
+    {
+      "key": "Date of creation",
+      "value": "1417"
+    },
+    {
+      "key": "Place of origin",
+      "value": "unknown"
+    },
+    {
+      "key": "Current location",
+      "value": "Vatican Library, Vatican"
+    },
+    {
+      "key": "TEI document",
+      "value": "[via REST](https://ahikar-dev.sub.uni-goettingen.de/rest/textgrid/data/3r7k7.xml)"
+    }
+  ],
+  "sequence": [
+    {
+      "@context": "https://gitlab.gwdg.de/subugoe/emo/text-api/-/raw/main/jsonld/sequence.jsonld",
+      "id": "http://localhost:8181/example/textapi/manifest-4/item-1/latest/item.json",
+      "label": "Page 1",
+      "type": "item"
+    }
+  ]
+}


### PR DESCRIPTION
New features: 

- new button in top bar to open a "sync" modal 
- in the modal all current panels can be chosen to be in "sync" mode
- once you click confirm in the modal, the "sync" will be enabled and a yellow frame appears around respective panels
- with the yellow frame there are 2 arrow buttons at the top center of each panel
- with enabling "sync" mode all "sync" targets will be highlighted in the texts of each panel with grey background
- also each "sync" panel scrolls in parallel 
- clicking on a "sync" target in each panel with cause the other "sync" panels to scroll to the position of their equivanet target (click target 1 in panel 1 -> scroll to target 1 in panel 2)
- clicking the arrows will cause the same as above but it remembers the active target index, so it can navigate through the target in the panel
- selecting new "sync" panels in the modal will reset all listeners appended previously and reapply them for the new selected "sync" panels

misc:
- refactoring tree files for a better file structure
- not using "Modal" comp for global stree selection but rather a custom fake modal because the trigger button and positioning should be handled by shadcn popover