### PR TITLE
Translations feat 

### DIFF
--- a/examples/config/4w-local.json
+++ b/examples/config/4w-local.json
@@ -1,6 +1,6 @@
 {
   "showGlobalTree": true,
-  "showNewCollectionButton": true,
+  "showNewCollectionButton": false,
   "theme": {
     "primaryColor": "#1E40AF"
   },

--- a/examples/config/4w-local.json
+++ b/examples/config/4w-local.json
@@ -9,5 +9,14 @@
       "collection": "http://localhost:8181/4w/reproduction/collection.json",
       "manifestIndex": 0
     }
-  ]
+  ],
+  "lang": "en",
+  "translations": {
+    "de": {
+      "sync_panels": "Panels synchronisieren bitte"
+    },
+  "en":  {
+    "sync_panels": "Synchronize panels"
+  }
+  }
 }

--- a/examples/config/4w-local.json
+++ b/examples/config/4w-local.json
@@ -1,6 +1,6 @@
 {
   "showGlobalTree": true,
-  "showNewCollectionButton": false,
+  "showNewCollectionButton": true,
   "theme": {
     "primaryColor": "#1E40AF"
   },
@@ -10,13 +10,5 @@
       "manifestIndex": 0
     }
   ],
-  "lang": "de",
-  "translations": {
-    "de": {
-      "sync_panels": "Panels synchronisieren bitte"
-    },
-  "en":  {
-    "sync_panels": "Synchronize panels"
-  }
-  }
+  "lang": "de"
 }

--- a/examples/config/4w-local.json
+++ b/examples/config/4w-local.json
@@ -10,7 +10,7 @@
       "manifestIndex": 0
     }
   ],
