### PR TITLE
feat: add "fitPanels" config option, control panel widths with flex values

### DIFF
--- a/src/components/panels/Panel.vue
+++ b/src/components/panels/Panel.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="panel t-flex-shrink-0 t-flex t-flex-col t-overflow-hidden t-rounded-lg t-bg-gray-50 dark:t-bg-gray-800
+    class="panel t-flex t-flex-col t-overflow-hidden t-rounded-lg t-bg-gray-50 dark:t-bg-gray-800
     t-border dark:t-border-gray-700 t-max-h-screen md:t-h-auto"
-    :style="{width: `${width}px`}"
+    :style="{ flexBasis, flexGrow, flexShrink }"
   >
     <div class="panel-header t-py-3 t-px-4 t-flex t-justify-between t-items-center">
       <div class="caption t-font-bold">
@@ -127,7 +127,7 @@
 
 <script lang="ts">
 import {
-  computed, nextTick, ref, watch,
+  computed, nextTick, onMounted, onUnmounted, ref, watch,
 } from 'vue';
 import { useI18n } from 'vue-i18n';
 import TabView from 'primevue/tabview';
@@ -176,22 +176,34 @@ export default {
       default: () => { },
     },
     activeView: Number,
-    defaultWidth: Number,
   },
   setup(props, { emit }) {
-    const { isMobile } = useResize();
     const configStore = useConfigStore();
     const contentStore = useContentsStore();
     const { t } = useI18n();
+    const { isMobile, onResize } = useResize();
 
+    const defaultWidth = 300;
     const tabs = ref([]);
     const activeTabIndex = ref(0);
     const unsubscribe = ref(null);
     const isLoading = ref(false);
-
-    const width = computed( () => props.defaultWidth * getWidth(props.panel.width));
+    const flexGrow = ref(1);
+    const flexShrink = ref(1);
+    const flexBasis = ref('0%');
 
     const item = computed<Item>(() => contentStore.item);
+    const config = computed(() => configStore.config);
+
+    let unsubscribeResize;
+
+    onMounted(() => {
+      unsubscribeResize = onResize(() => updateFlexValues(config.value.fitPanels, props.panel.width, isMobile.value));
+    });
+
+    onUnmounted(() => {
+      if (unsubscribeResize) unsubscribeResize();
+    });
 
     watch(
       () => props.activeView,
@@ -210,14 +222,9 @@ export default {
 
     watch(item,() => init(props.panel.views));
 
-    function getWidth(configValue) {
-      if (!configValue || typeof configValue !== 'number') return 1;
-      if (isMobile.value || configValue < 1) return 1;
-      if (configValue > 10) return 10;
-      return configValue;
-    }
-
     function init(views) {
+      updateFlexValues(config.value.fitPanels, props.panel.width, isMobile.value)
+
       tabs.value = [];
       if (unsubscribe.value !== null) unsubscribe.value();
 
@@ -241,6 +248,25 @@ export default {
             return createDefaultView(view);
         }
       });
+    }
+
+    function updateFlexValues(fitPanels: boolean, widthMultiplier: number, isMobile: boolean) {
+      if (fitPanels) {
+        flexBasis.value = '0%';
+        flexGrow.value = getValidatedWidthConfig(widthMultiplier);
+      } else {
+        flexBasis.value = isMobile
+          ? `${90 * getValidatedWidthConfig(widthMultiplier)}vw`
+          : `${defaultWidth * getValidatedWidthConfig(widthMultiplier)}px`;
+        flexShrink.value = 0;
+        flexGrow.value = 1;
+      }
+    }
+
+    function getValidatedWidthConfig(configValue) {
+      if (!configValue || typeof configValue !== 'number') return 1;
+      if (configValue > 10) return 10;
+      return configValue;
     }
 
     function createContentView(view, i) {
@@ -427,7 +453,9 @@ export default {
       isLoading,
       tabs,
       onViewChange,
-      width
+      flexBasis,
+      flexGrow,
+      flexShrink
     };
   },
 };

