### PR TITLE
fix: prevent text loading screen to overflow

### DIFF
--- a/src/components/panel/Panel.tsx
+++ b/src/components/panel/Panel.tsx
@@ -9,16 +9,14 @@ import ScrollPanelMenu from '@/components/panel/ScrollPanelMenu.tsx'
 import { GripVertical } from 'lucide-react'
 import SelectPanelModeDialog from '@/components/panel/select-panel-mode/SelectPanelModeDialog.tsx'
 import ImageView from '@/components/panel/views/ImageView.tsx'
-import TextView from '@/components/panel/views/TextView.tsx'
 import Swapper from '@/components/panel/Swapper.tsx'
 import TextOptions from '@/components/panel/TextOptions.tsx'
 import AnnotationsHeader from '@/components/panel/annotations/AnnotationsHeader.tsx'
 import TextViewWarning from '@/components/panel/views/TextViewWarning.tsx'
-import TextViewError from '@/components/panel/views/TextViewError.tsx'
-import { ErrorBoundary } from 'react-error-boundary'
 import AnnotationsView from '@/components/panel/annotations/AnnotationsView.tsx'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 import { TextProvider } from '@/contexts/TextContext.tsx'
+import TextViewContainer from '@/components/panel/views/TextViewContainer.tsx'
 
 const Panel: FC = React.memo(() => {
   const { panelId, panelState, initResizer, resizer, showTextOptions, setShowTextOptions, annotationsMode } = usePanel()
@@ -147,11 +145,7 @@ const Panel: FC = React.memo(() => {
           </div>
           <div data-scroll-container className={`h-full w-full bg-muted relative ${annotationsMode === 'align' ? 'overflow-x-hidden overflow-y-auto' : '' }`}>
             <TextProvider>
-              <div data-text-container className={`bg-background p-3 pr-5 min-h-[calc(100%+1px)] relative flex border-r
-                  ${showSidebarBorders ? 'border-border' : 'border-transparent'} ${showTextOptions ? 'pt-16' : ''}
-                  ${annotationsMode === 'list' ? 'overflow-x-hidden overflow-y-auto' : ''} `}>
-                {showText && <ErrorBoundary FallbackComponent={TextViewError} resetKeys={[panelState.item?.id]}><TextView /></ErrorBoundary>}
-              </div>
+              <TextViewContainer showText={showText} showSidebarBorders={showSidebarBorders} />
               <div data-sidebar-container className={`absolute top-0 h-full w-[400px] px-2 ${annotationsMode === 'list' ? 'overflow-x-hidden overflow-y-auto' : ''}`}>
                 {showSidebarContent && <AnnotationsView />}
               </div>

--- a/src/components/panel/views/TextView.tsx
+++ b/src/components/panel/views/TextView.tsx
@@ -5,15 +5,16 @@ import { usePanel } from '@/contexts/PanelContext.tsx'
 import DOMPurify from 'dompurify'
 import { useErrorBoundary } from 'react-error-boundary'
 import Loading from '@/components/ui/loading.tsx'
+import { useText } from '@/contexts/TextContext.tsx'
 
 const FORBID_TAGS = ['input', 'script', 'noscript', 'iframe', 'frame', 'frameset', 'noframes', 'applet', 'base', 'meta', 'form']
 
 const TextView: FC = () => {
   const { panelState, usePanelTranslation, setTextWarning, loading: loadingPanel } = usePanel()
+  const { loadingText, setLoadingText } = useText()
   const { t } = usePanelTranslation()
   const { showBoundary } = useErrorBoundary()
   const [text, setText] = useState<string>('')
-  const [loading, setLoading] = useState(false)
 
   const activeContentTypeIndex = panelState.contentIndex
   function getContentUrlByType(type: string | undefined) {
@@ -38,7 +39,7 @@ const TextView: FC = () => {
     }
 
     if (loadingPanel || !panelState) {
-      setLoading(true)
+      setLoadingText(true)
       return
     }
 
@@ -55,11 +56,11 @@ const TextView: FC = () => {
   }, [loadingPanel, panelState?.contentTypes, activeContentTypeIndex])
 
   function onReady() {
-    setLoading(false)
+    setLoadingText(false)
   }
 
   return <>
-    { loading && <div className="absolute z-10 bg-background left-0 top-0 w-full h-full">
+    { loadingText && <div className="absolute z-10 bg-background left-0 top-0 w-full h-full">
       <Loading size={36} />
     </div> }
     <TextRenderer htmlString={text} onReady={onReady} />

--- a/src/components/panel/views/TextViewContainer.tsx
+++ b/src/components/panel/views/TextViewContainer.tsx
@@ -1,0 +1,28 @@
+import { ErrorBoundary } from 'react-error-boundary'
+import TextViewError from '@/components/panel/views/TextViewError.tsx'
+import TextView from '@/components/panel/views/TextView.tsx'
+import { FC } from 'react'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+import { useText } from '@/contexts/TextContext.tsx'
+
+interface Props {
+  showText: boolean
+  showSidebarBorders: boolean
+}
+const TextViewContainer: FC<Props> = ({ showText, showSidebarBorders }) => {
+  const { panelState, annotationsMode, showTextOptions } = usePanel()
+  const { loadingText } = useText()
+
+  return <div
+    data-text-container
+    className={`bg-background p-3 pr-5 relative flex border-r overflow-x-auto
+      ${showSidebarBorders ? 'border-border' : 'border-transparent'} ${showTextOptions ? 'pt-16' : ''}
+      ${annotationsMode === 'list' ? 'overflow-y-auto' : ''}
+      ${loadingText ? 'overflow-hidden min-h-full h-full' : 'min-h-[calc(100%+1px)]'} `}
+  >
+    {showText &&
+      <ErrorBoundary FallbackComponent={TextViewError} resetKeys={[panelState.item?.id]}><TextView /></ErrorBoundary>}
+  </div>
+}
+
+export default TextViewContainer

--- a/src/contexts/TextContext.tsx
+++ b/src/contexts/TextContext.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext, useState } from 'react'
 type TextProviderState = {
   hoveredAnnotation: string | null
   setHoveredAnnotation: (value: string | null) => void
+  loadingText: boolean
+  setLoadingText: (value: boolean) => void
 }
 
 const TextProviderContext = createContext<TextProviderState>(null)
@@ -12,11 +14,14 @@ export const TextProvider = ({
 }) => {
 
   const [hoveredAnnotation, setHoveredAnnotation] = useState(null)
+  const [loadingText, setLoadingText] = useState(false)
 
   return (
     <TextProviderContext.Provider value={{
       hoveredAnnotation,
-      setHoveredAnnotation
+      setHoveredAnnotation,
+      loadingText,
+      setLoadingText
     }}>
       {children}
     </TextProviderContext.Provider>


### PR DESCRIPTION
1. Start 4w-local
2. Inspect text loading state

Loading spinner sits in the middle of text container. If its loonger than the panel height, the spinner sits far more below. In case of long texts (like BDN) the spinner will sit in the middle of that -> possibly not visible at all. 

This PR fixes that. Moving everything text-related to TextViewContainer component. Moving loading to TextProvider. Disabling scrolling of text container during loading (known trick for example for <body>-overflow during visible modals). 

Pay attention to general "overflow-x-auto" on text-container instead of "overflow-x-hidden" at list mode. Fixes two things at once: Overflow of fixed width layouts of texts (4W is the right case, the text width is 600px and would be cut at small panel size -> known bug), overflow issues in annotations list mode.  