-  "lang": "en",
+  "lang": "de",
   "translations": {
     "de": {
       "sync_panels": "Panels synchronisieren bitte"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "primereact": "^10.8.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^15.4.1",
         "standard-version": "^9.5.0",
         "start-server-and-test": "^2.0.8",
         "tailwind-merge": "^2.5.5",
@@ -281,9 +282,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -5467,6 +5468,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "dev": true,
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
@@ -5549,6 +5559,38 @@
       "dev": true,
       "engines": {
         "node": ">=8.12.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -7913,6 +7955,28 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.4.1.tgz",
+      "integrity": "sha512-ahGab+IaSgZmNPYXdV1n+OYky95TGpFwnKRflX/16dY04DsYYKHtVLjeny7sBSCREEcoMbAgSkFiGLF5g5Oofw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9816,6 +9880,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wait-on": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "primereact": "^10.8.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-i18next": "^15.4.1",
     "standard-version": "^9.5.0",
     "start-server-and-test": "^2.0.8",
     "tailwind-merge": "^2.5.5",

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -1,6 +1,6 @@
 {
   "new": "Neu",
-  "sync_panels": "Panels Synk",
+  "sync_panels": "Panels synchronisieren",
   "place": "Ort",
   "year": "Jahr",
   "author": "Autor",

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -1,0 +1,7 @@
+{
+  "sync_panels": "Panels Synk",
+  "place": "Ort",
+  "year": "Jahr",
+  "author": "Autor",
+  "editor": "Editor"
+}

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -1,4 +1,5 @@
 {
+  "new": "Neu",
   "sync_panels": "Panels Synk",
   "place": "Ort",
   "year": "Jahr",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "new": "New",
+  "sync_panels": "Sync Panels"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect } from 'react'
 import i18n from 'i18next'
 
 import { useConfigStore } from '@/store/ConfigStore.tsx'
@@ -30,22 +30,18 @@ const App: FC<AppProps> = ({ customConfig }) => {
   const { config, errors } = mergeAndValidateConfig(customConfig)
   if (Object.keys(errors).length > 0) console.error(errors)
 
+  initI18n(config.translations)
+  i18n.changeLanguage(config.lang)
+
   createThemeStyles(config)
 
   useConfigStore.getState().addCustomConfig(config)
 
   const collections = useDataStore(state => state.collections)
   const setTreeNodes = useDataStore(state => state.setTreeNodes)
-  const [ready, setReady] = useState(false)
 
 
   useEffect(() => {
-    function initI18nTranslations(translations: Translations) {initI18n(translations)
-      initI18n(translations)
-      i18n.changeLanguage(config.lang)
-      setReady(true)
-    }
-
     async function initTree(collections: CollectionMap) {
       const nodes = await createCollectionNodes(collections)
       if (!nodes) return
@@ -54,10 +50,8 @@ const App: FC<AppProps> = ({ customConfig }) => {
     }
 
     initTree(collections)
-    initI18nTranslations(config.translations)
   }, [collections])
 
-  if (!ready) return <div>Loading ...</div>
 
   return (
     <div className="tido t-flex t-flex-col t-h-full" data-cy="app">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,7 @@ const App: FC<AppProps> = ({ customConfig }) => {
   const { config, errors } = mergeAndValidateConfig(customConfig)
   if (Object.keys(errors).length > 0) console.error(errors)
 
-  initI18n(config.translations)
-  i18n.changeLanguage(config.lang)
+  initI18n(config.translations, config.lang)
 
   createThemeStyles(config)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { FC, useEffect } from 'react'
-import i18n from 'i18next'
 
 import { useConfigStore } from '@/store/ConfigStore.tsx'
 import { useDataStore } from '@/store/DataStore.tsx'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { FC, useEffect } from 'react'
+import { FC, useEffect, useState } from 'react'
+import i18n from 'i18next'
 
 import { useConfigStore } from '@/store/ConfigStore.tsx'
 import { useDataStore } from '@/store/DataStore.tsx'
@@ -11,6 +12,8 @@ import PanelsWrapper from '@/components/PanelsWrapper.tsx'
 import { getRGBColor } from '@/utils/colors.ts'
 import { defaultConfig } from '@/utils/config/default-config.ts'
 import { mergeAndValidateConfig } from '@/utils/config/config.ts'
+import { initI18n } from '@/utils/translations.ts'
+
 
 interface AppProps {
   customConfig: Partial<AppConfig>
@@ -33,8 +36,16 @@ const App: FC<AppProps> = ({ customConfig }) => {
 
   const collections = useDataStore(state => state.collections)
   const setTreeNodes = useDataStore(state => state.setTreeNodes)
+  const [ready, setReady] = useState(false)
+
 
   useEffect(() => {
+    function initI18nTranslations(translations: Translations) {initI18n(translations)
+      initI18n(translations)
+      i18n.changeLanguage(config.lang)
+      setReady(true)
+    }
+
     async function initTree(collections: CollectionMap) {
       const nodes = await createCollectionNodes(collections)
       if (!nodes) return
@@ -43,7 +54,10 @@ const App: FC<AppProps> = ({ customConfig }) => {
     }
 
     initTree(collections)
+    initI18nTranslations(config.translations)
   }, [collections])
+
+  if (!ready) return <div>Loading ...</div>
 
   return (
     <div className="tido t-flex t-flex-col t-h-full" data-cy="app">

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -31,7 +31,7 @@ const TopBar: FC = () => {
       <Modal TriggerButton={<Button data-cy="new-collection">{t('new')}</Button>}>
         <TreeSelectionModalContent />
       </Modal> }
-    <Modal TriggerButton={<Button>{t('sync_panels')}</Button>}>
+    <Modal TriggerButton={<Button data-cy="sync-panels">{t('sync_panels')}</Button>}>
       <SelectParallelPanels />
     </Modal>
   </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { useConfigStore } from '@/store/ConfigStore.tsx'
 
@@ -10,13 +11,13 @@ import { Button } from '@/components/ui/button.tsx'
 import SelectParallelPanels from '@/components/SelectParallelPanels.tsx'
 import { ListCollapse, X } from 'lucide-react'
 
-
 const TopBar: FC = () => {
   const showGlobalTreeConfig = useConfigStore(state => state.config.showGlobalTree)
   const showNewCollectionButton = useConfigStore(state => state.config.showNewCollectionButton)
 
   const setShowGlobalTree = useDataStore(state => state.setShowGlobalTree)
   const isGlobalTreeCollapsed = useDataStore(state => state.showGlobalTree)
+  const { t } = useTranslation()
 
   function toggleGlobalTree() {
     setShowGlobalTree(!isGlobalTreeCollapsed)
@@ -27,10 +28,10 @@ const TopBar: FC = () => {
       { !isGlobalTreeCollapsed ? <ListCollapse /> : <X /> }
     </button>
     { showNewCollectionButton &&
-      <Modal TriggerButton={<Button data-cy="new-collection">New</Button>}>
+      <Modal TriggerButton={<Button data-cy="new-collection">{t('new')}</Button>}>
         <TreeSelectionModalContent />
       </Modal> }
-    <Modal TriggerButton={<Button>Sync Panels</Button>}>
+    <Modal TriggerButton={<Button>{t('sync_panels')}</Button>}>
       <SelectParallelPanels />
     </Modal>
   </div>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -84,7 +84,9 @@ declare global {
     showGlobalTree: boolean
     showNewCollectionButton: boolean
     panels: PanelConfig[]
-    theme: ThemeConfig
+    theme: ThemeConfig,
+    lang: string,
+    translations: Translations
   }
 
   interface Content {
@@ -270,6 +272,14 @@ declare global {
   }
 
   type TitleType = 'main' | 'sub'
+
+  interface Translation {
+    [key: string]: string
+  }
+
+  interface Translations {
+    [key: string]: Translation
+  }
 
   type SuccessResponse<T> = {
     success: true

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -81,7 +81,7 @@ function validateLang(input: any): ValidationResult<AppConfig['lang']> {
         ? input
         : (() => {
           if (input !== undefined)
-            errors['language'] = 'lang must be a string'
+            errors['lang'] = 'lang must be a string'
           return defaultConfig.lang
         })()
   return { result, errors }

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -123,7 +123,7 @@ export function mergeAndValidateConfig(
   const defaultLangs = ['en', 'de']
   const language = getLanguage(lang.result, translations.result, defaultLangs)
   const defaultTranslations =  language === 'en' ? enTranslations : language === 'de' ? deTranslations : {}
-  mergedTranslations[language] = mergeTranslations(defaultTranslations, translations.result?.[language])
+  mergedTranslations[language] = { ...defaultTranslations, ...translations.result?.[language] }
 
 
   const errors = {

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { defaultConfig } from '@/utils/config/default-config.ts'
-import { mergeTranslations } from '@/utils/translations.ts'
 
 import enTranslations from '../../../public/translations/en.json'
 import deTranslations from '../../../public/translations/de.json'

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { defaultConfig } from '@/utils/config/default-config.ts'
+import { mergeTranslations } from '@/utils/translations.ts'
+
+import enTranslations from '../../../public/translations/en.json'
+import deTranslations from '../../../public/translations/de.json'
 
 type ValidationResult<T> = {
   result: T;
@@ -71,6 +75,38 @@ function validateTheme(input: any): ValidationResult<AppConfig['theme']> {
   return { result, errors }
 }
 
+function validateLang(input: any): ValidationResult<AppConfig['lang']> {
+  const errors: Record<string, string> = {}
+  const result =
+      typeof input === 'string'
+        ? input
+        : (() => {
+          if (input !== undefined)
+            errors['language'] = 'lang must be a string'
+          return defaultConfig.lang
+        })()
+  return { result, errors }
+}
+
+function validateTranslations(input: any): ValidationResult<AppConfig['translations']> {
+  const errors: Record<string, string>  = { }
+  const result =
+      typeof input === 'object'
+        ? input
+        : (() => {
+          if (input !== undefined)
+            errors['translations'] = 'translations needs to be an object'
+          return defaultConfig.translations
+        })()
+  return { result, errors }
+}
+
+
+function getLanguage(lang: string, translations: Translations, defaultLangs: string[]): string {
+  if (Object.keys(translations).includes(lang) || defaultLangs.includes(lang)) return lang
+  return 'en'
+}
+
 export function mergeAndValidateConfig(
   userConfig: Partial<AppConfig>,
 ): { config: AppConfig; errors: Record<string, string> } {
@@ -80,13 +116,24 @@ export function mergeAndValidateConfig(
   const showGlobalTree = validateGlobalTree(userConfig.showGlobalTree)
   const showNewCollectionButton = validateShowNewCollectionButton(userConfig.showNewCollectionButton)
   const theme = validateTheme(userConfig.theme)
+  const lang = validateLang(userConfig.lang)
+  const translations = validateTranslations(userConfig.translations)
+
+  const mergedTranslations: Record<string, Translation> = {}
+  const defaultLangs = ['en', 'de']
+  const language = getLanguage(lang.result, translations.result, defaultLangs)
+  const defaultTranslations =  language === 'en' ? enTranslations : language === 'de' ? deTranslations : {}
+  mergedTranslations[language] = mergeTranslations(defaultTranslations, translations.result?.[language])
+
 
   const errors = {
     ...container.errors,
     ...panels.errors,
     ...showGlobalTree.errors,
     ...showNewCollectionButton.errors,
-    ...theme.errors
+    ...theme.errors,
+    ...lang.errors,
+    ...translations.errors,
   }
 
   const config: AppConfig = {
@@ -94,7 +141,9 @@ export function mergeAndValidateConfig(
     panels: panels.result,
     showGlobalTree: showGlobalTree.result,
     showNewCollectionButton: showNewCollectionButton.result,
-    theme: theme.result
+    theme: theme.result,
+    lang: lang.result,
+    translations: mergedTranslations,
   }
 
   return { config, errors }

--- a/src/utils/config/default-config.ts
+++ b/src/utils/config/default-config.ts
@@ -6,6 +6,8 @@ const defaultConfig: AppConfig = {
   theme: {
     primaryColor: '#3456aa'
   },
+  lang: 'en',
+  translations: {}
 }
 
 export {

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -5,7 +5,10 @@ function convertTranslations(translations: Translations) {
   // translations are converted to expected 3 level format: lang, 'translation', key values translation object
   // i.e {
   //      'en': {
-  //          'translation': {'sync_panels': 'Sync Panels'}, {'new': 'New'}
+  //          'translation': {
+  //             'sync_panels': 'Sync Panels',
+  //             'new': 'New'
+  //          }
   //        }
   //     }
   return Object.fromEntries(

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -37,9 +37,5 @@ function initI18n (translations: Translations){
   }
 }
 
-function mergeTranslations(defaultTranslations: Translation, userTranslations: Translation) {
-  return { ...defaultTranslations, ...userTranslations }
-}
 
-
-export  { initI18n, mergeTranslations }
+export  { initI18n }

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -19,7 +19,7 @@ function convertTranslations(translations: Translations) {
   )
 }
 
-function initI18n (translations: Translations){
+function initI18n (translations: Translations, lang: string){
   if (!i18n.isInitialized) {
     const resources = convertTranslations(translations)
 
@@ -28,7 +28,7 @@ function initI18n (translations: Translations){
       .init({
         resources: resources,
         keySeparator: false,
-        lng: 'en',
+        lng: lang,
         fallbackLng: 'en', // Default language if language detection fails
         interpolation: {
           escapeValue: false, // React already does escaping

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -19,8 +19,6 @@ function initI18n (translations: Translations){
       .init({
         resources: resources,
         keySeparator: false,
-        ns: ['translation'], // still needed
-        defaultNS: 'translation',
         lng: 'en',
         fallbackLng: 'en', // Default language if language detection fails
         interpolation: {

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -2,6 +2,12 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 function convertTranslations(translations: Translations) {
+  // translations are converted to expected 3 level format: lang, 'translation', key values translation object
+  // i.e {
+  //      'en': {
+  //          'translation': {'sync_panels': 'Sync Panels'}, {'new': 'New'}
+  //        }
+  //     }
   return Object.fromEntries(
     Object.entries(translations).map(([lang, values]) => [
       lang,

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -1,0 +1,41 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+function convertTranslations(translations: Translations) {
+  return Object.fromEntries(
+    Object.entries(translations).map(([lang, values]) => [
+      lang,
+      { translation: values },
+    ])
+  )
+}
+
+function initI18n (translations: Translations){
+  if (!i18n.isInitialized) {
+    const resources = convertTranslations(translations)
+
+    i18n
+      .use(initReactI18next) // Integrates with React
+      .init({
+        resources: resources,
+        keySeparator: false,
+        ns: ['translation'], // still needed
+        defaultNS: 'translation',
+        lng: 'en',
+        fallbackLng: 'en', // Default language if language detection fails
+        interpolation: {
+          escapeValue: false, // React already does escaping
+        },
+        react: {
+          useSuspense: true, // Suspense support for loading translations
+        },
+      })
+  }
+}
+
+function mergeTranslations(defaultTranslations: Translation, userTranslations: Translation) {
+  return { ...defaultTranslations, ...userTranslations }
+}
+
+
+export  { initI18n, mergeTranslations }

--- a/tests/cypress/e2e/config.cy.js
+++ b/tests/cypress/e2e/config.cy.js
@@ -10,6 +10,8 @@ describe('Config', () => {
     cy.get('[data-cy="new-collection"]').should('have.css', 'background-color', 'rgb(52, 86, 170)')
     cy.get('[data-cy="global-tree-toggle"]').should('be.visible', true)
     cy.get('[data-cy="new-collection"]').should('be.visible', true)
+    cy.get('[data-cy="new-collection"]').should('have.text', 'New')
+    cy.get('[data-cy="sync-panels"]').should('have.text', 'Sync Panels')
   });
 
   // ===== Specific Config Values =====
@@ -22,12 +24,8 @@ describe('Config', () => {
   runConfigTest('showNewCollectionButton=false', 'showNewCollectionButton false', () => {
     cy.get('[data-cy="new-collection"]').should('be.visible', false)
   });
-  runConfigTest('', 'translations: No input for `lang` and `translations` object -> read from default `en` file', () => {
-    cy.get('[data-cy="new-collection"]').should('have.text', 'New')
-    cy.get('[data-cy="sync-panels"]').should('have.text', 'Sync Panels')
-  });
-  runConfigTest('lang=de', 'translations: Provide only `lang`= `de` -> read from default `de` file', () => {
+  runConfigTest('lang=de', 'translations: read from default `de` file', () => {
     cy.get('[data-cy="new-collection"]').should('have.text', 'Neu')
-    cy.get('[data-cy="sync-panels"]').should('have.text', 'Panels Synk')
+    cy.get('[data-cy="sync-panels"]').should('have.text', 'Panels synchronisieren')
   });
 });

--- a/tests/cypress/e2e/config.cy.js
+++ b/tests/cypress/e2e/config.cy.js
@@ -22,4 +22,5 @@ describe('Config', () => {
   runConfigTest('showNewCollectionButton=false', 'showNewCollectionButton false', () => {
     cy.get('[data-cy="new-collection"]').should('be.visible', false)
   });
+
 });

--- a/tests/cypress/e2e/config.cy.js
+++ b/tests/cypress/e2e/config.cy.js
@@ -22,5 +22,12 @@ describe('Config', () => {
   runConfigTest('showNewCollectionButton=false', 'showNewCollectionButton false', () => {
     cy.get('[data-cy="new-collection"]').should('be.visible', false)
   });
-
+  runConfigTest('', 'translations: No input for `lang` and `translations` object -> read from default `en` file', () => {
+    cy.get('[data-cy="new-collection"]').should('have.text', 'New')
+    cy.get('[data-cy="sync-panels"]').should('have.text', 'Sync Panels')
+  });
+  runConfigTest('lang=de', 'translations: Provide only `lang`= `de` -> read from default `de` file', () => {
+    cy.get('[data-cy="new-collection"]').should('have.text', 'Neu')
+    cy.get('[data-cy="sync-panels"]').should('have.text', 'Panels Synk')
+  });
 });


### PR DESCRIPTION
AC:

- Translations should be provided as an object in the TIDO config with keys of different languages.
- There should be two (en, de) translation files
- By default TIDO should take the translations from (en) file
- The translations from the translation file and the translation object in TIDO config should be merged. Translations in TIDO config should override their respective keys in translation file
- TIDO translations file should be delivered in (dist) folder of TIDO