### PR TITLE
fix: always load default translations (currently en and de)

### DIFF
--- a/src/components/panel/ContentTypesToggle.tsx
+++ b/src/components/panel/ContentTypesToggle.tsx
@@ -30,14 +30,14 @@ const ContentTypesToggle: FC = () => {
       { contentTypes && contentTypes.length > 0 && <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button ref={triggerRef} variant="ghost" size="sm">
-            { contentTypes[contentIndex] }<ChevronDown />
+            { t(contentTypes[contentIndex]) }<ChevronDown />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           <DropdownMenuLabel>{ t('text_type') } </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuRadioGroup value={contentTypes[contentIndex]} onValueChange={handleTextTabClick}>
-            {contentTypes.map((type) => <DropdownMenuRadioItem value={type}>{type}</DropdownMenuRadioItem>) }
+            {contentTypes.map((type) => <DropdownMenuRadioItem value={type}>{ t(type) }</DropdownMenuRadioItem>) }
           </DropdownMenuRadioGroup>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
problem was that when a key was missing in some translation file there was no english fallback as defined in the init function but just the raw key was displayed

adding also de translations by default since it is a language that we fully support and therefore could be used in a automatic language switch