### PR TITLE
Bug panel modes

### DIFF
--- a/src/components/header/AddNewPanel.tsx
+++ b/src/components/header/AddNewPanel.tsx
@@ -8,12 +8,10 @@ import { useTranslation } from 'react-i18next'
 import AddNewCollectionForm from '@/components/AddNewCollectionForm.tsx'
 import TreeSelection from '@/components/tree/TreeSelection.tsx'
 import { useConfigStore } from '@/store/ConfigStore.tsx'
-import { useUIStore } from '@/store/UIStore.tsx'
 
 const AddNewPanel: FC = () => {
   const title = useConfigStore(state => state.config.title)
   const allowNewCollections = useConfigStore(state => state.config.allowNewCollections)
-  const enabledSelectTextView = useUIStore(state => state.enabledSelectPanelMode)
 
   const { t } = useTranslation()
 
@@ -31,7 +29,6 @@ const AddNewPanel: FC = () => {
 
   function onConfirmNewCollectionForm() {
     setShowDialog(false)
-    if (enabledSelectTextView) useUIStore.getState().updateShowSelectPanelMode(true)
   }
 
   function renderTriggerButton() {

--- a/src/components/panel/AddPanel.tsx
+++ b/src/components/panel/AddPanel.tsx
@@ -4,16 +4,13 @@ import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog.tsx'
 import TreeSelection from '@/components/tree/TreeSelection.tsx'
-import { useUIStore } from '@/store/UIStore.tsx'
 
 const AddPanel: FC = () => {
   const { t } = useTranslation()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const enabledSelectTextView = useUIStore(state => state.enabledSelectPanelMode)
 
   function onConfirm() {
     setIsDialogOpen(false)
-    if (enabledSelectTextView) useUIStore.getState().updateShowSelectPanelMode(true)
   }
 
   return (

--- a/src/components/tree/TreeSelection.tsx
+++ b/src/components/tree/TreeSelection.tsx
@@ -11,6 +11,8 @@ import { useTranslation } from 'react-i18next'
 import { usePanelStore } from '@/store/PanelStore.tsx'
 import { useUIStore } from '@/store/UIStore.tsx'
 
+import { showSelectPanelModeModalIfNeeded } from '@/utils/panel.ts'
+
 interface Props {
   onConfirm?: () => void
 }
@@ -36,11 +38,14 @@ const TreeSelection: FC<Props> = ({ onConfirm }) => {
       const { collectionUrl, manifestIndex, itemIndex } = selectedItemIndices.current
       const newPanelId = crypto.randomUUID()
       useUIStore.getState().updateNewestPanelId(newPanelId)
-      addPanel({
+      const newPanelConfig = {
         collection: collectionUrl,
         manifestIndex: manifestIndex,
         itemIndex: itemIndex
-      }, newPanelId)
+      }
+
+      await showSelectPanelModeModalIfNeeded(newPanelConfig)
+      addPanel(newPanelConfig, newPanelId)
     }
 
     if (onConfirm) onConfirm()

--- a/src/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx
+++ b/src/components/tree/tree-modal/GlobalTreeSelectionModalContent.tsx
@@ -3,6 +3,8 @@ import { useTree } from '@/contexts/TreeContext'
 import { usePanelStore } from '@/store/PanelStore.tsx'
 import { useUIStore } from '@/store/UIStore.tsx'
 
+import { showSelectPanelModeModalIfNeeded } from '@/utils/panel.ts'
+
 interface SelectedItemIndicesType {
   collectionUrl: string
   manifestIndex: number
@@ -19,7 +21,6 @@ const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> 
   const panels = usePanelStore(state => state.panels)
   const updatePanel = usePanelStore(state => state.updatePanel)
   const addPanel = usePanelStore(state => state.addPanel)
-  const enabledSelectPanelMode = useUIStore(state => state.enabledSelectPanelMode)
 
   const { setSelectedNodeId } = useTree()
 
@@ -29,15 +30,15 @@ const GlobalTreeSelectionModalContent: FC<GlobalTreeSelectionModalContentProps> 
     itemIndex: selectedItemIndices.itemIndex
   }
 
-  function select(i?: number) {
+  async function select(i?: number) {
     if (i !== undefined) {
       updatePanel(panels[i].id, { config: newPanelConfig })
     } else {
       const newPanelId = crypto.randomUUID()
       useUIStore.getState().updateNewestPanelId(newPanelId)
-      addPanel(newPanelConfig, newPanelId)
 
-      if (enabledSelectPanelMode) useUIStore.getState().updateShowSelectPanelMode(true)
+      await showSelectPanelModeModalIfNeeded(newPanelConfig)
+      addPanel(newPanelConfig, newPanelId)
     }
 
     onSelect()

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -4,7 +4,8 @@ import { defaultConfig } from '@/utils/config/default-config.ts'
 
 import enTranslations from '../../../public/translations/en.json'
 import deTranslations from '../../../public/translations/de.json'
-import { TidoConfig, PanelMode } from '@/types'
+import { TidoConfig, PanelMode, PanelConfig } from '@/types'
+import { apiRequest } from '@/utils/api.ts'
 
 type ValidationResult<T> = {
   result: T;
@@ -305,3 +306,9 @@ function deepMerge(objectA: object, objectB: object) {
   return result
 }
 
+export async function existsImageInNewItem(config: PanelConfig) {
+  const collection = await apiRequest<Collection>(config.collection)
+  const manifest = await apiRequest<Manifest>(collection.sequence[config.manifestIndex].id)
+  const item = await apiRequest<Item>(manifest.sequence[config.itemIndex].id)
+  return !!item.image
+}

--- a/src/utils/panel.ts
+++ b/src/utils/panel.ts
@@ -3,6 +3,9 @@ import { usePanelStore } from '@/store/PanelStore.tsx'
 import { PanelModeButtonData, PanelConfig } from '@/types'
 import { useUIStore } from '@/store/UIStore.tsx'
 import { useDataStore } from '@/store/DataStore.tsx'
+import { useConfigStore } from '@/store/ConfigStore.tsx'
+
+import { existsImageInNewItem } from '@/utils/config/config.ts'
 
 export const DEFAULT_PANEL_WIDTH = 600
 export const MIN_PANEL_WIDTH = 600
@@ -103,4 +106,12 @@ export async function createNewPanel(collectionId: string, manifest: Manifest, i
 
   useUIStore.getState().updateNewestPanelId(newPanelId)
   await usePanelStore.getState().addPanel(newPanelConfig, newPanelId)
+}
+
+export async function showSelectPanelModeModalIfNeeded(newConfig: PanelConfig) {
+  const existsImage = await existsImageInNewItem(newConfig)
+  const showModal = existsImage && useUIStore.getState().enabledSelectPanelMode && useConfigStore.getState().config.panelModes.length > 1
+  if (showModal) {
+    useUIStore.getState().updateShowSelectPanelMode(true)
+  }
 }


### PR DESCRIPTION
When user opens a new panel from tree selection it might be the case that the new item has no 'image' as part of TextAPI content. In order to tackle this, for each new item selection in tree I check additionally if it contains image. If not, then we do not show the Modal. 

Closes #777 