### PR TITLE
fix: loading content from a more nested collection

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -85,6 +85,8 @@
     "split": "Split",
     "text": "Text",
     "image": "Bild",
-    "panel_modes": "Panelmodi"
+    "panel_modes": "Panelmodi",
+    "error_collection_url": "Collection URL \"{{url}}\" ist nicht korrekt formatiert.",
+    "unknown_name": "Unbekannter Name"
   }
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -81,6 +81,8 @@
     "split": "Split",
     "text": "Text",
     "image": "Image",
-    "panel_modes": "Panel modes"
+    "panel_modes": "Panel modes",
+    "error_collection_url": "Collection URL \"{{url}}\" is not formatted correctly.",
+    "unknown_name": "Unknown name"
   }
 }

--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -11,17 +11,15 @@ interface TreeNodeProps {
 }
 
 const TreeNode: FC<TreeNodeProps> = ({ node }) => {
-  const [isExpanded, setIsExpanded] = useState(node.expanded)
   const { onSelect, getChildren, selectedNodeId, setSelectedNodeId } = useTree()
-
   const { t } = useTranslation()
-
+  const [isExpanded, setIsExpanded] = useState(node.expanded)
   const [showEmptyNode, setShowEmptyNode] = useState(false)
 
   async function handleNodeClick(e: MouseEvent<HTMLElement>) {
     e.preventDefault()
 
-    if (!node.expanded)  node.children = [...await getChildren(node)]
+    if (!node.expanded && !node.leaf) node.children = [...await getChildren(node)]
 
     if (node.children.length > 0) {
       toggleExpand()
@@ -35,22 +33,18 @@ const TreeNode: FC<TreeNodeProps> = ({ node }) => {
       return
     }
 
-
     onSelect(node, e.target as HTMLElement)
     setSelectedNodeId(node.id)
   }
-
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded)
   }
 
-
   return <div className="mb-1">
-    <div
-      data-cy="tree-node"
-    >
-      <div className={`flex items-start px-2 py-1 rounded-md cursor-pointer ${ selectedNodeId === node.id ? 'bg-muted border border-border active' : 'hover:bg-accent' }`}
+    <div data-cy="tree-node" data-node-key={node.key}>
+      <div
+        className={`flex items-start px-2 py-1 rounded-md cursor-pointer ${ selectedNodeId === node.id ? 'bg-muted border border-border active' : 'hover:bg-accent' }`}
         onClick={(e) => handleNodeClick(e)}
       >
         {!node.leaf && <span className={`mt-1 transition-all ${isExpanded && 'rotate-90'}`}><ChevronRight size={18} /></span>}

--- a/src/store/DataStore.tsx
+++ b/src/store/DataStore.tsx
@@ -1,6 +1,8 @@
 import { create } from 'zustand'
 import { apiRequest } from '@/utils/api.ts'
 import { getCollectionSlug } from '@/utils/tree.ts'
+import { isCollectionUrl } from '@/utils/api-validate.ts'
+import { getI18n } from 'react-i18next'
 
 
 interface AnnotationMap {
@@ -29,8 +31,9 @@ export const useDataStore = create<DataStoreType>((set, get) => ({
   showGlobalTree: false,
   initCollection: async (url: string) => {
     if (url in get().collections) return get().collections[url].collection
-
+    const { t } = getI18n()
     try {
+      if (!isCollectionUrl(url)) throw t('error_collection_url', { url })
       const collection = await apiRequest<Collection>(url)
 
       // TODO: we need to check if this collection is already in treeCollections or child of existing treeCollections data

--- a/src/utils/api-validate.ts
+++ b/src/utils/api-validate.ts
@@ -1,0 +1,12 @@
+function isCollectionUrl(url: string) {
+  return url.includes('collection.json')
+}
+
+function isManifestUrl(url: string) {
+  return url.includes('manifest.json')
+}
+
+export {
+  isCollectionUrl,
+  isManifestUrl
+}


### PR DESCRIPTION
a small fix on loading data:

- on node click we now init collections
- so it is not "undefined" when trying to load the item into a panel

an issue still persists:

- the collection slugs are ambiguous, e.g. in bdn "a/erster-band" and "b/erster-band"
- at node select we compare the slugs

mathias said the collection slugs have to be unique, so for bdn a backend change is needed. 
though, we might need a better mechanism anyways since the uniqueness of slugs may not be a convention everywhere.