### PR TITLE
Use correctly deep merge for translations

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -13,6 +13,6 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:2222',
     specPattern: 'tests/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'tests/cypress/support/e2e.js',
-    defaultCommandTimeout: 8000
+    defaultCommandTimeout: 4000
   },
 });

--- a/examples/config/bdn.json
+++ b/examples/config/bdn.json
@@ -1,7 +1,7 @@
 {
   "allowNewCollections": false,
   "title": "BDN",
-  "lang": "en",
+  "lang": "de",
   "panels": [
     {
       "collection": "https://bdnportal.d.sub.uni-goettingen.de/api/textapi/griesbach/collection.json"
@@ -15,7 +15,7 @@
   },
   "showPanelPlaceholder": true,
   "translations": {
-    "en": {
+    "de": {
       "common": {
         "contents_and_metadata": "Inhalt & Metadaten",
         "next_item": "Nächste Seite",

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -1,5 +1,7 @@
 {
   "common": {
+    "annotation_collection_error_title": "Fehler in der Annotationssammlung",
+    "annotation_collection_error_message": "Der Inhalt der Annotationssammlung wird nicht korrekt angezeigt im Panel",
     "new": "Neu",
     "sync_panels": "Panels synchronisieren",
     "place": "Ort",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -1,5 +1,7 @@
 {
   "common": {
+    "annotation_collection_error_title": "Error in annotation collection",
+    "annotation_collection_error_message": "Annotation collection content is not provided correctly in panel",
     "new": "New",
     "sync_panels": "Sync Panels",
     "confirm": "Confirm",

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -52,11 +52,12 @@ class CustomError extends Error {
 async function getAnnotations(annotationCollectionUrl: string): Promise<Annotation[]> {
   const collection: AnnotationCollection = await apiRequest<AnnotationCollection>(annotationCollectionUrl)
   if (typeof collection !== 'object' || !Object.hasOwn(collection, 'first')) {
-    throw new CustomError('Annotation collection error', 'Annotation collection content is not provided correctly in panel')
+    throw new CustomError('annotation_collection_error_title', 'annotation_collection_error_message')
   }
   const page = await apiRequest<AnnotationPage>(collection.first)
   return page.items ?? []
 }
+
 
 const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
   const [loading, setLoading] = useState(true)
@@ -68,6 +69,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
   const [showTextOptions, setShowTextOptions] = useState(false)
   const [textWarning, setTextWarning] = useState('')
 
+  const { t } = useTranslation()
   const getCollection = useDataStore(state => state.initCollection)
 
   const panelState = usePanelStore(state => state.getPanel(panelId))
@@ -81,6 +83,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
     const ns = panelState.collectionId ? getCollectionSlug(panelState.collectionId) : 'common'
     return useTranslation(ns)
   }
+
 
   useEffect(() => {
     const showText = panelState.mode !== 'image'
@@ -121,7 +124,8 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
         })
 
       } catch (e) {
-        toast.error(e.name, { description: e.message })
+        const panelNumber = usePanelStore.getState().panels.findIndex(p => p.id === panelId) + 1
+        toast.error(t(e.name), { description: t(e.message) + ' ' + panelNumber.toString() })
       } finally {
         // add a timeout, since loading is finished when updatePanel() is finished
         setTimeout(() => {

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -224,8 +224,8 @@ export function mergeAndValidateConfig(
   const translations = validateTranslations(userConfig.translations)
 
   const mergedTranslations = {
-    en: { ...enTranslations, ...(translations.result.en ?? {}) },
-    de: { ...deTranslations, ...(translations.result.de ?? {}) },
+    en: deepMerge(enTranslations, translations.result.en ?? {}),
+    de: deepMerge(deTranslations, translations.result.de ?? {}),
     ...Object.keys(translations.result)
       .filter(key => key !== 'en' && key !== 'de')
       .reduce((acc, cur) => {
@@ -233,6 +233,7 @@ export function mergeAndValidateConfig(
         return acc
       }, {})
   }
+
 
   const errors = {
     ...allowNewCollections.errors,
@@ -270,3 +271,22 @@ export function mergeAndValidateConfig(
 
   return { config, errors }
 }
+
+function deepMerge(objectA: object, objectB: object) {
+  // deep merge of two given objects
+  // we take initially objectA and iterate on it with the keys of objectB. For same key we override its value from objectB. When a new key is in objectB then we append it to objectA
+  const result = { ...objectA }
+
+  for (const key in objectB) {
+    if (Object.hasOwn(objectB, key)) {
+      if (objectB[key] instanceof Object && objectA[key] instanceof Object) {
+        result[key] = deepMerge(objectA[key], objectB[key])
+      } else {
+        result[key] = objectB[key]
+      }
+    }
+  }
+
+  return result
+}
+

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -117,12 +117,17 @@ describe('Panel', () => {
   })
 
   it('Should switch to next manifest', () => {
-    cy.findPanelTitleAndNavArrows()
-      .should('be.visible')
+    cy.validateLabel('item','Page 279')
+      .click()
+    cy.get('[data-cy="items-dropdown"]')
+      .children()
+      .eq(2)
+      .click()
+      .validateLabel('item','Page 281')
+
+      .findPanelTitleAndNavArrows()
       .find('[data-cy="next-button"]')
-      .click()
-      .click()
-      .click()  // should switch to the first item of Kloserneuburg manifest+
+      .click()  // should switch to the first item of Klosterneuburg manifest
       .validateLabel('manifest', 'Kloster Neuburg, Cod. 251')         // Manifest and item labels should get updated
       .validateLabel('item', '192r')
       .validateText('fol. 192r')                        // Text area should update


### PR DESCRIPTION
Now the translations object is nested, with i.e a key 'common'. In current solution 'common' object of user config would override the 'common' of translations file. However we want instead to merge the values even within 'common' object - deep merge.