--- a/src/components/panels/Panel.vue
+++ b/src/components/panels/Panel.vue
@@ -253,6 +253,7 @@ export default {
     function updateFlexValues(fitPanels: boolean, widthMultiplier: number, isMobile: boolean) {
       if (fitPanels) {
         flexBasis.value = '0%';
+        flexShrink.value = 1;
         flexGrow.value = getValidatedWidthConfig(widthMultiplier);
       } else {
         flexBasis.value = isMobile

--- a/src/components/panels/PanelsWrapper.vue
+++ b/src/components/panels/PanelsWrapper.vue
@@ -13,9 +13,8 @@
         :key="`pc${i}`"
         :panel="panel"
         :active-view="getActiveView(i)"
+        class="panel"
         :class="{
-          't-ml-4': i > 0 && panels[i-1].show && !isMobile,
-          't-ml-2': i > 0 && panels[i-1].show && isMobile,
           't-mr-4': i === panels.length - 1 && isMobile
         }"
         @active-view="onActiveViewChange($event, i)"
@@ -50,3 +49,8 @@ function getActiveView(panelIndex) {
   return activeViews.value[panelIndex];
 }
 </script>
+<style>
+.panel +.panel {
+  @apply t-ml-2 lg:t-ml-4;
+}
+</style>

--- a/src/components/panels/PanelsWrapper.vue
+++ b/src/components/panels/PanelsWrapper.vue
@@ -13,7 +13,11 @@
         :key="`pc${i}`"
         :panel="panel"
         :active-view="getActiveView(i)"
-        :class="{ 't-ml-4': i > 0 && !isMobile, 't-ml-2': i > 0 && isMobile, 't-mr-4': i === panels.length - 1 && isMobile }"
+        :class="{
+          't-ml-4': i > 0 && panels[i-1].show && !isMobile,
+          't-ml-2': i > 0 && panels[i-1].show && isMobile,
+          't-mr-4': i === panels.length - 1 && isMobile
+        }"
         @active-view="onActiveViewChange($event, i)"
       />
     </div>

--- a/src/components/panels/PanelsWrapper.vue
+++ b/src/components/panels/PanelsWrapper.vue
@@ -13,7 +13,6 @@
         :key="`pc${i}`"
         :panel="panel"
         :active-view="getActiveView(i)"
-        :default-width="defaultWidth"
         :class="{ 't-ml-4': i > 0 && !isMobile, 't-ml-2': i > 0 && isMobile, 't-mr-4': i === panels.length - 1 && isMobile }"
         @active-view="onActiveViewChange($event, i)"
       />
@@ -22,50 +21,22 @@
 </template>
 
 <script setup>
+import { useResize } from "@/utils/resize.js";
 
-import {computed, onMounted, onUnmounted, ref, useTemplateRef, watch} from 'vue';
+const { isMobile } = useResize();
+
+import { computed, useTemplateRef } from 'vue';
 import { useConfigStore } from '@/stores/config';
 
 import Panel from '@/components/panels/Panel.vue';
-import { useResize } from "@/utils/resize.js";
-
-const { isMobile, onResize } = useResize();
 
 const configStore = useConfigStore();
-
-const panelWrapperPadding = 32;
-const panelMargin = 16;
 
 const panels = computed(() => config.value.panels);
 const config = computed(() => configStore.config);
 const activeViews = computed(() => configStore.activeViews);
 const container = useTemplateRef('container');
-const defaultWidth = ref(300)
 
-let unsubscribe;
-
-const updatePanelWidth = (isMobile) => {
-  if (container.value) {
-    defaultWidth.value = isMobile ? container.value.clientWidth - panelWrapperPadding : container.value.clientWidth / panels.value.filter(({ show }) => !!(show)).length - panelMargin;
-  }
-  return 300;
-}
-
-onMounted(() => {
-  // Call once on init
-  updatePanelWidth(isMobile.value);
-
-  // Call again after each window resize
-  unsubscribe = onResize(updatePanelWidth);
-});
-
-onUnmounted(() => {
-  if (unsubscribe) unsubscribe();
-});
-
-watch(configStore.config, () => {
-  updatePanelWidth(isMobile.value)
-})
 
 function onActiveViewChange(viewIndex, panelIndex) {
   configStore.setActivePanelView(viewIndex, panelIndex);

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -15,6 +15,7 @@ import { i18n } from '@/i18n';
         collection: '',
         manifest: '',
         item: '',
+        fitPanels: true,
         panels: [
           {
             label: 'contents',
@@ -279,6 +280,10 @@ import { i18n } from '@/i18n';
       return isValid;
     }
 
+    function validateFitPanels(value) {
+      return !!(value);
+    }
+
       function createDefaultActiveViews(panelsConfig) {
         return panelsConfig
           .filter((p) => p.views && p.views.length > 0)
@@ -384,7 +389,7 @@ import { i18n } from '@/i18n';
 
     function discoverCustomConfig(customConfig, defaultConfig)  {
         const {
-          container, translations, collection, manifest, item, panels, lang, colors, header, labels
+          container, translations, collection, manifest, item, panels, lang, colors, header, labels, fitPanels
         } = customConfig;
 
         return {
@@ -398,6 +403,7 @@ import { i18n } from '@/i18n';
           ...(validateColors(colors) && { colors }),
           ...(validateHeader(header, defaultConfig.header) && { header }),
           ...(validateLabels(labels, defaultConfig.labels) && { labels }),
+          ...(validateFitPanels(fitPanels) && { fitPanels }),
         };
       }
 

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -281,7 +281,7 @@ import { i18n } from '@/i18n';
     }
 
     function validateFitPanels(value) {
-      return !!(value);
+      return typeof value === 'boolean';
     }
 
       function createDefaultActiveViews(panelsConfig) {


### PR DESCRIPTION
Adding a new config key "fitPanels" at the rool level of config. This boolean controls whether all the configured panels should fit in the container or whether they should keep a certain width (defaultWidth) and make the container overflow. If fitPanels set to true, the "width" key inside each panelConfig behaves differently than with fitPanels = false. 

Test with:
1 Panel - fit:true - null - Desktop
1 Panel - fit:true - 0.5 - Desktop
1 Panel - fit:true - 2 - Desktop
1 Panel - fit:false - null - Desktop
1 Panel - fit:false - 0.5 - Desktop
1 Panel - fit:false - 2 - Desktop
1 Panel - fit:true - null - Mobile
1 Panel - fit:false - 2 - Mobile
2 Panels - fit:true - null 2 - Desktop
2 Panels - fit:true - null 2 - Mobile
4 Panels- fit:true - 0.5 0.5 1 2 - Desktop
4 Panels- fit:true - 0.5 0.5 2 2 - Desktop
4 Panels- fit:true - 0.5 0.5 2 2 - Desktop - toggle different panel show
4 Panels- fit:true - null null null 2 - Desktop
4 Panels- fit:false - 0.5 0.5 2 2 - Desktop
4 Panels- fit:false - null null null 2 - Desktop
4 Panels- fit:false - null null null 2 - Desktop - toggle different panel show
7 Panels- fit:true - null null null 2 null null null - Desktop
7 Panels- fit:false - null null null 2 null null null - Desktop
7 Panels- fit:false - 0.5 5 null 2 null null null - Desktop
4 Panels- fit:true - 0.5 0.5 1 2 - Mobile
4 Panels- fit:true - null null null 2 - Mobile
4 Panels- fit:false - null null null 2 - Mobile
7 Panels- fit:false - 0.5 5 null 2 null null null - Mobile
