### PR TITLE
fix: reset text warning on content update, don't overwrite initial panel config at navigation

### DIFF
--- a/src/components/panel/NavigationButton.tsx
+++ b/src/components/panel/NavigationButton.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const NavigationButton: FC<Props> = ({ isPrev = false }) => {
-  const { panelState, updatePanel } = usePanel()
+  const { panelState, init } = usePanel()
 
   function navigate() {
     if (isPrev) prev()
@@ -66,16 +66,16 @@ const NavigationButton: FC<Props> = ({ isPrev = false }) => {
       const nextManifestIndex = sequence.findIndex(({ id }) => id === manifest.id) + 1
       if (nextManifestIndex > sequence.length - 1) return
 
-      updatePanel({ config: {
+      init({
         ...config,
         manifestIndex: nextManifestIndex,
         itemIndex: 0
-      } })
+      })
     } else {
-      updatePanel({ config: {
+      init({
         ...config,
         itemIndex: nextIndex
-      } })
+      })
     }
   }
 
@@ -96,17 +96,17 @@ const NavigationButton: FC<Props> = ({ isPrev = false }) => {
       if (prevManifestIndex < 0) return
       const prevManifest = await apiRequest<Manifest>(sequence[prevManifestIndex].id)
 
-      updatePanel({ config: {
+      init({
         ...config,
         manifestIndex: prevManifestIndex,
         itemIndex: prevManifest.sequence.length - 1
-      } })
+      })
     } else {
       // We load the previous item
-      updatePanel({ config: {
+      init({
         ...config,
         itemIndex: prevIndex
-      } })
+      })
     }
   }
 

--- a/src/components/panel/views/TextView.tsx
+++ b/src/components/panel/views/TextView.tsx
@@ -21,6 +21,7 @@ const TextView: FC = () => {
 
   useEffect(() => {
     async function updateText(contentUrl: string) {
+      setTextWarning('')
       try {
         const response = await apiRequest<string>(contentUrl)
         const cleanHtml = DOMPurify.sanitize(response, { FORBID_TAGS })

--- a/src/components/panel/views/TextViewWarning.tsx
+++ b/src/components/panel/views/TextViewWarning.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button.tsx'
 import { TriangleAlert } from 'lucide-react'
 
 const TextViewWarning: FC = () => {
-  const { textWarning, usePanelTranslation } = usePanel()
+  const { textWarning, setTextWarning, usePanelTranslation } = usePanel()
   const [visible, setVisible] = useState(false)
 
   const { t } = usePanelTranslation()
@@ -17,7 +17,7 @@ const TextViewWarning: FC = () => {
     { visible && <div className="flex bg-amber-100 dark:bg-amber-800 text-amber-700 dark:text-amber-100 items-center p-2 w-full">
       <TriangleAlert size={15} className="shrink-0" />
       <span className="ml-2 mr-3 truncate text-sm" title={textWarning}>{ textWarning }</span>
-      <Button variant="ghostAmber" className="ml-auto" size="sm" onClick={() => setVisible(false)}>{ t('dismiss') }</Button>
+      <Button variant="ghostAmber" className="ml-auto" size="sm" onClick={() => setTextWarning('')}>{ t('dismiss') }</Button>
     </div> }
   </>
 }


### PR DESCRIPTION
- define init function outside of useEffect in panel context
- expose the init function to usePanel
- execute init once at render of panel, pass the config from user 
- execute init at navigation instead of going through updatePanel
- call updatePanel once inside init 
- reset textWarning correctly

result: no double call of updatePanel which caused loading the same data again and probably more problems

(the initial issue was that the text warning did not reset after loading new item)
