### PR TITLE
Update panel config in update panel

### DIFF
--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -124,7 +124,8 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId }) => {
         mode: getPanelMode(imageExists, 'text'),
         contentTypes,
         activeTargetIndex: -1,
-        imageExists
+        imageExists,
+        config
       })
 
       // initialize AnnotationsMode


### PR DESCRIPTION
When navigating to new item (NavigationButton component) and the item is in the same manifest, one updates only the itemIndex. However the manifestIndex should be up to date. Please see in NavigationButton component, line 76, it expects the config to have the latest manifestIndex. 
To ensure this we update config in updatePanel.

Closes #778 