### PR TITLE
fix: avoid unnecessary collection requests on panel updates

### DIFF
--- a/src/components/tree/TreeNode.tsx
+++ b/src/components/tree/TreeNode.tsx
@@ -5,7 +5,6 @@ import { ChevronRight, Folder, LibraryBig, File, FolderOpen } from 'lucide-react
 
 import EmptyNode from '@/components/tree/EmptyNode.tsx'
 import ErrorNode from '@/components/tree/ErrorNode.tsx'
-import { usePanelStore } from '@/store/PanelStore.tsx'
 import OpenedIcon from '@/components/tree/OpenedIcon.tsx'
 import { apiRequest } from '@/utils/api.ts'
 import { getRootChildrenCollectionsIds } from '@/utils/tree.ts'
@@ -18,8 +17,7 @@ interface TreeNodeProps {
 
 
 const TreeNode: FC<TreeNodeProps> = ({ node }) => {
-  const { onSelect, getChildren, selectedNodeId, setSelectedNodeId, elevation } = useTree()
-  const panels = usePanelStore(state => state.panels)
+  const { onSelect, getChildren, selectedNodeId, setSelectedNodeId, elevation, panels } = useTree()
   const { t } = useTranslation()
   const [isExpanded, setIsExpanded] = useState(node.expanded)
   const [showEmptyNode, setShowEmptyNode] = useState(false)

--- a/src/contexts/TreeContext.tsx
+++ b/src/contexts/TreeContext.tsx
@@ -1,6 +1,13 @@
-import { ReactNode, createContext, useContext, FC, useState } from 'react'
+import { ReactNode, createContext, useContext, FC, useState, useRef, useEffect } from 'react'
+import { usePanelStore } from '@/store/PanelStore.tsx'
 
 const TreeContext = createContext<TreeType | undefined>(undefined)
+
+interface PanelData {
+  item: Item,
+  manifest: Manifest,
+  collectionId: string
+}
 
 interface TreeType {
   onSelect(node: TreeNode, target: HTMLElement): void
@@ -8,6 +15,7 @@ interface TreeType {
   selectedNodeId: string
   setSelectedNodeId: (val: string) => void
   elevation: number
+  panels: PanelData[]
 }
 
 interface TreeProviderProps {
@@ -19,9 +27,32 @@ interface TreeProviderProps {
 
 const TreeProvider: FC<TreeProviderProps> = ({ children, onSelect, getChildren, elevation = 0 }) => {
   const [selectedNodeId, setSelectedNodeId] = useState('')
+  const [panels, setPanels] = useState<PanelData[]>([])
+  const panelStates = usePanelStore(state => state.panels)
+  const prevPanelsRef = useRef<PanelData[]>([])
+
+  useEffect(() => {
+    // This is needed for displaying the "opened" icons at tree nodes.
+    // Since mapping out item, manifest and collectionId creates a new reference everytime and thus a triggers a re-rendering
+    // in TreeNodes, we need only update "panels" when something actually was changed in value.
+
+    const extracted = panelStates.map(({ item, manifest, collectionId }) => ({ item, manifest, collectionId }))
+
+    const hasChanged = extracted.length !== prevPanelsRef.current.length ||
+      extracted.some((p, i) =>
+        p.item !== prevPanelsRef.current[i]?.item ||
+        p.manifest !== prevPanelsRef.current[i]?.manifest ||
+        p.collectionId !== prevPanelsRef.current[i]?.collectionId
+      )
+
+    if (hasChanged) {
+      prevPanelsRef.current = extracted
+      setPanels(extracted)
+    }
+  }, [panelStates])
 
   return (
-    <TreeContext.Provider value={{ onSelect, getChildren, selectedNodeId, setSelectedNodeId, elevation }}>
+    <TreeContext.Provider value={{ onSelect, getChildren, selectedNodeId, setSelectedNodeId, elevation, panels }}>
       {children}
     </TreeContext.Provider>
   )


### PR DESCRIPTION
Problem:
 1. Toggle on/off some panel view from dropdown
 2. You see how it requests the collection from API for no reason

Diagnose: For updating opened icons in the global tree, there was a useEffect that listened to updates of panel states. So each update of the panel states would trigger the whole procedure of recalculation of opened icons. As we agreed on the "dirty solution" to immediately request the collection within that function, it did exactly that. 

Solution: Extract the needed information for the tree and pass it from context provider. Check for changed values with the help of ref.

The consequence of technical debt ;)