### PR TITLE
refactor: use native resizing of sidebar instead of nested Allotment panes

### DIFF
--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -10,17 +10,12 @@ import 'allotment/dist/style.css'
 import { Allotment } from 'allotment'
 import SidebarView from '@/components/panel/views/SidebarView.tsx'
 import PanelError from '@/components/panel/PanelError.tsx'
-import { DEFAULT_PANEL_WIDTH, SIDEBAR_DEFAULT_WIDTH } from '@/utils/panel.ts'
+import ResizeHandle from '@/components/panel/ResizeHandle.tsx'
 
 const PanelContent: FC = React.memo(() => {
   const { panelState, resizer, error } = usePanel()
   const [showSidebar, setShowSidebar] = useState(false)
   const [contentPanes, setContentPanes] = useState([])
-  const [sizes, setSizes] = useState({
-    main: 0,
-    sidebar: 0
-  })
-  const [isOpening, setIsOpening] = useState(false)
 
   useEffect(() => {
     const panes = panelState.panelViews.filter(v => v.visible).map(v => {
@@ -34,9 +29,7 @@ const PanelContent: FC = React.memo(() => {
 
   useEffect(() => {
     if (!resizer) return
-    setIsOpening(true)
     resizer.setAnnotationsOpen(panelState.annotationsOpen)
-    const isOpeningTimeout = setTimeout(() => setIsOpening(false), 500)
 
     let sidebarContentTimeout = null
 
@@ -50,51 +43,38 @@ const PanelContent: FC = React.memo(() => {
     }
 
     return () => {
-      clearTimeout(isOpeningTimeout)
       if (sidebarContentTimeout) clearTimeout(sidebarContentTimeout)
     }
   }, [panelState.annotationsOpen])
 
-  const handleChange = (newSizes: number[]) => {
-    setSizes({
-      main: newSizes[0],
-      sidebar: newSizes[1] ?? 0
-    })
-
-    if (newSizes[1]) resizer.setSidebarWidth(newSizes[1])
-  }
 
   if (error) return <PanelError error={error} resetErrorBoundary={() => {}} />
   return (
-    <div
-      className={`h-full flex flex-col relative overflow-hidden`} style={{
-        '--sash-hover-size': '2px',
-        '--focus-border': 'rgb(var(--tido-color-primary))'
-      } as React.CSSProperties}>
+    <TextProvider>
       <div
-        className="flex h-full w-full overflow-hidden" data-cy="panel-container">
-        <TextProvider>
-          <Allotment onChange={handleChange} proportionalLayout={true}>
-            <Allotment.Pane
-              minSize={isOpening ? sizes.main : DEFAULT_PANEL_WIDTH - 4}
-              maxSize={isOpening ? sizes.main : Infinity}
-            >
-              <div className="flex flex-col h-full @container/panel">
-                <PanelHeader />
-                <div className="flex-1">
-                  <Allotment proportionalLayout={true}>
-                    {contentPanes.map((pane) => <Allotment.Pane className="pl-px">
-                      {pane}
-                    </Allotment.Pane>)}
-                  </Allotment>
-                </div>
-              </div>
-            </Allotment.Pane>
-            {showSidebar && <Allotment.Pane preferredSize={SIDEBAR_DEFAULT_WIDTH} minSize={SIDEBAR_DEFAULT_WIDTH} className="pl-px"><SidebarView /></Allotment.Pane>}
-          </Allotment>
-        </TextProvider>
+        className={`h-full flex flex-col relative overflow-hidden`} style={{
+          '--sash-hover-size': '2px',
+          '--focus-border': 'rgb(var(--tido-color-primary))'
+        } as React.CSSProperties}>
+        <div className="h-full w-full overflow-hidden relative" data-cy="panel-container">
+          <div className="main-content flex flex-col h-full @container/panel">
+            <PanelHeader />
+            <div className="flex-1">
+              <Allotment proportionalLayout={true}>
+                {contentPanes.map((pane) => <Allotment.Pane>
+                  {pane}
+                </Allotment.Pane>)}
+              </Allotment>
+            </div>
+          </div>
+          <div className="sidebar absolute h-full top-0">
+            <div className="absolute inset-y-0 left-0 w-px bg-border z-10" />
+            <ResizeHandle className="-left-1.5" data-sidebar-resize-handle />
+            {showSidebar && <SidebarView />}
+          </div>
+        </div>
       </div>
-    </div>
+    </TextProvider>
   )
 })
 

--- a/src/components/panel/PanelShell.tsx
+++ b/src/components/panel/PanelShell.tsx
@@ -1,12 +1,12 @@
 import { FC, ReactNode, useEffect, useRef } from 'react'
-import { GripVertical } from 'lucide-react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
+import ResizeHandle from '@/components/panel/ResizeHandle.tsx'
 
 interface Props {
   children?: ReactNode
 }
 const PanelShell: FC<Props> = ({ children }) => {
-  const { panelId, initResizer, getSidebarScroller } = usePanel()
+  const { panelId, initResizer, getSidebarScroller, resizer } = usePanel()
   const ref = useRef(null)
 
   useEffect(() => {
@@ -17,20 +17,22 @@ const PanelShell: FC<Props> = ({ children }) => {
     // Scroll to this panel
     const scrollPosX = ref.current.offsetLeft - ref.current.offsetWidth / 2
     document.getElementById('panels-wrapper').scrollTo({ left: scrollPosX, behavior: 'smooth' })
+
+    return () => {
+      resizer?.clean()
+    }
   }, [ref])
 
   return <div
     id={panelId}
     ref={ref}
-    className={`panel bg-background text-foreground grow-0 shrink-0 relative`}
+    className={`panel bg-background text-foreground grow-0 shrink-0 relative transition-width`}
     data-cy="panel"
   >
     <div className="h-full overflow-hidden relative border-2 border-border rounded-lg">
       { children }
     </div>
-    <div data-resize-handle className="z-10 absolute flex h-6 w-3 items-center justify-center rounded-sm border border-border bg-muted -translate-y-1/2 top-1/2 -right-1.5">
-      <GripVertical className="h-4 w-2.5 text-muted-foreground" />
-    </div>
+    <ResizeHandle className="-right-1.5" data-panel-resize-handle />
   </div>
 }
 

--- a/src/components/panel/ResizeHandle.tsx
+++ b/src/components/panel/ResizeHandle.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+import { GripVertical } from 'lucide-react'
+
+interface Props {
+  className?: string
+  'data-sidebar-resize-handle'?: boolean
+  'data-panel-resize-handle'?: boolean
+}
+
+const ResizeHandle: FC<Props> = ({ className = '', ...props }) => {
+  return (
+    <div
+      {...props}
+      className={`z-10 absolute flex h-6 w-3 items-center justify-center rounded-sm border border-border bg-muted -translate-y-1/2 top-1/2 ${className}`}
+    >
+      <GripVertical className="h-4 w-2.5 text-muted-foreground" />
+    </div>
+  )
+}
+
+export default ResizeHandle

--- a/src/utils/panel-resizer.ts
+++ b/src/utils/panel-resizer.ts
@@ -4,18 +4,26 @@ import {
   PANEL_GAP
 } from '@/utils/panel.ts'
 
-
 class PanelResizer {
   wrapper: HTMLElement
   panelEl: HTMLElement
+  mainContentEl: HTMLElement
+  sidebarEl: HTMLElement | null = null
+
   panelId: string
   resizeHandle: HTMLElement
   sidebarWidth: number = SIDEBAR_DEFAULT_WIDTH
 
-  eventListeners: Array<{ name: string; listener: EventListener }> = []
+  panelEventListeners: { el: HTMLElement | Window; name: string; listener: EventListener }[] = []
+  sidebarEventListeners: { el: HTMLElement | Window; name: string; listener: EventListener }[] = []
+
   isResizing = false
+  isSidebarResizing = false
   annotationsOpen = false
   lastWidth: number | null = null
+
+  private isDragToResizeInitialized = false
+  private isSidebarResizeInitialized = false
 
   constructor(panelEl: HTMLElement) {
     this.init(panelEl)
@@ -24,8 +32,10 @@ class PanelResizer {
   init(panelEl: HTMLElement) {
     this.wrapper = document.getElementById('panels-wrapper')
     this.panelEl = panelEl
+    this.mainContentEl = panelEl.querySelector('.main-content')
+    this.sidebarEl = panelEl.querySelector('.sidebar')
     this.panelId = this.panelEl.id
-    this.resizeHandle = this.panelEl.querySelector('[data-resize-handle]')
+    this.resizeHandle = this.panelEl.querySelector('[data-panel-resize-handle]')
 
     this.panelEl.style.minWidth = `${MIN_PANEL_WIDTH}px`
 
@@ -33,10 +43,27 @@ class PanelResizer {
     this.dragToResize()
   }
 
+  // ─── Panel edge resize ───────────────────────────────────────────────────────
+
   resize() {
     const width = this.calculateWidth(this.wrapper)
-    this.lastWidth = width
-    this.panelEl.style.width = `${width}px`
+    this.onResizePanel(width)
+  }
+
+  onResizePanel(newWidth: number) {
+    this.lastWidth = newWidth
+    this.panelEl.style.width = `${newWidth}px`
+
+    if (this.annotationsOpen) {
+      const mainWidth = newWidth - this.sidebarWidth
+      this.mainContentEl.style.width = `${mainWidth}px`
+      this.sidebarEl.style.left = `${mainWidth}px`
+      this.sidebarEl.style.width = `${this.sidebarWidth}px`
+    } else {
+      this.mainContentEl.style.width = `${newWidth}px`
+      this.sidebarEl.style.left = `${newWidth}px`
+      this.sidebarEl.style.width = '0px'
+    }
   }
 
   calculateWidth(wrapper: HTMLElement): number {
@@ -54,6 +81,9 @@ class PanelResizer {
   }
 
   dragToResize() {
+    if (this.isDragToResizeInitialized) return
+    this.isDragToResizeInitialized = true
+
     const handleMouseMove = (e: MouseEvent) => {
       if (this.isResizing) {
         const rect = this.panelEl.getBoundingClientRect()
@@ -61,15 +91,15 @@ class PanelResizer {
 
         if (newWidth < MIN_PANEL_WIDTH + (this.annotationsOpen ? this.sidebarWidth : 0)) return
 
-        this.lastWidth = newWidth
-        this.panelEl.style.width = `${newWidth}px`
+        this.onResizePanel(newWidth)
         return
       }
 
-      // Hover detection logic (within 8px of right edge)
       const rect = this.panelEl.getBoundingClientRect()
       const offsetX = e.clientX - rect.left
-      this.setIsHoveringEdge(offsetX > rect.width - 8 && offsetX <= rect.width)
+      const isNearEdge = offsetX > rect.width - 12 && offsetX <= rect.width
+
+      this.setIsHoveringEdge(isNearEdge)
     }
 
     const handleMouseUp = () => this.setIsResizing(false)
@@ -77,24 +107,20 @@ class PanelResizer {
     const handleMouseDown = (e: MouseEvent) => {
       const rect = this.panelEl.getBoundingClientRect()
       const offsetX = e.clientX - rect.left
-      if (offsetX > rect.width - 8) {
+      if (offsetX > rect.width - 12) {
         this.setIsResizing(true)
       }
     }
 
     window.addEventListener('mousemove', handleMouseMove)
     window.addEventListener('mouseup', handleMouseUp)
-    this.resizeHandle.addEventListener('mousedown', handleMouseDown)
+    this.panelEl.addEventListener('mousedown', handleMouseDown)
 
-    this.eventListeners.push(...[
-      { name: 'mousemove', listener: handleMouseMove },
-      { name: 'mouseup', listener: handleMouseUp },
-      { name: 'mousedown', listener: handleMouseDown }
-    ])
-  }
-
-  onResize(callback: (width: number) => void) {
-    callback(this.lastWidth)
+    this.panelEventListeners.push(
+      { el: window, name: 'mousemove', listener: handleMouseMove },
+      { el: window, name: 'mouseup', listener: handleMouseUp },
+      { el: this.panelEl, name: 'mousedown', listener: handleMouseDown }
+    )
   }
 
   setIsHoveringEdge(value: boolean) {
@@ -114,15 +140,102 @@ class PanelResizer {
     }
   }
 
-  setAnnotationsOpen(value: boolean) {
-    this.annotationsOpen = value
-    if (value) {
-      this.lastWidth = this.lastWidth + this.sidebarWidth
-      this.panelEl.style.width = `${this.lastWidth}px`
+  // ─── Sidebar split resize ────────────────────────────────────────────────────
+
+  private initSidebarResize() {
+    if (!this.sidebarEl) return
+    if (this.isSidebarResizeInitialized) return
+    this.isSidebarResizeInitialized = true
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!this.sidebarEl) return
+
+      const sidebarRect = this.sidebarEl.getBoundingClientRect()
+      const offsetX = e.clientX - sidebarRect.left
+
+      if (offsetX > 12) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      this.isSidebarResizing = true
+      this.panelEl.style.userSelect = 'none'
+    }
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!this.sidebarEl) return
+
+      const sidebarRect = this.sidebarEl.getBoundingClientRect()
+      const offsetX = e.clientX - sidebarRect.left
+      const isNearEdge = offsetX <= 12
+
+      if (!this.isSidebarResizing) {
+        this.sidebarEl.style.cursor = isNearEdge ? 'ew-resize' : 'default'
+        return
+      }
+
+      const panelRect = this.panelEl.getBoundingClientRect()
+      const newMainWidth = e.clientX - panelRect.left
+      const newSidebarWidth = panelRect.width - newMainWidth
+
+      if (newMainWidth < MIN_PANEL_WIDTH || newSidebarWidth < SIDEBAR_DEFAULT_WIDTH) return
+
+      this.mainContentEl.style.width = `${newMainWidth}px`
+      this.sidebarEl.style.left = `${newMainWidth}px`
+      this.sidebarEl.style.width = `${newSidebarWidth}px`
+      this.sidebarWidth = newSidebarWidth
+    }
+
+    const handleMouseUp = () => {
+      if (!this.isSidebarResizing) return
+      this.isSidebarResizing = false
+      this.panelEl.style.userSelect = 'auto'
+    }
+
+    this.sidebarEl.addEventListener('mousedown', handleMouseDown)
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+
+    this.sidebarEventListeners.push(
+      { el: this.sidebarEl, name: 'mousedown', listener: handleMouseDown },
+      { el: window, name: 'mousemove', listener: handleMouseMove },
+      { el: window, name: 'mouseup', listener: handleMouseUp }
+    )
+  }
+
+  private teardownSidebarResize() {
+    this.sidebarEventListeners.forEach(({ el, name, listener }) => {
+      el.removeEventListener(name, listener)
+    })
+    this.sidebarEventListeners = []
+    this.isSidebarResizeInitialized = false
+
+    if (this.sidebarEl) {
+      this.sidebarEl.style.cursor = ''
+    }
+  }
+
+  // ─── Annotations open/close ──────────────────────────────────────────────────
+
+  setAnnotationsOpen(isOpen: boolean) {
+    if (isOpen === this.annotationsOpen) return
+    this.annotationsOpen = isOpen
+
+    if (isOpen) {
+      const newWidth = this.lastWidth + this.sidebarWidth
+      this.onResizePanel(newWidth)
+      this.initSidebarResize()
     } else {
-      this.lastWidth = this.lastWidth - this.sidebarWidth
-      this.panelEl.style.width = `${this.lastWidth}px`
+      // Reset sidebarWidth before onResizePanel so the subtraction uses the right value
       this.sidebarWidth = SIDEBAR_DEFAULT_WIDTH
+
+      // Clear any manual drag overrides so onResizePanel takes full control
+      this.mainContentEl.style.width = ''
+      this.sidebarEl.style.left = ''
+      this.sidebarEl.style.width = ''
+
+      const newWidth = this.lastWidth - this.sidebarWidth
+      this.onResizePanel(newWidth)
+      this.teardownSidebarResize()
     }
   }
 
@@ -130,13 +243,17 @@ class PanelResizer {
     this.sidebarWidth = value
   }
 
+  // ─── Cleanup ─────────────────────────────────────────────────────────────────
+
   clean() {
-    this.eventListeners.forEach(({ name, listener }) => {
-      window.removeEventListener(name, listener)
+    [...this.panelEventListeners, ...this.sidebarEventListeners].forEach(({ el, name, listener }) => {
+      el.removeEventListener(name, listener)
     })
+    this.panelEventListeners = []
+    this.sidebarEventListeners = []
+    this.isDragToResizeInitialized = false
+    this.isSidebarResizeInitialized = false
   }
 }
 
-export {
-  PanelResizer
-}
+export { PanelResizer }


### PR DESCRIPTION
- Removed nested Allotment setup. Previously the sidebar and main content would sit in 2 Allotment panes while the main content was an Allotment container itself containing the content views. The sidebar was mounted upon state change which caused friction while resizing the panel width. This was solved by a "hack" where we would set a fixed width to main content's pane during resizing and unset it when resizing was finished. 
- Now the sidebar is an absolutely position element again and the resizing between main content and sidebar is done by the panel-resizer. 