### PR TITLE
feat: render panels from panel store instead of config store, avoid m…

### DIFF
--- a/src/components/AddNewCollectionForm.tsx
+++ b/src/components/AddNewCollectionForm.tsx
@@ -6,6 +6,7 @@ import { useConfigStore } from '@/store/ConfigStore.tsx'
 import { createCollectionNode } from '@/utils/tree.ts'
 import { useDataStore } from '@/store/DataStore.tsx'
 import { Button } from '@/components/ui/button.tsx'
+import { usePanelStore } from '@/store/PanelStore.tsx'
 
 interface Props {
   onConfirm?: () => void
@@ -13,7 +14,7 @@ interface Props {
 
 const AddNewCollectionForm: FC<Props> = ({ onConfirm }) => {
   const { t } = useTranslation()
-  const addNewPanel = useConfigStore.getState().addNewPanel
+  const addPanel = usePanelStore(state => state.addPanel)
   const initCollection = useDataStore.getState().initCollection
 
   let inputValue = ''
@@ -25,13 +26,11 @@ const AddNewCollectionForm: FC<Props> = ({ onConfirm }) => {
   async function onConfirmClick() {
     if (inputValue === '') return
 
-    addNewPanel(
-      {
-        collection: inputValue,
-        manifestIndex: 0,
-        itemIndex: 0
-      }
-    )
+    addPanel({
+      collection: inputValue,
+      manifestIndex: 0,
+      itemIndex: 0
+    })
 
     if (!(useConfigStore.getState().config.rootCollections.includes(inputValue))) {
       const newRootNode = await createCollectionNode(inputValue)

--- a/src/components/PanelsWrapper.tsx
+++ b/src/components/PanelsWrapper.tsx
@@ -1,20 +1,27 @@
-import { FC } from 'react'
-
+import { FC, useEffect } from 'react'
 import Panel from '@/components/panel/Panel'
 import { useConfigStore } from '@/store/ConfigStore.tsx'
 import { PanelProvider } from '@/contexts/PanelContext.tsx'
 import AddPanel from '@/components/panel/AddPanel.tsx'
+import { usePanelStore } from '@/store/PanelStore.tsx'
+
+
 const PanelsWrapper: FC = () => {
   const config = useConfigStore(state => state.config)
+  const panels = usePanelStore(state => state.panels)
+  const initializePanels = usePanelStore(state => state.initializePanels)
+
+  useEffect(() => {
+    initializePanels(config.panels)
+  }, [config.panels])
 
   return <div id="panels-wrapper" className="t-flex-1 t-flex t-h-full t-py-4 t-space-x-4 t-overflow-x-auto" data-cy="panels-wrapper">
     {
-      (config.panels ?? [])
-        .map((panelConfig, i: number) => (
-          <PanelProvider panelConfig={panelConfig} index={i} key={i}>
-            <Panel />
-          </PanelProvider>
-        ))
+      panels.map((state) => (
+        <PanelProvider panelId={state.id} key={state.id}>
+          <Panel />
+        </PanelProvider>
+      ))
     }
     <AddPanel />
   </div>

--- a/src/components/panel/ContentTypesToggle.tsx
+++ b/src/components/panel/ContentTypesToggle.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '@/components/ui/skeleton.tsx'
 import { useTranslation } from 'react-i18next'
 
 const ContentTypesToggle: FC = () => {
-  const { panelState, updatePanelState } = usePanel()
+  const { panelState, updatePanel } = usePanel()
   const { t } = useTranslation()
 
   const { contentTypes, contentIndex } = panelState || {}
@@ -15,7 +15,7 @@ const ContentTypesToggle: FC = () => {
     contentIndex: number
   ) {
     e.preventDefault()
-    updatePanelState({ contentIndex })
+    updatePanel({ contentIndex })
   }
 
   if (!panelState || !contentTypes?.length) return <Skeleton className="t-w-[150px] t-h-6" />

--- a/src/components/panel/NavigationButton.tsx
+++ b/src/components/panel/NavigationButton.tsx
@@ -3,76 +3,17 @@ import { Button } from '@/components/ui/button.tsx'
 import { ChevronRight } from 'lucide-react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import { useDataStore } from '@/store/DataStore.tsx'
-import { useConfigStore } from '@/store/ConfigStore.tsx'
 import { apiRequest } from '@/utils/api.ts'
 interface Props {
   isPrev?: boolean
 }
 
-function next(panelState: PanelState) {
-  const { manifest, item, collectionId, index: panelIndex } = panelState || {}
-  if (!collectionId || !manifest || !item) return
-
-  const itemIndex = manifest?.sequence.findIndex(({ id }) => id === item?.id) ?? -1
-
-  if (itemIndex === -1) return
-
-  const nextIndex = itemIndex + 1
-  if (nextIndex > manifest?.sequence.length - 1) {
-    const sequence = useDataStore.getState().collections[collectionId].collection.sequence
-
-    const nextManifestIndex = sequence.findIndex(({ id }) => id === manifest.id) + 1
-    if (nextManifestIndex > sequence.length - 1) return
-
-    useConfigStore.getState().updatePanel({
-      manifestIndex: nextManifestIndex,
-      itemIndex: 0
-    }, panelIndex)
-  } else {
-    useConfigStore.getState().updatePanel({
-      itemIndex: nextIndex
-    }, panelIndex)
-  }
-}
-
-async function prev(panelState: PanelState) {
-  const { manifest, item, collectionId, index: panelIndex } = panelState || {}
-  if (!collectionId || !manifest || !item) return
-
-  const itemIndex = manifest?.sequence.findIndex(({ id }) => id === item?.id) ?? -1
-  if (itemIndex === -1) return
-
-  const prevIndex = itemIndex - 1
-
-  if (prevIndex < 0) {
-    const sequence = useDataStore.getState().collections[collectionId].collection.sequence
-
-    // If the index is lower than 0, we will load the prev manifest's last item
-    const prevManifestIndex = sequence.findIndex(({ id }) => id === manifest.id) - 1
-    if (prevManifestIndex < 0) return
-    const prevManifest = await apiRequest<Manifest>(sequence[prevManifestIndex].id)
-
-    useConfigStore.getState().updatePanel({
-      manifestIndex: prevManifestIndex,
-      itemIndex: prevManifest.sequence.length - 1
-    }, panelIndex)
-  } else {
-    // We load the previous item
-    useConfigStore.getState().updatePanel({
-      itemIndex: prevIndex
-    }, panelIndex)
-  }
-}
-
-
-
 const NavigationButton: FC<Props> = ({ isPrev = false }) => {
-  const { panelState } = usePanel()
+  const { panelState, updatePanel } = usePanel()
 
   function navigate() {
-    if (!panelState) return
-    if (isPrev) prev(panelState)
-    else next(panelState)
+    if (isPrev) prev()
+    else next()
   }
 
   function hasPrev() {
@@ -110,7 +51,73 @@ const NavigationButton: FC<Props> = ({ isPrev = false }) => {
     return true
   }
 
-  return <Button variant="ghost" size="icon" disabled={isPrev ? !hasPrev() : !hasNext()} className={`${isPrev ? 't-rotate-180 t-mr-1' : 't-ml-1'} t-rounded-full t-mt-1`} onClick={navigate}><ChevronRight /></Button>
+  function next() {
+    const { config, manifest, item, collectionId } = panelState || {}
+    if (!collectionId || !manifest || !item) return
+
+    const itemIndex = manifest?.sequence.findIndex(({ id }) => id === item?.id) ?? -1
+
+    if (itemIndex === -1) return
+
+    const nextIndex = itemIndex + 1
+    if (nextIndex > manifest?.sequence.length - 1) {
+      const sequence = useDataStore.getState().collections[collectionId].collection.sequence
+
+      const nextManifestIndex = sequence.findIndex(({ id }) => id === manifest.id) + 1
+      if (nextManifestIndex > sequence.length - 1) return
+
+      updatePanel({ config: {
+        ...config,
+        manifestIndex: nextManifestIndex,
+        itemIndex: 0
+      } })
+    } else {
+      updatePanel({ config: {
+        ...config,
+        itemIndex: nextIndex
+      } })
+    }
+  }
+
+  async function prev() {
+    const { config, manifest, item, collectionId } = panelState || {}
+    if (!collectionId || !manifest || !item) return
+
+    const itemIndex = manifest?.sequence.findIndex(({ id }) => id === item?.id) ?? -1
+    if (itemIndex === -1) return
+
+    const prevIndex = itemIndex - 1
+
+    if (prevIndex < 0) {
+      const sequence = useDataStore.getState().collections[collectionId].collection.sequence
+
+      // If the index is lower than 0, we will load the prev manifest's last item
+      const prevManifestIndex = sequence.findIndex(({ id }) => id === manifest.id) - 1
+      if (prevManifestIndex < 0) return
+      const prevManifest = await apiRequest<Manifest>(sequence[prevManifestIndex].id)
+
+      updatePanel({ config: {
+        ...config,
+        manifestIndex: prevManifestIndex,
+        itemIndex: prevManifest.sequence.length - 1
+      } })
+    } else {
+      // We load the previous item
+      updatePanel({ config: {
+        ...config,
+        itemIndex: prevIndex
+      } })
+    }
+  }
+
+  return <Button
+    variant="ghost"
+    size="icon"
+    disabled={isPrev ? !hasPrev() : !hasNext()}
+    className={`${isPrev ? 't-rotate-180 t-mr-1' : 't-ml-1'} t-rounded-full t-mt-1`}
+    onClick={navigate}>
+    <ChevronRight />
+  </Button>
 }
 
 export default NavigationButton

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -59,7 +59,7 @@ const Panel: FC = React.memo(() => {
   }, [])
 
   useEffect(() => {
-    setIsScrollPanel(panelId ? scrollPanelIds.includes(panelId) : false)
+    setIsScrollPanel(scrollPanelIds.includes(panelId))
   }, [scrollPanelIds, panelId])
 
   useEffect(() => {
@@ -95,7 +95,7 @@ const Panel: FC = React.memo(() => {
 
   return (
     <div
-      id={panelId ?? ''}
+      id={panelId}
       ref={cardRef}
       style={{
         flexGrow: flexValues.flexGrow,

--- a/src/components/panel/PanelBody.tsx
+++ b/src/components/panel/PanelBody.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from 'react'
 
-import { usePanelStore } from '@/store/PanelStore.tsx'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 
 import TextViewOne from '@/components/panel/views/TextViewOne.tsx'
@@ -16,12 +15,9 @@ import Loading from '@/components/ui/loading.tsx'
 
 
 const PanelBody: FC = () => {
-  const { panelId, panelState, loading, error, setError } = usePanel()
+  const { panelState, loading, error, setError } = usePanel()
   const { t } = useTranslation()
-
-  const activeContentTypeIndex = usePanelStore(
-    (state) => panelId && state.panels[panelId] ? state.panels[panelId].contentIndex : 0
-  )
+  const activeContentTypeIndex = panelState.contentIndex
   const [text, setText] = useState<string>('')
 
   function getContentUrlByType(type: string | undefined) {
@@ -40,7 +36,7 @@ const PanelBody: FC = () => {
       }
     }
 
-    if (error || loading) return
+    if (error || loading || !panelState) return
     if (!panelState?.contentTypes.length) {
       setError(t('no_content_found'))
       return
@@ -54,7 +50,7 @@ const PanelBody: FC = () => {
   }, [loading, panelState, activeContentTypeIndex])
 
   function renderContent() {
-    if (error || !panelState) return <ErrorMessage message={error ?? t('unknown_error')} title={t('error_occurred')} />
+    if (error) return <ErrorMessage message={error ?? t('unknown_error')} title={t('error_occurred')} />
     if (loading) return <Loading size={40} />
 
     if (panelState.viewIndex === 0) return <TextViewOne textHtml={text} />

--- a/src/components/panel/TextViewsToggle.tsx
+++ b/src/components/panel/TextViewsToggle.tsx
@@ -22,7 +22,7 @@ const icons = {
 
 const TextViewsToggle: FC = () => {
   const { panelState } = usePanel()
-  const updatePanelState = usePanelStore((state) => state.updatePanelState)
+  const updatePanel = usePanelStore((state) => state.updatePanel)
 
   function handleTextViewClick(
     e: MouseEvent<HTMLButtonElement>,
@@ -30,7 +30,7 @@ const TextViewsToggle: FC = () => {
   ) {
     e.preventDefault()
     if (!panelState) return
-    updatePanelState(panelState.id, { viewIndex: newIndex })
+    updatePanel(panelState.id, { viewIndex: newIndex })
   }
 
   return (

--- a/src/components/tree/TreeSelection.tsx
+++ b/src/components/tree/TreeSelection.tsx
@@ -1,6 +1,5 @@
 import { FC, useRef } from 'react'
 
-import { useConfigStore } from '@/store/ConfigStore'
 import { useDataStore } from '@/store/DataStore'
 import { TreeProvider } from '@/contexts/TreeContext.tsx'
 
@@ -9,6 +8,7 @@ import Tree from '@/components/tree/Tree.tsx'
 import { getChildren, getSelectedItemIndices } from '@/utils/tree.ts'
 import { Button } from '@/components/ui/button.tsx'
 import { useTranslation } from 'react-i18next'
+import { usePanelStore } from '@/store/PanelStore.tsx'
 
 interface Props {
   onConfirm?: () => void
@@ -16,7 +16,7 @@ interface Props {
 
 const TreeSelection: FC<Props> = ({ onConfirm }) => {
   const { t } = useTranslation()
-  const addNewPanel = useConfigStore(state => state.addNewPanel)
+  const addPanel = usePanelStore(state => state.addPanel)
   const treeNodes = useDataStore(state => state.treeNodes)
   const clickedItemUrl = useRef('')
 
@@ -30,7 +30,7 @@ const TreeSelection: FC<Props> = ({ onConfirm }) => {
     if (clickedItemUrl.current) {
       // transfer the clicked item indices
       const { collectionUrl, manifestIndex, itemIndex } = selectedItemIndices.current
-      addNewPanel({
+      addPanel({
         collection: collectionUrl,
         manifestIndex: manifestIndex,
         itemIndex: itemIndex

--- a/src/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx
+++ b/src/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
-import { useConfigStore } from '@/store/ConfigStore.tsx'
 import { useTree } from '@/contexts/TreeContext'
+import { usePanelStore } from '@/store/PanelStore.tsx'
 
 interface SelectedItemIndicesType {
   collectionUrl: string
@@ -15,9 +15,9 @@ interface GlobalTreeSelectionModalContentProps {
 
 const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> = ({ selectedItemIndices, onSelect }) => {
 
-  const panels = useConfigStore(state => state.config.panels)
-  const addNewPanel = useConfigStore(state => state.addNewPanel)
-  const updatePanel = useConfigStore(state => state.updatePanel)
+  const panels = usePanelStore(state => state.panels)
+  const updatePanel = usePanelStore(state => state.updatePanel)
+  const addPanel = usePanelStore(state => state.addPanel)
   const { setSelectedNodeId } = useTree()
 
   const newPanelConfig = {
@@ -27,15 +27,15 @@ const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> 
   }
 
   function select(i?: number) {
-    if (i !== undefined) updatePanel(newPanelConfig, i)
-    else addNewPanel(newPanelConfig)
+    if (i !== undefined) updatePanel(panels[i].id, { config: newPanelConfig })
+    else addPanel(newPanelConfig)
     onSelect()
     setSelectedNodeId('')
   }
 
   let buttonsUpdatePanel
-  if (panels && panels?.length > 0) {
-    buttonsUpdatePanel = panels?.map((_, i) => <button
+  if (panels.length > 0) {
+    buttonsUpdatePanel = panels.map((_, i) => <button
       className="t-bg-slate-200 t-w-20 t-h-8 t-mr-1 t-rounded-md hover:t-bg-slate-300" key={i} data-cy="button-update-panel"
       onClick={() => select(i)}>Panel {i + 1}</button>)
   }

--- a/src/store/ConfigStore.tsx
+++ b/src/store/ConfigStore.tsx
@@ -1,14 +1,11 @@
 import { create } from 'zustand'
 import { defaultConfig } from '@/utils/config/default-config.ts'
-import { PanelConfig, TidoConfig } from '@/types'
+import { TidoConfig } from '@/types'
 
 interface ConfigStoreType {
   config: TidoConfig,
   addCustomConfig: (customConfig: TidoConfig) => void,
   addRootCollection: (newRootCollection: string) => void,
-  addNewPanel: (newPanelConfig: PanelConfig) => void,
-  updatePanel: (newPanelConfig: Partial<PanelConfig>, index: number) => void,
-  removePanel: (index: number) => void
 }
 
 export const useConfigStore = create<ConfigStoreType>((set, get) => ({
@@ -26,25 +23,5 @@ export const useConfigStore = create<ConfigStoreType>((set, get) => ({
         ]
       }
     })
-  },
-  addNewPanel: (newPanelConfig: PanelConfig) => {
-    const newConfig = { ...get().config }
-    newConfig.panels?.push(newPanelConfig)
-
-    set({ config: newConfig })
-  },
-  updatePanel: (newPanelConfig: Partial<PanelConfig>, index: number) => {
-    const newConfig = { ...get().config }
-    if (newConfig.panels) newConfig.panels[index] = {
-      ...newConfig.panels[index],
-      ...newPanelConfig
-    }
-
-    set({ config: newConfig })
-  },
-  removePanel: (index: number) => {
-    const newConfig = { ...get().config }
-    newConfig.panels = newConfig.panels.filter((_, i) => i !== index)
-    set({ config: newConfig })
   }
 }))

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -138,7 +138,6 @@ declare global {
 
   interface PanelState {
     id: string
-    index: number
     collectionId: string | null
     manifest: Manifest | null
     item: Item | null
@@ -147,6 +146,7 @@ declare global {
     viewIndex: number
     imageUrl?: string
     activeTargetIndex: number
+    config: PanelConfig
   }
 
   type ItemType = 'section' | 'page' | 'full'


### PR DESCRIPTION
- panels render from panels store
- each panel gets initialized (generate panel id, set default state) upon config (updates)
- panel context starts off with a panel id instead of generating one on it's own and having a strange "uninitialized" state beforehand
- no (panel) config updates by user interaction
- upon user interaction -> panel store update
- cleaned up panel store -> enforce universal update function
- enforce using panelUpdate function from context in panel components
- cleaned up config store