### PR TITLE
Show correctly image when switching from text to image containing mode

### DIFF
--- a/src/components/panel/ImageRenderer.tsx
+++ b/src/components/panel/ImageRenderer.tsx
@@ -16,24 +16,6 @@ const ImageRenderer: FC = () => {
   const imageUrl = panelState?.item?.image?.id
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    setLoading(true)
-
-    if (loadingPanel) return
-
-    if (!imageUrl || !viewerRef.current) {
-      showBoundary(t('could_not_find_image'))
-      return
-    }
-
-    const oldItem = viewerRef.current.world.getItemAt(0)
-    if (oldItem) viewerRef.current.world.removeItem(oldItem)
-
-    viewerRef.current.open({
-      type: 'image',
-      url: imageUrl
-    })
-  }, [imageUrl, loadingPanel])
 
   useEffect(() => {
     if (!viewerContainerRef.current) return
@@ -54,10 +36,32 @@ const ImageRenderer: FC = () => {
     viewerRef.current.addHandler('open', function () {
       setLoading(false)
     })
+
     return () => {
       if (viewerRef.current) viewerRef.current.destroy()
     }
   }, [])
+
+
+  useEffect(() => {
+    setLoading(true)
+
+    if (loadingPanel) return
+
+    if (!imageUrl || !viewerRef.current) {
+      showBoundary(t('could_not_find_image'))
+      return
+    }
+
+    const oldItem = viewerRef.current.world.getItemAt(0)
+    if (oldItem) viewerRef.current.world.removeItem(oldItem)
+
+    viewerRef.current.open({
+      type: 'image',
+      url: imageUrl
+    })
+  }, [imageUrl, loadingPanel])
+
 
 
   return (


### PR DESCRIPTION
Closes #894 

When switching from text to image mode the OpenSeaDragonViewer instance should be recreated. In current implementation the order of useEffects is not correct: We try to access the instance of openSeaDragonViewer in the above useEffect, meantime this instance is created in the lower useEffect. In a React Component the useEffects appear to run in direction from top to bottom.

Therefore I fix this by reordering the useEffects.