### PR TITLE
test: add config tests for rootCollections, showGlobalTree and panel markers in tree

### DIFF
--- a/src/components/tree/OpenedIcon.tsx
+++ b/src/components/tree/OpenedIcon.tsx
@@ -33,6 +33,7 @@ const OpenedIcon: FC<Props> = ({ panelsNumbers, nodeType }) => {
     <Tooltip>
       <TooltipTrigger asChild>
         <div
+          data-cy="tree-node-marker"
           className="bg-primary w-2 h-2 hover:scale-130 transition-all duration-200 rounded-full"
           onClick={(e) => scrollToPanel(e)}
         ></div>

--- a/tests/cypress/e2e/config.cy.js
+++ b/tests/cypress/e2e/config.cy.js
@@ -1,8 +1,14 @@
-function runConfigTest(param, name, callback) {
-  it(name, () => {
+function runConfigTest(param, name, callback, only=false) {
+  const test = () => {
     cy.visit('/e2e.html?' + param);
     callback();
-  });
+  }
+  
+  if (only) {
+    it.only(name, test);
+  }
+
+  it(name, test);
 }
 
 function getPanelModeOption(mode) {
@@ -22,6 +28,50 @@ function checkPanelItemLabels(collectionLabel, manifestLabel, itemLabel, panelId
       
       cy.get('[data-cy="item-label"]')
         .should('contain.text', itemLabel)
+    })
+}
+
+function checkTreeExpandedCollectionManifests(
+  $manifestNodes, 
+  manifests = { count: 0, idx: 0, label: '' },
+  items = { count: 0, idx: 0, label: '' }
+) {
+  cy.wrap($manifestNodes)
+    .should('have.length', manifests.count)
+
+    .eq(manifests.idx)
+    .should('contain.text', manifests.label)
+    .as('manifest')
+  
+  cy.get('@manifest')
+    .click()
+  
+  cy.get('@manifest')
+    .children('[data-cy="node-children"]')
+    .find('[data-cy="tree-node"]')
+    .should('have.length', items.count)
+
+    .eq(items.idx)
+    .should('contain.text', items.label)
+}
+
+function checkTreeCollapsedCollection($rootCollection, collectionLabel, manifests, items) {
+  cy.wrap($rootCollection).as('rootCollection')
+
+  cy.get('@rootCollection')
+    .children('[data-cy="node-children"]')
+    .should('not.be.visible')
+
+  cy.get('@rootCollection')
+    .should('contain.text', collectionLabel)  
+    .click()
+  
+    .children('[data-cy="node-children"]')
+    .should('be.visible')
+    
+    .find('[data-cy="tree-node"]')
+    .then(($manifestNodes) => {
+      checkTreeExpandedCollectionManifests($manifestNodes, manifests, items)
     })
 }
 
@@ -73,7 +123,7 @@ describe('Config', () => {
   runConfigTest('showThemeToggle=false', 'Should not show theme toggle', () => {
     cy.get('[data-cy="settings"]').click()
     cy.contains('Toggle theme').should('not.exist')
-  })
+  });
   runConfigTest('showThemeToggle=true', 'Should show theme toggle', () => {
     cy.get('[data-cy="settings"]').click()
     
@@ -86,7 +136,7 @@ describe('Config', () => {
     cy.contains('Light').should('be.visible')
     cy.contains('Dark').should('be.visible')
     cy.contains('System').should('be.visible')
-  })
+  });
   runConfigTest('panels[0].collection=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json',
     'Should show first item from first manifest when providing collection', () => {
       checkPanelItemLabels(
@@ -95,7 +145,7 @@ describe('Config', () => {
         '2a'
       )
     }
-  )
+  );
   runConfigTest('panels[0].collection=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json&panels[0].manifest=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/3r176/manifest.json',
     'Should show first item when providing collection and manifest', () => {
       checkPanelItemLabels(
@@ -104,7 +154,7 @@ describe('Config', () => {
         '182b'
       )
     }
-  )
+  );
   runConfigTest('panels[0].collection=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json&panels[0].manifest=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/3r176/manifest.json&panels[0].item=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/3r176/183a/latest/item.json',
     'Should show item when providing collection, manifest and item', () => {
       checkPanelItemLabels(
@@ -113,7 +163,7 @@ describe('Config', () => {
         '183a'
       )
     }
-  )
+  );
   runConfigTest('panels[0].collection=http://localhost:8181/4w/reproduction/collection.json&panels[1].collection=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json',
     'Should show two panels with first item from two collections', () => {
       cy.get('[data-cy="panels-wrapper"]')
@@ -134,11 +184,12 @@ describe('Config', () => {
         1
       )
     }
-  )
+  );
   //simplified is the second (=non-default) contentType of the collection
   runConfigTest('panels[0].collection=http://localhost:8181/4w/reproduction/collection.json&panels[0].contentType=simplified',
     'Should apply the given panel contentType', () => {
       cy.get('[data-cy="content-type"]')
+        .should('be.visible')
         .should('contain.text', 'simplified')
         .click()
       
@@ -150,6 +201,115 @@ describe('Config', () => {
         .contains('accurate')
         .should('have.attr', 'data-state', 'unchecked')
     }
-  )
-  
+  );
+  runConfigTest('rootCollections[]=http://localhost:8181/4w/reproduction/collection.json&panels[0].collection=http://localhost:8181/4w/reproduction/collection.json',
+    'Should show markers in tree for open panel', () => {
+      //open tree
+      cy.get('[data-cy="global-tree-toggle"]')
+        .should('be.visible')
+        .click()
+      
+      cy.get('[data-cy="tree"]')
+        .children('[data-cy="tree-node"]')
+        .eq(0)
+        .as('rootCollection')
+      
+      //should have a marker at collection level
+      cy.get('@rootCollection')  
+        .find('[data-cy="node-label"]')
+        .eq(0)
+        .should('contain.text', 'Ebene 1: Reproduktion der Dokumente')
+        .siblings('[data-cy="tree-node-actions"]')
+        .find('[data-cy="tree-node-marker"]')
+        .should('be.visible')
+      
+      cy.get('@rootCollection')
+        .children('[data-cy="node-children"]') //manifest nodes
+        .find('[data-cy="tree-node-marker"]') 
+        .should('have.length', 1)
+        .parents('[data-cy="tree-node"]')
+        .eq(0)
+        //manifest node with marker
+        .within(() => {
+          //open items of marked manifest
+          cy.get('[data-cy="node-label"]')
+            .should('contain.text', 'Einsiedeln, 278 1040')
+            .click()
+          //should only have one marker at item level for item '279'
+          cy.get('[data-cy="node-children"]')
+            .find('[data-cy="tree-node-marker"]')
+            .should('have.length', 1)
+            .parents('[data-cy="tree-node"]')
+            .eq(0)
+            .find('[data-cy="node-label"]')
+            .should('contain.text', '279')
+        })
+    }
+  );
+  runConfigTest('rootCollections[]=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json',
+    'Should show one root collection in global tree with root node expanded', () => {
+      cy.get('[data-cy="global-tree-toggle"]')
+        .should('be.visible')
+        .click()
+      
+      cy.get('[data-cy="tree"]')
+        .children('[data-cy="tree-node"]')
+        .should('have.length', 1)
+        .children()
+        .eq(0)
+        .find('[data-cy="node-label"]')
+        .should('contain.text', 'Textual witnesses in Arabic and Karshuni')
+
+        .parents('[data-cy="tree-node"]')
+        .children('[data-cy="node-children"]')
+        .find('[data-cy="tree-node"]')
+        .then(($manifestNodes) => {
+          //should have 30 manifests and the third should be labelled 'Borg. Arab. 201'
+          const manifests = { count: 30, idx: 2, label: 'Borg. Arab. 201' }
+          //should have 18 items under 'Borg. Arab. 201' and the fourth should be labelled '200a'
+          const items = { count: 18, idx: 3, label: '200a' }
+          checkTreeExpandedCollectionManifests($manifestNodes, manifests, items)
+        })
+    }
+  );
+  runConfigTest('rootCollections[]=http://localhost:8181/ahiqar/textapi/ahiqar/arabic-karshuni/collection.json&rootCollections[]=http://localhost:8181/4w/reproduction/collection.json', 
+    'Should show two root collections in global tree with both root nodes collapsed', () => {
+      cy.get('[data-cy="global-tree-toggle"]')
+        .should('be.visible')
+        .click()
+      
+      cy.get('[data-cy="tree"]')
+        .children('[data-cy="tree-node"]')
+        .should('have.length', 2)
+        .as('rootCollections')
+
+      cy.get('@rootCollections')
+        .eq(0)
+        .then(($rootCollection) => {
+          const collectionLabel = 'Textual witnesses in Arabic and Karshuni'
+          //should have 30 manifests and the last one should be labelled 'Syr 17'
+          const manifests = { count: 30, idx: 29, label: 'Syr 17'}
+          //should have 50 items under 'Syr 17' and the second should be labelled '2v'
+          const items = { count: 50, idx: 1, label: '2v'}
+
+          checkTreeCollapsedCollection($rootCollection, collectionLabel, manifests, items)
+        })
+
+      cy.get('@rootCollections')
+        .eq(1)
+        .then(($rootCollection) => {
+          const collectionLabel = 'Ebene 1: Reproduktion der Dokumente'
+          //should have 8 manifests and the first should be labelled 'Einsiedeln, 278 1040'
+          const manifests = { count: 8, idx: 0, label: 'Einsiedeln, 278 1040'}
+          //should have 3 items under 'Einsiedeln, 278 1040' and the last should be labelled '281'
+          const items = { count: 3, idx: 2, label: '281'}
+
+          checkTreeCollapsedCollection($rootCollection, collectionLabel, manifests, items)
+        })
+    }
+  );
+  runConfigTest('showGlobalTree=false', 'Should not show the global tree toggle', () => {
+    cy.get('[data-cy="global-tree-toggle"]')
+      .should('not.exist')
+  });
 });

--- a/tests/cypress/e2e/tree.cy.js
+++ b/tests/cypress/e2e/tree.cy.js
@@ -16,32 +16,6 @@ describe('Tree', () => {
     cy.visit('/4w-local.html')
   });
 
-  it('Global tree: Should display one root collection node as expanded', () => {
-    cy.get('[data-cy="global-tree-toggle"]').click()
-
-    cy.get('[data-cy="tree"]').should('be.visible')
-      // we have one root node with the title
-      .children('[data-cy="tree-node"]')
-      .should('have.length', 1)
-      .children().eq(0)
-      .contains('Vier Wachen vernetzt: Digitale Edition eines mystischen Traktats des Spätmittelalters')
-
-      // it has two children with corresponding collection titles
-      .parent().parent()
-      .find('[data-cy="node-children"]').first()
-      .children()
-      .should('have.length', 2)
-      .children()
-      .eq(0).find('span').should('have.text','Ebene 1: Reproduktion der Dokumente')
-      .parents('[data-cy="node-children"]')
-      .children()
-      .should('have.length', 2)
-      .children()
-      .eq(1).find('span').should('have.text','Ebene 2: Kritische Edition der Fassungen')
-  })
-
-  // TODO: Having two root collections shows initially both two root nodes as not expanded
-
   it('Should render manifests of collection', () => {
     cy.get('[data-cy="global-tree-toggle"]').click()
     cy.get('.tree')


### PR DESCRIPTION
Adds tests for the cases:

- Should show markers in tree for open panel from root collection
- Should show one root collection as expanded in tree (moved from tree tests)
- Should show two root collections as collapsed in tree
- showGlobalTree: false