### PR TITLE
Panel resizing

### DIFF
--- a/examples/config/default.json
+++ b/examples/config/default.json
@@ -11,8 +11,7 @@
     "primaryColor": "#1E40AF"
   },
   "rootCollections": [
-    "https://textapi.dev.vierwachen.sub.uni-goettingen.de/api/4w/collection.json",
-    "https://api.dev.ahiqar.sub.uni-goettingen.de/textapi/ahiqar/arabic-karshuni/collection.json"
+    "https://textapi.dev.vierwachen.sub.uni-goettingen.de/api/4w/collection.json"
   ],
   "translations": {
     "de": {

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -37,5 +37,6 @@
   "from_new_collection": "Aus einer neuen Kollektion",
   "from_new_collection_description": "Geben Sie eine neue Collection-URL ein. Sie können anschließend daraus einen Panel-Inhalt wählen.",
   "from_existing_collections": "Aus bestehenden Kollektionen",
-  "from_existing_collections_description": "Wählen Sie aus Kollektionen, die bereits hinzugefügt wurden."
+  "from_existing_collections_description": "Wählen Sie aus Kollektionen, die bereits hinzugefügt wurden.",
+  "remove_panel": "Remove panel"
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -33,5 +33,6 @@
   "from_new_collection": "From new collection",
   "from_new_collection_description": "Enter a new collection URL. From that, you can choose the content for the new panel.",
   "from_existing_collections": "From existing collections",
-  "from_existing_collections_description": "Choose from collections that already have been added."
+  "from_existing_collections_description": "Choose from collections that already have been added.",
+  "remove_panel": "Panel entfernen"
 }

--- a/src/components/PanelsWrapper.tsx
+++ b/src/components/PanelsWrapper.tsx
@@ -7,7 +7,7 @@ import AddPanel from '@/components/panel/AddPanel.tsx'
 const PanelsWrapper: FC = () => {
   const config = useConfigStore(state => state.config)
 
-  return <div className="t-flex-1 t-flex t-h-full t-flex-row t-py-4 t-space-x-4 t-overflow-x-auto" data-cy="panels-wrapper">
+  return <div id="panels-wrapper" className="t-flex-1 t-flex t-h-full t-py-4 t-space-x-4 t-overflow-x-auto" data-cy="panels-wrapper">
     {
       (config.panels ?? [])
         .map((panelConfig, i: number) => (
@@ -16,7 +16,7 @@ const PanelsWrapper: FC = () => {
           </PanelProvider>
         ))
     }
-    { !config.panels.length && <AddPanel /> }
+    <AddPanel />
   </div>
 }
 

--- a/src/components/panel/Actions.tsx
+++ b/src/components/panel/Actions.tsx
@@ -1,0 +1,36 @@
+import { FC, useState } from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { Ellipsis, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+
+
+const Actions: FC = () => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const { remove } = usePanel()
+
+  function removePanel() {
+    remove()
+  }
+  return (
+    <>
+      <Popover open={isOpen} onOpenChange={(value) => setIsOpen(value)}>
+        <PopoverTrigger asChild>
+          <Button className="-t-mr-2" variant="ghost" size="icon">
+            <Ellipsis />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <Button variant="ghostDestructive" onClick={removePanel}>
+            <Trash2 className="t-mr-2" /> { t('remove_panel') }
+          </Button>
+        </PopoverContent>
+      </Popover>
+    </>
+
+  )
+}
+
+export default Actions

--- a/src/components/panel/CollectionTitle.tsx
+++ b/src/components/panel/CollectionTitle.tsx
@@ -11,7 +11,7 @@ const CollectionTitle: FC = () => {
   )
   return (
     <>
-      { !collection && <Skeleton className="t-w-[100px] t-h-6" /> }
+      { !collection && <Skeleton className="t-w-[200px] t-h-6" /> }
       {collection && <div
         className="t-text-sm t-bg-gray-200 t-px-2 t-py-1 t-rounded-md t-font-semibold t-truncate t-max-w-[200px]"
         title={collection.title[0].title}

--- a/src/components/panel/PanelHeader.tsx
+++ b/src/components/panel/PanelHeader.tsx
@@ -9,9 +9,12 @@ import ContentTypesToggle from '@/components/panel/ContentTypesToggle.tsx'
 import CollectionTitle from '@/components/panel/CollectionTitle.tsx'
 import NavigationButton from '@/components/panel/NavigationButton.tsx'
 import Metadata from '@/components/metadata/Metadata'
+import Actions from '@/components/panel/Actions.tsx'
+import { usePanel } from '@/contexts/PanelContext.tsx'
 
 const PanelHeader: FC = () => {
   const [showMetadataModal, setShowMetadataModal] = useState(false)
+  const { panelState } = usePanel()
 
   const handleOpenChange = (open: boolean) => {
     setShowMetadataModal(open)
@@ -22,12 +25,16 @@ const PanelHeader: FC = () => {
       <div className="t-flex t-items-center t-mb-6">
         <CollectionTitle />
 
-        <div className="t-ml-1 t-w-[400px] t-text-wrap t-break-words">
+        <div className="t-ml-1 t-text-wrap t-break-words">
           <Popover open={showMetadataModal} onOpenChange={handleOpenChange} modal={true}>
             <PopoverTrigger asChild>
-              <Button onClick={() => setShowMetadataModal(!showMetadataModal)}
+              <Button
+                onClick={() => setShowMetadataModal(!showMetadataModal)}
                 variant={showMetadataModal ? 'secondary' : 'ghost'}
-                size={'icon'}>{<Info />}
+                size={'icon'}
+                disabled={!panelState?.contentTypes?.length}
+              >
+                {<Info />}
               </Button>
             </PopoverTrigger>
             <PopoverContent side="bottom" align="start"  sideOffset={8} className="t-w-[400px] t-pr-0" >
@@ -36,8 +43,8 @@ const PanelHeader: FC = () => {
             </PopoverContent>
           </Popover>
         </div>
-
-        <TextViewsToggle />
+        <div className="t-ml-auto t-mr-2"><TextViewsToggle /></div>
+        <Actions />
       </div>
       <div className="t-flex t-justify-center t-mb-4">
         <NavigationButton isPrev={true} />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,6 +20,7 @@ const buttonVariants = cva(
           't-bg-gray-300 t-text-gray-900 hover:t-bg-gray-300/80 dark:t-bg-gray-700 dark:t-text-gray-50 dark:hover:t-bg-gray-700/80',
         ghost: 'hover:t-bg-gray-100 hover:t-text-gray-900 dark:hover:t-bg-gray-800 dark:hover:t-text-gray-50',
         ghostAmber: 't-text-amber-700 hover:t-bg-amber-300 hover:t-text-amber-800 dark:hover:t-bg-amber-800 dark:hover:t-text-gray-50',
+        ghostDestructive: 't-text-red-500 hover:t-bg-red-100 hover:t-text-red-600',
         link: 't-text-primary t-underline-offset-4 hover:t-underline dark:t-text-gray-50',
       },
       size: {

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -16,7 +16,7 @@ const PopoverContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      't-z-50 t-rounded-md t-border t-bg-white t-p-4 t-text-gray-950 t-shadow-md t-outline-none data-[state=open]:t-animate-in data-[state=closed]:t-animate-out data-[state=closed]:t-fade-out-0 data-[state=open]:t-fade-in-0 data-[state=closed]:t-zoom-out-95 data-[state=open]:t-zoom-in-95 data-[side=bottom]:t-slide-in-from-top-2 data-[side=left]:t-slide-in-from-right-2 data-[side=right]:t-slide-in-from-left-2 data-[side=top]:t-slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+      't-z-50 t-rounded-md t-border t-bg-white t-p-2 t-text-gray-950 t-shadow-md t-outline-none data-[state=open]:t-animate-in data-[state=closed]:t-animate-out data-[state=closed]:t-fade-out-0 data-[state=open]:t-fade-in-0 data-[state=closed]:t-zoom-out-95 data-[state=open]:t-zoom-in-95 data-[side=bottom]:t-slide-in-from-top-2 data-[side=left]:t-slide-in-from-right-2 data-[side=right]:t-slide-in-from-left-2 data-[side=top]:t-slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
       className
     )}
     {...props}

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -15,6 +15,7 @@ interface PanelContentType {
   error: string | null
   setError: (value: string | null) => void
   updatePanelState: (data: Partial<PanelState>) => void
+  remove: () => void
 }
 
 interface PanelProviderProps {
@@ -32,6 +33,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelConfig, index })
   const getCollection = useDataStore(state => state.initCollection)
   const initPanelState = usePanelStore((state) => state.initPanelState)
   const updateStorePanelState = usePanelStore((state) => state.updatePanelState)
+  const removePanel = usePanelStore(state => state.removePanel)
 
   const panelState = usePanelStore(state => state.getPanelState(panelId))
 
@@ -97,8 +99,14 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelConfig, index })
     return 0
   }
 
+  function remove() {
+    if (!panelId) return
+    removePanel(panelId)
+    useConfigStore.getState().removePanel(index)
+  }
+
   return (
-    <PanelContext.Provider value={{ panelId, panelState, updatePanelState, loading, error, setError }}>
+    <PanelContext.Provider value={{ panelId, panelState, updatePanelState, loading, error, setError, remove }}>
       {children}
     </PanelContext.Provider>
   )

--- a/src/store/ConfigStore.tsx
+++ b/src/store/ConfigStore.tsx
@@ -7,6 +7,7 @@ interface ConfigStoreType {
   addRootCollection: (newRootCollection: string) => void,
   addNewPanel: (newPanelConfig: PanelConfig) => void,
   updatePanel: (newPanelConfig: Partial<PanelConfig>, index: number) => void,
+  removePanel: (index: number) => void
 }
 
 export const useConfigStore = create<ConfigStoreType>((set, get) => ({
@@ -38,6 +39,11 @@ export const useConfigStore = create<ConfigStoreType>((set, get) => ({
       ...newPanelConfig
     }
 
+    set({ config: newConfig })
+  },
+  removePanel: (index: number) => {
+    const newConfig = { ...get().config }
+    newConfig.panels = newConfig.panels.filter((_, i) => i !== index)
     set({ config: newConfig })
   }
 }))

--- a/src/store/PanelStore.tsx
+++ b/src/store/PanelStore.tsx
@@ -18,6 +18,7 @@ interface PanelStoreTypes {
   updateViewIndex: (panelId: string, newViewIndex: number) => void
   getPanelState: (panelId: string | null) => PanelState | null
   setActiveTargetIndex: (panelId: string, index: number) => void
+  removePanel: (panelId: string) => void
 }
 
 function getDefaultPanelState(id: string, index: number): PanelState {
@@ -87,5 +88,20 @@ export const usePanelStore = create<PanelStoreTypes>((set, get) => ({
     const panelState = get().panels[panelId]
     panelState.activeTargetIndex = index
     get().updatePanels(panelId, panelState)
+  },
+  removePanel: (panelId: string) => {
+    const panels = get().panels
+    const updatedPanels = Object
+      .keys(panels)
+      .filter(key => key !== panelId)
+      .reduce((acc, cur) => {
+        acc = {
+          ...acc,
+          [cur]: panels[cur]
+        }
+        return acc
+      }, {} as PanelStates)
+
+    set({ panels: updatedPanels })
   }
 }))

--- a/src/utils/config/default-config.ts
+++ b/src/utils/config/default-config.ts
@@ -9,6 +9,7 @@ const defaultConfig: AppConfig = {
   theme: {
     primaryColor: '#3456aa'
   },
+  title: '',
   translations: {}
 }
 

--- a/tests/cypress/e2e/tree.cy.js
+++ b/tests/cypress/e2e/tree.cy.js
@@ -57,7 +57,8 @@ describe('Tree', () => {
       .should('have.text', 'New Panel')         // click New Panel
       .click()
     cy.get('[data-cy="panels-wrapper"]')  // check whether the item - 280 -  is opened in second panel
-      .children().should('have.length', 2)
+      .find('[data-cy="panel"]')
+      .should('have.length', 2)
       .eq(1)
       .find('[data-cy="item-label"]')
       .should('have.text', 'Page unknown')     // Label is missing
@@ -82,7 +83,8 @@ describe('Tree', () => {
       .click()
 
     cy.get('[data-cy="panels-wrapper"]')  // check whether the item - 280 -  is opened in first panel
-      .children().should('have.length', 1)
+      .find('[data-cy="panel"]')
+      .should('have.length', 1)
       .eq(0)
       .find('[data-cy="item-label"]')
       .should('have.text', 'Page unknown')      // Label is missing


### PR DESCRIPTION
AC:

- on first load the loaded panels grow
- without resizing the first: adding new panel will shrink the first panel so both fit in the container
- with resizing the first: the width of that panel will be memorized and the second panel
    -  adapts when there is still space
    - gets the default width when there is no space (=scrollbar)
- having added 4+ panels (so there is no space anymore = scrollbar) the new panel get a default width, scrollbar stays