### PR TITLE
Read and update annotations in PanelState after updating other Panel states' attributes

### DIFF
--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -94,10 +94,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
         const collection = await getCollection(panelState.config.collection)
         const manifest = await apiRequest<Manifest>(collection.sequence[panelState.config.manifestIndex ?? 0].id)
         const item = await apiRequest<Item>(manifest.sequence[panelState.config.itemIndex ?? 0].id)
-        let annotations = null
-        if (item.annotationCollection) {
-          annotations = await getAnnotations(item.annotationCollection)
-        }
+
         const contentTypes: string[] = getContentTypes(item.content)
 
         const { support } = manifest
@@ -117,8 +114,13 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
           contentTypes,
           activeTargetIndex: -1,
           imageExists,
-          annotations
         })
+
+        let annotations = null
+        if (item.annotationCollection) {
+          annotations = await getAnnotations(item.annotationCollection)
+          updatePanel({ annotations })
+        }
 
       } catch (e) {
         toast.error(e.name, { description: e.message })


### PR DESCRIPTION
- read and update annotations in PanelState after updating other panel states' attributes

an error in annotation collection should not prevent us from updating current Panel State with item, manifest, content types etc

Closes #746