### PR TITLE
feat: add variants display in annotation items, witness filter in sid…

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -69,6 +69,8 @@
     "retry": "Erneut versuchen",
     "text_loading_failed": "Text konnte nicht geladen werden",
     "dismiss": "Verwerfen",
-    "text_not_displayed_correctly": "Der Text wird vermutlich nicht korrekt dargestellt, da er unerlaubte HTML-Elemente enthielt."
+    "text_not_displayed_correctly": "Der Text wird vermutlich nicht korrekt dargestellt, da er unerlaubte HTML-Elemente enthielt.",
+    "witnesses": "Textzeugen",
+    "selected_witnesses": "{{selected}} von {{total}} Textzeugen ausgewählt"
   }
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -65,6 +65,8 @@
     "retry": "Retry",
     "text_loading_failed": "Text loading failed",
     "dismiss": "Dismiss",
-    "text_not_displayed_correctly": "The text is probably not displayed correctly because it contained unallowed HTML elements."
+    "text_not_displayed_correctly": "The text is probably not displayed correctly because it contained unallowed HTML elements.",
+    "witnesses": "Witnesses",
+    "selected_witnesses": "{{selected}} of {{total}} witnesses selected"
   }
 }

--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -118,11 +118,8 @@ const Panel: FC = React.memo(() => {
           <div data-panel-header className={`px-3 pt-3 pb-5 border-r ${showSidebarBorders ? 'border-border' : 'border-transparent'}`}>
             <PanelHeader />
           </div>
-          <div data-header-sidebar className={`absolute top-0 h-full w-[400px] pl-2`}>
-            { showSidebarContent &&
-              <div className="absolute bottom-2">
-                <AnnotationsHeader />
-              </div>
+          <div data-header-sidebar className={`absolute top-0 h-full w-[400px]`}>
+            { showSidebarContent && <AnnotationsHeader />
             }
           </div>
         </div>

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -10,6 +10,7 @@ import {
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import React from 'react'
 import { parseStyleString } from '@/utils/html-to-react.ts'
+import { isSelected } from '@/utils/annotations.ts'
 const END_CLASS = 'tido-text-end'
 
 interface Props {
@@ -66,7 +67,7 @@ const GenericElement = memo(<T extends ElementType>({ tagName: Tag, props, child
         (props.className || '') +
         (isHighlighted ? ' bg-gray-200 relative cursor-pointer' : '') +
         (isHovered ? ' bg-primary/20' : '') +
-        (selectedAnnotation && selectedAnnotation.id === props['data-annotation'] ? ' bg-primary/40' : '')
+        (selectedAnnotation && isSelected(selectedAnnotation.id, props['data-annotation']) ? ' bg-primary/40' : '')
       }
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
@@ -80,7 +81,6 @@ const GenericElement = memo(<T extends ElementType>({ tagName: Tag, props, child
 const convertNodeToReact = (node: HTMLElement, key, matches, onClickTarget) => {
   // Main function to create GenericElement recursively out of HTML nodes.
   // Additional attributes regarding annotations will be applied.
-
 
   if (node.nodeType === Node.TEXT_NODE) {
     return node.textContent

--- a/src/components/panel/annotations/Annotation.tsx
+++ b/src/components/panel/annotations/Annotation.tsx
@@ -1,46 +1,21 @@
 import React, { FC, useRef, useState } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
-import { parseStyleString } from '@/utils/html-to-react.ts'
 import { Badge } from '@/components/ui/badge.tsx'
+import AnnotationContent from '@/components/panel/annotations/AnnotationContent.tsx'
+import VariantContent from '@/components/panel/annotations/VariantContent.tsx'
 
 interface Props {
   data: Annotation
   top: number
 }
 
-const convertNodeToReact = (node, key) => {
-  if (node.nodeType === Node.TEXT_NODE) {
-    return node.textContent
-  }
-
-  if (node.nodeType !== Node.ELEMENT_NODE) return null
-
-  const Tag = node.tagName.toLowerCase()
-  const children = Array.from(node.childNodes).map((child, i) =>
-    convertNodeToReact(child, `${key}-${i}`)
-  )
-
-  const props = {}
-  for (const attr of node.attributes) {
-    if (attr.name === 'style') {
-      props.style = parseStyleString(attr.value)
-    } else {
-      props[attr.name === 'class' ? 'className' : attr.name] = attr.value
-    }
-  }
-
-  return <Tag
-    {...props}
-    className={props.className || ''}
-  >
-    {children}
-  </Tag>
-}
 
 const Annotation: FC<Props> = React.memo(({ data, top }) => {
   const {  setHoveredAnnotation, selectedAnnotation, setSelectedAnnotation } = usePanel()
   const ref = useRef(null)
   const [isHovered, setIsHovered] = useState(false)
+  const type = data.body['x-content-type']
+  const value = data.body.value
 
   function handleClick() {
     setSelectedAnnotation(data)
@@ -63,19 +38,6 @@ const Annotation: FC<Props> = React.memo(({ data, top }) => {
     return selectedAnnotation && selectedAnnotation.id === data.id
   }
 
-  const parsedDom = React.useMemo(() => {
-    const parser = new DOMParser()
-    if (typeof data.body.value !== 'string') return null
-    return parser.parseFromString(`${data.body.value}`, 'text/html')
-  }, [data.body.value])
-
-  const children = React.useMemo(() => {
-    if (!parsedDom) return
-    return Array.from(parsedDom.body.childNodes).map((node, i) =>
-      convertNodeToReact(node, i)
-    )
-  }, [parsedDom])
-
   return <>
     <div
       ref={ref}
@@ -83,14 +45,15 @@ const Annotation: FC<Props> = React.memo(({ data, top }) => {
       {...(isSelected() ? { 'data-selected': true } : {})}
       className={`absolute w-[calc(100%-2rem)] flex flex-col px-3 py-2 rounded-lg border border-border
       ${isSelected() ? 'shadow-md bg-background' : 'bg-accent border-border hover:bg-background cursor-pointer'}
-      ${isHovered ? 'border-primary' : ''} transition-all max-h-16 overflow-hidden`}
+      ${isHovered ? 'border-primary' : ''} transition-all max-h-18 overflow-hidden`}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       style={{ top }}
     >
-      <Badge variant="secondary" className="mb-1">{ data.body['x-content-type'] }</Badge>
-      {children}
+      <Badge variant="secondary" className="mb-1">{ type }</Badge>
+      { type === 'Variant' && <VariantContent value={value as AnnotationVariantValue} /> }
+      { type !== 'Variant' && <AnnotationContent value={value as string} /> }
     </div>
   </>
 })

--- a/src/components/panel/annotations/AnnotationContent.tsx
+++ b/src/components/panel/annotations/AnnotationContent.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from 'react'
+import { parseStyleString } from '@/utils/html-to-react.ts'
+
+interface Props {
+  value: string
+}
+
+const convertNodeToReact = (node, key) => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) return null
+
+  const Tag = node.tagName.toLowerCase()
+  const children = Array.from(node.childNodes).map((child, i) =>
+    convertNodeToReact(child, `${key}-${i}`)
+  )
+
+  const props = {}
+  for (const attr of node.attributes) {
+    if (attr.name === 'style') {
+      props.style = parseStyleString(attr.value)
+    } else {
+      props[attr.name === 'class' ? 'className' : attr.name] = attr.value
+    }
+  }
+
+  return <Tag
+    {...props}
+    className={props.className || ''}
+  >
+    {children}
+  </Tag>
+}
+
+const AnnotationContent: FC<Props> = React.memo(({ value }) => {
+
+  const parsedDom = React.useMemo(() => {
+    const parser = new DOMParser()
+    if (typeof value !== 'string') return null
+    return parser.parseFromString(`${value}`, 'text/html')
+  }, [value])
+
+  const children = React.useMemo(() => {
+    if (!parsedDom) return
+    return Array.from(parsedDom.body.childNodes).map((node, i) =>
+      convertNodeToReact(node, i)
+    )
+  }, [parsedDom])
+
+  return <>
+    <div>{children}</div>
+  </>
+})
+
+export default AnnotationContent

--- a/src/components/panel/annotations/AnnotationFilters.tsx
+++ b/src/components/panel/annotations/AnnotationFilters.tsx
@@ -1,0 +1,34 @@
+import { FC, useEffect, useState } from 'react'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+import AnnotationTypes from '@/components/panel/annotations/AnnotationTypes.tsx'
+import WitnessFilter from '@/components/panel/annotations/WitnessFilter.tsx'
+
+const AnnotationFilters: FC = () => {
+  const [visibleAnnotationTypes, setVisibleAnnotationTypes] = useState<AnnotationTypesDict>({})
+  const { fullAnnotationTypes, matchedAnnotationsMap, panelState } = usePanel()
+  const textAnnotations = panelState.annotations?.length > 0 ? panelState.annotations.filter(a => Object.keys(matchedAnnotationsMap).includes(a.id)) : []
+
+  useEffect(() => {
+    if (Object.keys(fullAnnotationTypes).length === 0) return
+    if (textAnnotations.length === 0) {
+      setVisibleAnnotationTypes([])
+      return
+    }
+    const uniqueAnnotationTypes: string[] = [... new Set(textAnnotations.map((a) => a.body['x-content-type']))]
+    const annotationTypes: AnnotationTypesDict = Object.fromEntries(
+      uniqueAnnotationTypes.map(key => [key, fullAnnotationTypes[key]])
+    )
+    setVisibleAnnotationTypes(annotationTypes)
+  }, [matchedAnnotationsMap])
+
+  function isVisibleType(type: string) {
+    return visibleAnnotationTypes[type] ?? false
+  }
+
+  return <div className="flex flex-col items-center w-100 mt-2">
+    <AnnotationTypes typesMap={visibleAnnotationTypes} />
+    { isVisibleType('Variant') && <div className="mt-2"><WitnessFilter /></div> }
+  </div>
+}
+
+export default AnnotationFilters

--- a/src/components/panel/annotations/AnnotationTypes.tsx
+++ b/src/components/panel/annotations/AnnotationTypes.tsx
@@ -1,0 +1,60 @@
+import { FC, useEffect, useRef, useState } from 'react'
+import AnnotationType from '@/components/panel/annotations/AnnotationType.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface Props {
+  typesMap: AnnotationTypesDict
+}
+
+const AnnotationTypes: FC<Props> = ({ typesMap }) => {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [showButtons, setShowButtons] = useState(false)
+
+  const scroll = (direction: 'left' | 'right') => {
+    if (scrollRef.current) {
+      const { scrollLeft, clientWidth } = scrollRef.current
+      const scrollAmount = direction === 'left' ? -clientWidth : clientWidth
+      scrollRef.current.scrollTo({
+        left: scrollLeft + scrollAmount,
+        behavior: 'smooth',
+      })
+    }
+  }
+
+  const checkScroll = () => {
+    if (scrollRef.current) {
+      const { scrollWidth, clientWidth } = scrollRef.current
+      setShowButtons(scrollWidth > clientWidth)
+    }
+  }
+
+  useEffect(() => {
+    checkScroll()
+  }, [typesMap])
+
+  return <div className="relative flex justify-center w-100 gap-1">
+    { showButtons && <Button
+      variant="ghost"
+      size="icon"
+      className="rounded-full"
+      onClick={() => scroll('left')}
+    >
+      <ChevronLeft className="h-6 w-6" />
+    </Button> }
+    { Object.keys(typesMap).length > 1 && <div ref={scrollRef} data-cy="annotation-types" className="flex flex-nowrap gap-2 overflow-x-auto max-w-[75%]">
+      { Object.keys(typesMap).map((type: string, i) => <AnnotationType type={type} key={'annotation-type-' +i} />)}
+    </div> }
+
+    { showButtons && <Button
+      variant="ghost"
+      size="icon"
+      className=" rounded-full"
+      onClick={() => scroll('right')}
+    >
+      <ChevronRight className="h-6 w-6" />
+    </Button> }
+  </div>
+}
+
+export default AnnotationTypes

--- a/src/components/panel/annotations/AnnotationsHeader.tsx
+++ b/src/components/panel/annotations/AnnotationsHeader.tsx
@@ -1,37 +1,10 @@
-
-import  { FC, useEffect, useState } from 'react'
-import { usePanel } from '@/contexts/PanelContext.tsx'
-import AnnotationType from '@/components/panel/annotations/AnnotationType.tsx'
+import  { FC } from 'react'
+import AnnotationFilters from '@/components/panel/annotations/AnnotationFilters.tsx'
 
 const AnnotationsHeader: FC = () => {
-
-  const { fullAnnotationTypes, matchedAnnotationsMap, panelState } = usePanel()
-  const textAnnotations = panelState.annotations?.length > 0 ? panelState.annotations.filter(a => Object.keys(matchedAnnotationsMap).includes(a.id)) : []
-  const [visibleAnnotationTypes, setVisibleAnnotationTypes] = useState<AnnotationTypesDict>({})
-
-  useEffect(() => {
-    if (Object.keys(fullAnnotationTypes).length === 0) return
-    if (textAnnotations.length === 0) {
-      setVisibleAnnotationTypes([])
-      return
-    }
-    const uniqueAnnotationTypes: string[] = [... new Set(textAnnotations.map((a) => a.body['x-content-type']))]
-    const annotationTypes: AnnotationTypesDict = Object.fromEntries(
-      uniqueAnnotationTypes.map(key => [key, fullAnnotationTypes[key]])
-    )
-    setVisibleAnnotationTypes(annotationTypes)
-
-  }, [matchedAnnotationsMap])
-
-
-
-  if (Object.keys(visibleAnnotationTypes).length > 0) return (
-    <div data-cy="annotations-header" className="flex flex-col items-center">
-      <div data-cy="annotation-types" className="flex gap-2 flex-wrap">
-        { Object.keys(visibleAnnotationTypes).map((type: string, i) => <AnnotationType type={type} key={'annotation-type-' +i} />)}
-      </div>
-    </div>
-  )
+  return <div data-cy="annotations-header" className="flex flex-col items-center p-3">
+    <AnnotationFilters />
+  </div>
 }
 
 export default AnnotationsHeader

--- a/src/components/panel/annotations/VariantContent.tsx
+++ b/src/components/panel/annotations/VariantContent.tsx
@@ -1,0 +1,63 @@
+import React, { FC } from 'react'
+import { parseStyleString } from '@/utils/html-to-react.ts'
+import WitnessChip from '@/components/panel/annotations/WitnessChip.tsx'
+
+interface Props {
+  value: AnnotationVariantValue
+}
+
+const convertNodeToReact = (node, key) => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) return null
+
+  const Tag = node.tagName.toLowerCase()
+  const children = Array.from(node.childNodes).map((child, i) =>
+    convertNodeToReact(child, `${key}-${i}`)
+  )
+
+  const props = {}
+  for (const attr of node.attributes) {
+    if (attr.name === 'style') {
+      props.style = parseStyleString(attr.value)
+    } else {
+      props[attr.name === 'class' ? 'className' : attr.name] = attr.value
+    }
+  }
+
+  return <Tag
+    {...props}
+    className={props.className || ''}
+  >
+    {children}
+  </Tag>
+}
+
+const VariantContent: FC<Props> = React.memo(({ value }) => {
+
+  const parsedDom = React.useMemo(() => {
+    const parser = new DOMParser()
+    if (typeof value === 'string') return null
+    return parser.parseFromString(`${value.entry}`, 'text/html')
+  }, [value])
+
+  const children = React.useMemo(() => {
+    if (!parsedDom) return
+    return Array.from(parsedDom.body.childNodes).map((node, i) =>
+      convertNodeToReact(node, i)
+    )
+  }, [parsedDom])
+
+
+
+  return <div className="flex">
+    <div>{children}</div>
+    <div className="ml-auto flex gap-1">
+      {value.witnesses.map(witness => <WitnessChip idno={witness} />)}
+    </div>
+  </div>
+})
+
+export default VariantContent

--- a/src/components/panel/annotations/WitnessChip.tsx
+++ b/src/components/panel/annotations/WitnessChip.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
+
+interface Props {
+  idno: string
+}
+
+const WitnessChip: FC<Props> = React.memo(({ idno }) => {
+  const { witnesses } = usePanel()
+
+  function getWitnessLabel(idno: string) {
+    return witnesses.find(w => w.idno === idno).idnoAlt ?? 'none'
+  }
+
+  function getWitnessTitle(idno: string) {
+    return witnesses.find(w => w.idno === idno).title ?? 'none'
+  }
+
+  function getWitnessStyle(witnessIdno: string) {
+    const witness = witnesses.find(w => w.idno === witnessIdno)
+    if (!witness) {}
+    return { backgroundColor: witness.bgColor, color: witness.color }
+  }
+
+  return <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="rounded-full h-5 px-2 leading-none flex items-center justify-center bg-muted text-xs font-semibold"
+          style={getWitnessStyle(idno)}
+        >
+          {getWitnessLabel(idno)}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span className="leading-none">{getWitnessTitle(idno)}</span>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+})
+
+export default WitnessChip

--- a/src/components/panel/annotations/WitnessFilter.tsx
+++ b/src/components/panel/annotations/WitnessFilter.tsx
@@ -1,0 +1,59 @@
+import { FC, useEffect } from 'react'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+import {
+  DropdownMenu, DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu.tsx'
+import { Button } from '@/components/ui/button.tsx'
+import { ChevronDown } from 'lucide-react'
+
+const WitnessFilter: FC = () => {
+  const { witnesses, selectedWitnesses, setSelectedWitnesses, usePanelTranslation, matchedAnnotationsMap, setMatchedAnnotationsMap } = usePanel()
+  const { t } = usePanelTranslation()
+
+  function toggleSelectedWitness(witness: WitnessWithColor, checked: boolean) {
+    const selected = [ ...selectedWitnesses ]
+    if (checked) selected.push(witness)
+    else {
+      const index = selected.findIndex(w => w.idno === witness.idno)
+      if (index > -1) selected.splice(index, 1)
+    }
+    // Small timeout before updating selected to reduce friction in the UI
+    setTimeout(() => setSelectedWitnesses(selected), 100)
+  }
+
+  function getSelectedLabel() {
+    return t('selected_witnesses', { selected: selectedWitnesses.length, total: witnesses.length })
+  }
+
+  useEffect(() => {
+    const _matchedAnnotationsMap = { ...matchedAnnotationsMap }
+    Object.keys(_matchedAnnotationsMap).forEach(key => {
+      const { annotation } = _matchedAnnotationsMap[key]
+      if (annotation.body['x-content-type'] !== 'Variant') return
+      _matchedAnnotationsMap[key].filtered = selectedWitnesses.some(selWit => (annotation.body.value as AnnotationVariantValue).witnesses.includes(selWit.idno))
+    })
+    setMatchedAnnotationsMap(_matchedAnnotationsMap)
+  }, [selectedWitnesses])
+
+  return <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <Button variant="outline" size="sm">{ getSelectedLabel() } <ChevronDown className="ml-1 h-6 w-6" /></Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent className="w-56">
+      <DropdownMenuLabel>{ t('witnesses') }</DropdownMenuLabel>
+      { witnesses?.map(witness => <>
+        <DropdownMenuCheckboxItem
+          checked={selectedWitnesses.map(w => w.idno).includes(witness.idno)}
+          onCheckedChange={(checked) => toggleSelectedWitness(witness, checked)}
+        >
+          { witness.title }
+        </DropdownMenuCheckboxItem>
+      </>) ?? <></> }
+    </DropdownMenuContent>
+  </DropdownMenu>
+}
+
+export default WitnessFilter

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -12,6 +12,7 @@ import { PanelResizer } from '@/utils/panel-resizer.ts'
 import { PanelMode } from '@/types'
 import { useTranslation, UseTranslationResponse } from 'react-i18next'
 import { getCollectionSlug } from '@/utils/tree.ts'
+import { setColors } from '@/utils/witness-colors.ts'
 
 const PanelContext = createContext<PanelContentType | undefined>(undefined)
 
@@ -34,7 +35,10 @@ interface PanelContentType {
   showTextOptions: boolean
   usePanelTranslation: () =>  UseTranslationResponse<'common', undefined>
   textWarning: string
-  setTextWarning: (warning: string) => void
+  setTextWarning: (warning: string) => void,
+  witnesses: WitnessWithColor[]
+  selectedWitnesses: WitnessWithColor[]
+  setSelectedWitnesses: (witnesses: WitnessWithColor[]) => void
 }
 
 interface PanelProviderProps {
@@ -49,13 +53,12 @@ class CustomError extends Error {
   }
 }
 
-async function getAnnotations(annotationCollectionUrl: string): Promise<Annotation[]> {
+async function getAnnotationPage(annotationCollectionUrl: string): Promise<AnnotationPage> {
   const collection: AnnotationCollection = await apiRequest<AnnotationCollection>(annotationCollectionUrl)
   if (typeof collection !== 'object' || !Object.hasOwn(collection, 'first')) {
     throw new CustomError('Annotation collection error', 'Annotation collection content is not provided correctly in panel')
   }
-  const page = await apiRequest<AnnotationPage>(collection.first)
-  return page.items ?? []
+  return await apiRequest<AnnotationPage>(collection.first)
 }
 
 const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
@@ -67,6 +70,9 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
   const [selectedAnnotation, setSelectedAnnotation] = useState(null)
   const [showTextOptions, setShowTextOptions] = useState(false)
   const [textWarning, setTextWarning] = useState('')
+  const [witnesses, setWitnesses] = useState<WitnessWithColor[]>([])
+  const [selectedWitnesses, setSelectedWitnesses] = useState<WitnessWithColor[]>([])
+
 
   const getCollection = useDataStore(state => state.initCollection)
 
@@ -95,8 +101,17 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
         const manifest = await apiRequest<Manifest>(collection.sequence[panelState.config.manifestIndex ?? 0].id)
         const item = await apiRequest<Item>(manifest.sequence[panelState.config.itemIndex ?? 0].id)
         let annotations = null
+        let _witnesses = []
         if (item.annotationCollection) {
-          annotations = await getAnnotations(item.annotationCollection)
+          const page = await getAnnotationPage(item.annotationCollection)
+          annotations = page.items ?? []
+          _witnesses = page.refs ?? []
+
+          if (_witnesses.length > 0) {
+            _witnesses = setColors(_witnesses)
+            setWitnesses(_witnesses)
+            setSelectedWitnesses(_witnesses)
+          }
         }
         const contentTypes: string[] = getContentTypes(item.content)
 
@@ -109,7 +124,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
 
         const imageExists = validateImage(item)
 
-        updatePanel( {
+        updatePanel({
           collectionId: collection.id,
           manifest,
           item,
@@ -176,7 +191,10 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
       showTextOptions,
       usePanelTranslation,
       textWarning,
-      setTextWarning
+      setTextWarning,
+      witnesses,
+      selectedWitnesses,
+      setSelectedWitnesses
     }}>
       {children}
     </PanelContext.Provider>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,25 +29,36 @@ declare global {
 
   interface Witness {
     idno: string
-    manifest: string
+    idnoAlt: string
+    title: string
   }
 
+  interface WitnessWithColor extends Witness {
+    bgColor: string
+    color: string
+  }
+
+
   interface Annotation {
-    body: AnnotationContent[]
+    body: AnnotationBody
     target: AnnotationTarget[]
     type: string
     id: string
   }
 
-  interface AnnotationContent {
+  interface AnnotationVariantValue {
+    witnesses: string[],
+    entry: string
+  }
+
+  interface AnnotationBody {
     type: 'TextualBody'
-    value: string | object
+    value: string | AnnotationVariantValue
     format: AnnotationContentFormat
-    'x-content-type': AnnotationContentType
+    'x-content-type': string
   }
 
   type AnnotationContentFormat = 'text/plain' | 'text/html'
-  type AnnotationContentType = 'Person' | 'Place'
 
   interface AnnotationTarget {
     selector: CssSelector | RangeSelector

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -219,8 +219,13 @@ function getFilteredAnnotations(matchedAnnotationsMap: MatchedAnnotationsMap) {
   return Object.values(filteredMatchedAnnotationsMap).map(value => value.annotation)
 }
 
+function isSelected(selectedId: string, attrValue: string) {
+  return attrValue?.split(',').includes(selectedId) ?? false
+}
+
 export {
   setupScrollPanels,
   selectSyncTargetByIndex,
-  getFilteredAnnotations
+  getFilteredAnnotations,
+  isSelected
 }

--- a/src/utils/witness-colors.ts
+++ b/src/utils/witness-colors.ts
@@ -1,0 +1,34 @@
+const witnessColorsCache = {}
+let index = 0
+export function generateWitnessColors(idno: string): string[] {
+  const bgSaturation = 40
+  const bgLightness = 93
+
+  const saturation = 70
+  const lightness = 50
+
+  const goldenAngle = 137.508
+  const hue = (index * goldenAngle) % 360
+
+  index++
+
+  const colorsArr = [
+    `hsl(${hue}, ${bgSaturation}%, ${bgLightness}%)`,
+    `hsl(${hue}, ${saturation}%, ${lightness}%)`
+  ]
+
+  witnessColorsCache[idno] = colorsArr
+
+  return colorsArr
+}
+
+export function setColors(witnesses: Witness[]): WitnessWithColor[] {
+  return witnesses.map(witness => {
+    const [bgColor, color] = witnessColorsCache[witness.idno] ?? generateWitnessColors(witness.idno)
+    return {
+      ...witness,
+      bgColor,
+      color
+    }
+  })
+}


### PR DESCRIPTION
- witness chips appear in annotation items
- tooltip over chips shows full title
- witness filter appears in sidebar header when variants are avaiable
- annotation items + highlighting is toggled on/off when changing the witness filter
- witness filter is persisted across all content inside panel