### PR TITLE
fix: filter variants correctly based on witnesses selection

### DIFF
--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -20,7 +20,7 @@ function getSelectedTypesFromNode(node: FilterNode): AnnotationTypesDict {
     if (isVariant) {
       // If a node has configured type "Variant", we ignore all other types and grandchildren
       // and consider only direct children as "witnesses".
-      types['Variant'] = node.items?.map(item => item.types?.[0] ?? '') ?? []
+      types['Variant'] = node.items?.filter(item => item.selected).map(item => item.types?.[0] ?? '') ?? []
       return types
     }
 


### PR DESCRIPTION
Here is the config you can check with bdn

{
  "allowNewCollections": false,
  "title": "BDN",
  "lang": "de",
  "panels": [
    {
      "collection": "https://bdnportal.d.sub.uni-goettingen.de/api/textapi/griesbach/collection.json"
    }
  ],
  "rootCollections": [
    "https://bdnportal.d.sub.uni-goettingen.de/api/textapi/griesbach/collection.json"
  ],
  "theme": {
    "primaryColor": "#2b7fff"
  },
  "showPanelPlaceholder": false,
  "translations": {
    "de": {
      "common": {
        "contents_and_metadata": "Inhalt & Metadaten",
        "next_item": "Nächste Seite",
        "previous_item": "Vorherige Seite",
        "next_manifest": "Nächste Editionseinheit",
        "previous_manifest": "Vorherige Editionseinheit",
        "item": "Seite"
      }
    }
  },
  "annotations": {
    "types": {},
    "filters": {
      "rootSelectionRule": "single",
      "items": [
        {
          "label": "Textkritik",
          "selected": true,
          "types": [
            "Variant"
          ],
          "items": [
            {
              "label": "Auflage a",
              "selected": true,
              "types": [
                "a"
              ]
            },
            {
              "label": "Auflage b",
              "selected": true,
              "types": [
                "b"
              ]
            },
            {
              "label": "Auflage d",
              "selected": true,
              "types": [
                "d"
              ]
            }
          ]
        },
        {
          "label": "Erläuterungen",
          "types": [
            "EditorialCorrection"
          ],
          "items": [
            {
              "label": "Satzfehlerkorrektur",
              "types": [
                "Satzfehlerkorrektur"
              ]
            },
            {
              "label": "Autorschaftliche Korrektur",
              "types": [
                "Autorschaftliche Korrektur"
              ]
            }
          ]
        }
      ]
    }
  }
}

