### PR TITLE
Set max width to manifest/item label popovers

### DIFF
--- a/src/components/panel/ItemLabel.tsx
+++ b/src/components/panel/ItemLabel.tsx
@@ -96,7 +96,7 @@ const ItemLabel: FC<ItemLabelProps> = ({ selectedManifest, onItemSelect }) => {
           { getItemLabel() }
         </div>
       </DropdownMenuTrigger>
-      <DropdownMenuContent data-cy="items-dropdown">
+      <DropdownMenuContent data-cy="items-dropdown" className="max-w-80">
         {labels.map((label, i) => <DropdownMenuItem
           key={label + '_'+i}
           className={`cursor-pointer ${panelState.item.n === label ? 'data-[highlighted]:text-primary text-primary' : ''} `}

--- a/src/components/panel/ManifestLabel.tsx
+++ b/src/components/panel/ManifestLabel.tsx
@@ -50,7 +50,7 @@ const ManifestLabel: FC<ManifestLabelProps> = ({ selectedManifest, onManifestSel
           {selectedLabel}
         </div>
       </DropdownMenuTrigger>
-      <DropdownMenuContent data-cy="manifests-dropdown">
+      <DropdownMenuContent data-cy="manifests-dropdown" className="max-w-80">
         {labels.map((label, i) => <DropdownMenuItem
           key={label + '_'+i}
           className={`cursor-pointer ${panelState.manifest.label === label ? 'text-primary' : ''} `}


### PR DESCRIPTION
I noticed in bdn for noesselt/critical/erster band for a long manifest label the popover becomes too wide.
Therefore we can restrict its max width.