### PR TITLE
Annotations in annotations

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -2,6 +2,8 @@
   "common": {
     "annotation_collection_error_title": "Fehler in der Annotation Collection",
     "annotation_collection_response_error": "Der abgerufene Inhalt der Annotation Collection ist ungültig.",
+    "nested_annotation": "verschachtelte Annotation",
+    "nested_annotations": "verschachtelte Annotationen",
     "new": "Neu",
     "sync_panels": "Panels synchronisieren",
     "place": "Ort",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -2,6 +2,8 @@
   "common": {
     "annotation_collection_error_title": "Error in annotation collection",
     "annotation_collection_response_error": "The retrieved response from the annotation collection is invalid.",
+    "nested_annotation": "nested annotation",
+    "nested_annotations": "nested annotations",
     "new": "New",
     "sync_panels": "Sync Panels",
     "confirm": "Confirm",

--- a/src/components/panel/annotations/AlignAnnotationsList.tsx
+++ b/src/components/panel/annotations/AlignAnnotationsList.tsx
@@ -56,9 +56,7 @@ const AlignAnnotationsList: FC = () => {
   }, [selectedAnnotation])
 
 
-  function onAnnotationExpand(annotationId: string, bodyAnnotationEl: HTMLElement, bodyFinalHeight: number, translateY: number) {
-    // Idea: we transition the body of Annotation
-    // translateY: the amount that annotation expanded (expandedHeight - collapsedHeight). Necessary to push down the lower annotations
+  function onAnnotationExpand(annotationId: string, expandableEl: HTMLElement, expandableElFinalHeight: number, translateY: number) {
     const newElements = [...elements]
     const index = elements.findIndex(el => el.annotation.id === annotationId)
 
@@ -77,11 +75,10 @@ const AlignAnnotationsList: FC = () => {
 
     setYMap(map)
 
-    // Step 4: Expand the annotation (slightly delayed or same time)
     setTimeout(() => {
-      bodyAnnotationEl.style.height = bodyFinalHeight + 'px'
-      bodyAnnotationEl.style.transition = 'height 300ms ease-out'
-    },0)
+      expandableEl.style.height = expandableElFinalHeight + 'px'
+      expandableEl.style.transition = 'height 300ms ease-out'
+    }, 0)
   }
 
   function onAnnotationCollapse(bodyAnnotationEl: HTMLElement, bodyFinalHeight: number) {

--- a/src/components/panel/annotations/Annotation.tsx
+++ b/src/components/panel/annotations/Annotation.tsx
@@ -6,6 +6,21 @@ import VariantContent from '@/components/panel/annotations/VariantContent.tsx'
 import { useText } from '@/contexts/TextContext.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { useTranslation } from 'react-i18next'
+
+import AnnotationFooter from '@/components/panel/annotations/AnnotationFooter.tsx'
+import { useAnnotations } from '@/contexts/AnnotationsContext.tsx'
+import {
+  addHighlightStyle,
+  addHoverStyle, addSelectedStyle, isTargetPartOfSelectedAnnotation,
+  removeHighlightStyle,
+  removeHoverStyle,
+  removeSelectedStyle
+} from '@/utils/text.ts'
+import {
+  findTargetsInsideAnnotation,
+  getAnnotationIdsByEl,
+  getFlippedNestedMatchedAnnotationsMap
+} from '@/utils/annotations.ts'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 
 const THRESHOLD_LONG_ANNOTATION_BODY_HEIGHT = 60
@@ -17,12 +32,14 @@ interface Props {
   top?: number,
   onExpand?: (annotationId: string, element: HTMLElement, finalHeight: number, translateY: number) => void
   onCollapse?: (element: HTMLElement, finalHeight: number) => void
+  isNested?: boolean
 }
 
 
-const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) => {
+const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse, isNested = false }) => {
   const { annotations: annotationsConfig } = useConfig()
-  const { selectedAnnotation, setSelectedAnnotation, annotationsMode } = usePanel()
+  const { selectedAnnotation, setSelectedAnnotation, annotationsMode, panelState } = usePanel()
+  const { nestedMatchedAnnotationsMap, hoveredNestedAnnotationIds, setHoveredNestedAnnotationIds  } = useAnnotations()
   const { setHoveredAnnotations, hoveredAnnotations } = useText()
   const ref = useRef(null)
   const annotationBodyRef = useRef(null)
@@ -30,10 +47,12 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
   const [isSelected, setIsSelected] = useState(false)
   const [isLong, setIsLong] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
+  const [showNestedAnnotations, setShowNestedAnnotations] = useState(false)
 
-  const expandedHeightRef = useRef(-1)
-  const collapsedHeightRef = useRef(-1)
 
+  const nestedAnnotationsRef = useRef(null)
+
+  const collapsedBodyHeightRef = useRef(-1)
   const expandedBodyHeightRef = useRef(-1)
 
   const { t } = useTranslation()
@@ -46,15 +65,127 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
 
   useEffect(() => {
     setIsSelected(selectedAnnotation && selectedAnnotation.id === data.id)
+    const panelEl = document.getElementById(panelState.id) as HTMLElement
+    const targetsOfSelectedAnnotation = selectedAnnotation && !!(nestedMatchedAnnotationsMap[selectedAnnotation.id]) ? nestedMatchedAnnotationsMap[selectedAnnotation.id].target.map((selector: string) => panelEl.querySelector(selector)) : []
+
+    const flippedNestedMatched = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
+    Object.keys(flippedNestedMatched).forEach((targetSelector) => {
+      const targetEl = document.querySelector(targetSelector)
+      if (!targetEl) return
+
+      removeSelectedStyle(targetEl)
+      removeHighlightStyle(targetEl)
+
+      if (isTargetPartOfSelectedAnnotation(targetEl, targetsOfSelectedAnnotation)) {
+        addSelectedStyle(targetEl)
+        return
+      }
+      else {
+        addHighlightStyle(targetEl)
+      }
+    })
   }, [data, selectedAnnotation])
+
+  useEffect(() => {
+    setIsHovered(hoveredNestedAnnotationIds?.includes(data.id))
+
+    const selectorsHoveredAnnotations = hoveredNestedAnnotationIds?.flatMap(id =>
+      nestedMatchedAnnotationsMap[id]?.target ?? []
+    )
+
+    const panelEl = document.getElementById(panelState.id) as HTMLElement
+    const targetsOfSelectedAnnotation = selectedAnnotation &&
+    !!(nestedMatchedAnnotationsMap[selectedAnnotation.id]) ? nestedMatchedAnnotationsMap[selectedAnnotation.id].target.map((selector: string) => panelEl.querySelector(selector)) : []
+
+    const flippedNestedMatched = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
+    Object.keys(flippedNestedMatched).forEach((targetSelector) => {
+      const targetEl = panelEl.querySelector(targetSelector)
+      if (targetEl) {
+        removeHighlightStyle(targetEl)
+        removeHoverStyle(targetEl)
+
+        if (selectorsHoveredAnnotations?.includes(targetSelector)) {
+          addHoverStyle(targetEl)
+        }
+        else if (!isTargetPartOfSelectedAnnotation(targetEl, targetsOfSelectedAnnotation)) {
+          addHighlightStyle(targetEl)
+        }
+      }
+    })
+  }, [hoveredNestedAnnotationIds])
+
+
+  function onClickTarget(e: Event) {
+    // expand parentAnnotation of target when clicking it
+    //  clicking at a target -> expands the nested annotations
+    //    -> since the nested annotations are expanded, then we show the full parent annotation
+    //      -> reason: makes easier the functionality of showing another selected target when clicking at another nested annotation whose target is not initially shown in parentAnnotation
+    setIsExpanded(true)
+
+    const nestedAnnotations = nestedAnnotationsRef.current
+    if (nestedAnnotations && nestedAnnotations.length > 0) {
+      // from flippedMatchedAnnotationsMap select its first nested annotation
+      const flippedNestedMatchedAnnotationsMap = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
+      const targetAnnotationIds = getAnnotationIdsByEl(flippedNestedMatchedAnnotationsMap, e.target as HTMLElement)
+      // get the first nested annotation which belongs to the selected target
+      for (let i = 0; i< nestedAnnotations.length; i++ ) {
+        if (targetAnnotationIds.includes(nestedAnnotations[i].id)) {
+          setShowNestedAnnotations(true)
+          setSelectedAnnotation(nestedAnnotations[i])
+          break
+        }
+      }
+    }
+  }
+
+  function collapseNestedAnnotations() {
+    setShowNestedAnnotations(false)
+  }
+
+  function onMouseEnterTarget(e: Event) {
+    const flippedNestedMatchedAnnotationsMap = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
+    const annotationIds = getAnnotationIdsByEl(flippedNestedMatchedAnnotationsMap, e.currentTarget as HTMLElement)
+    // add hover style to annotation els
+    setHoveredNestedAnnotationIds(annotationIds)
+  }
+
+  function onMouseLeaveTarget() {
+    setHoveredNestedAnnotationIds([])
+  }
+
 
   useEffect(() => {
     if (!annotationBodyRef.current) return
     const annotBodyHeight = annotationBodyRef.current.clientHeight
     if (annotBodyHeight > THRESHOLD_LONG_ANNOTATION_BODY_HEIGHT) setIsLong(true)
+
+    nestedAnnotationsRef.current = nestedMatchedAnnotationsMap[data.id]['nestedAnnotations']
+
+    // for each new nested Annotation - we add highlighting once it is mounted.
+    const itemAnnotations = panelState.annotations
+    const targetsInsideAnnotation = findTargetsInsideAnnotation(data.id, itemAnnotations)
+    targetsInsideAnnotation.forEach((selector) => {
+      const target = document.querySelector(selector)
+      if (target) {
+        addHighlightStyle(target)
+        target.addEventListener('click', onClickTarget)
+        target.addEventListener('mouseenter', onMouseEnterTarget)
+        target.addEventListener('mouseleave', onMouseLeaveTarget)
+      }
+    })
   }, [])
 
-  function handleClick() {
+  function handleClick(e: React.MouseEvent<HTMLDivElement>) {
+    // we should get the deepest level annotation as selected
+    e.stopPropagation()
+
+    // when clicking target inside an Annotation -> we have two click events (on Target and onAnnotation)
+    // this function considers click on Annotation
+    // if we have clicked a target -> we should not proceed further in its parentAnnotation, also in this function
+    const clickedEl = e.target
+    const flippedMatchedAnnotationsMap = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
+    if (Object.values(flippedMatchedAnnotationsMap).some((entry) => entry.el === clickedEl)) return
+
     if (selectedAnnotation && selectedAnnotation.id === data.id) {
       setIsSelected(false)
       setTimeout(() => setSelectedAnnotation(null), 100)
@@ -66,26 +197,25 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
   }
 
   function handleMouseEnter() {
-    setIsHovered(true)
+    if (!data.target[0].source.endsWith('.html')) {
+      setHoveredNestedAnnotationIds([data.id])
+      return
+    }
     setHoveredAnnotations([data.id])
   }
 
   function handleMouseLeave() {
     setIsHovered(false)
     setHoveredAnnotations(null)
+    setHoveredNestedAnnotationIds(null)
   }
 
-
-  function handleViewMore(e: React.MouseEvent) {
-    e.stopPropagation()
-    setIsExpanded(true)
-
-    const annotationEl = ref.current
-    const bodyEl = annotationBodyRef.current // we expand/collapse its content
-
-    if (collapsedHeightRef.current === -1) {
+  function getExpandableInfoOnViewMore(bodyEl: HTMLElement) {
+    let expandableElFinalHeight = 0
+    const expandableEl = bodyEl
+    if (collapsedBodyHeightRef.current === -1) {
       // initial height is the collapsed height
-      collapsedHeightRef.current = annotationEl.offsetHeight
+      collapsedBodyHeightRef.current = bodyEl.offsetHeight
     }
 
     if (expandedBodyHeightRef.current === -1) {
@@ -97,10 +227,14 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       bodyEl.offsetHeight
       expandedBodyHeightRef.current = bodyEl.offsetHeight
-      expandedHeightRef.current = annotationEl.offsetHeight
+
+      expandableElFinalHeight = expandedBodyHeightRef.current
+    }
+    else {
+      expandableElFinalHeight = expandedBodyHeightRef.current
     }
 
-    const translateY = expandedHeightRef.current - collapsedHeightRef.current
+    const translateY = expandedBodyHeightRef.current - collapsedBodyHeightRef.current
 
     // Step 2: Revert back to collapsed state (no visual change yet)
     if (expandedBodyHeightRef.current === -1) {
@@ -108,7 +242,28 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
       bodyEl.classList.add('h-18', 'overflow-y-hidden')
     }
 
-    if (onExpand) onExpand(data.id, bodyEl, expandedBodyHeightRef.current, translateY)
+    return {
+      expandableEl,
+      expandableElFinalHeight,
+      translateY
+    }
+  }
+
+  function expandAnnotation(e: React.MouseEvent, expandType: 'view-more' | 'nested-annotations') {
+    e?.stopPropagation()
+    setIsExpanded(true)
+
+    const bodyEl = annotationBodyRef.current
+
+    if (expandType === 'view-more') {
+      const { expandableEl, expandableElFinalHeight, translateY } = getExpandableInfoOnViewMore(bodyEl)
+      if (onExpand) onExpand(data.id, expandableEl, expandableElFinalHeight, translateY)
+    }
+  }
+
+
+  function handleViewMore(e: React.MouseEvent) {
+    expandAnnotation(e, 'view-more')
   }
 
   function handleViewLess(e: React.MouseEvent) {
@@ -118,21 +273,22 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
     if (onCollapse) onCollapse(bodyEl, DEFAULT_ANNOTATION_BODY_HEIGHT)
   }
 
-  return <>
-    <div
-      ref={ref}
-      aria-label="annotation"
-      data-annotation={data.id}
-      {...(isSelected ? { 'data-selected': true } : {})}
-      className={`w-[calc(100%-2rem)] flex flex-col px-3 py-2 rounded-lg border border-border
-      ${annotationsMode === 'aligned' ? 'absolute' : 'mb-2'}
+  return <div
+    ref={ref}
+    aria-label="annotation"
+    data-annotation={data.id}
+    {...(isSelected ? { 'data-selected': true } : {})}
+    className={` flex flex-col pt-2 rounded-lg border border-border h-fit overflow-x-hidden
+      ${annotationsMode === 'aligned' && !isNested ? 'absolute' : 'mb-2'}
+      ${annotationsMode === 'aligned' ? 'w-[calc(100%-1.3rem)]': !isNested ? 'w-[100%]': 'w-[calc(100%-0.3rem)]' }
       ${isSelected ? 'shadow-md bg-background outline-primary outline-2' : 'bg-muted border-border hover:bg-background cursor-pointer'}
-      ${isHovered ? 'border-primary' : ''} transition-all `}
-      onClick={handleClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      style={{ top }}
-    >
+      ${isHovered ? 'border-primary' : ''} transition-[height] duration-400 ease-in-out h-54 overflow-y-hidden`}
+    onClick={handleClick}
+    onMouseEnter={handleMouseEnter}
+    onMouseLeave={handleMouseLeave}
+    style={{ top }}
+  >
+    <div className="px-3 pb-2">
       <div ref={annotationBodyRef} className={`transition-[height] duration-400 ease-in-out ${isLong && !isExpanded ? 'h-18 overflow-y-hidden' : 'h-fit'}`}  >
         <Badge variant="accent" className="mb-1">{ type }</Badge>
         { type === 'Variant' && <VariantContent body={data.body} /> }
@@ -141,7 +297,8 @@ const Annotation: FC<Props> = React.memo(({ data, top, onExpand, onCollapse }) =
       { isLong && !isExpanded && <Button className="mt-4" size='sm' variant="ghostPrimary" onClick={(e) => handleViewMore(e)} >{t('view_more')}</Button> }
       { isLong && isExpanded && <Button className="mt-4" size='sm' variant="ghostPrimary" onClick={(e) => handleViewLess(e)} >{t('view_less')}</Button> }
     </div>
-  </>
+    { nestedAnnotationsRef.current?.length > 0 && <AnnotationFooter nestedAnnotations={nestedAnnotationsRef.current} showExpanded={showNestedAnnotations} onExpand={expandAnnotation} onCollapse={collapseNestedAnnotations} /> }
+  </div>
 })
 
 export default Annotation

--- a/src/components/panel/annotations/AnnotationFooter.tsx
+++ b/src/components/panel/annotations/AnnotationFooter.tsx
@@ -1,0 +1,51 @@
+import React, { FC, useRef, useState, useEffect } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import Annotation from '@/components/panel/annotations/Annotation.tsx'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  nestedAnnotations: Annotation[],
+  showExpanded: boolean,
+  onExpand?: (e: React.MouseEvent<HTMLDivElement>, expandType: string) => void,
+  onCollapse?: () => void
+}
+
+const AnnotationFooter: FC<Props> = ({ nestedAnnotations, showExpanded, onExpand, onCollapse }) => {
+
+  const [expanded, setExpanded] = useState(false)
+  const nestedAnnotationsRef = useRef(null)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    setExpanded(showExpanded)
+  }, [showExpanded])
+
+  function handleClick(e: React.MouseEvent<HTMLDivElement>) {
+    e.stopPropagation()
+    if (!expanded) {
+      setExpanded(true)
+      onExpand(e, 'nested-annotations')
+      return
+    }
+    setExpanded(false)
+    onCollapse()
+  }
+
+  useEffect(() => {
+    if (showExpanded) setExpanded(true)
+  }, [showExpanded])
+
+
+  return <div className="w-full h-full flex flex-col border-t-[1px] border-gray-400 bg-gray-100">
+    <div className="flex footer-stripe pr-4 py-1 items-center justify-end hover:bg-border hover:cursor-pointer" onClick={(e) => handleClick(e)}>
+      <span className="p-0.5 text-sm">{nestedAnnotations.length} {nestedAnnotations.length > 1 ? t('nested_annotations') : t('nested_annotation')} </span>
+      {expanded ? <ChevronUp size={18} className="" /> : <ChevronDown size={18} />}
+    </div>
+    {expanded && <div className="nested-annotations pl-4  mt-2 flex flex-col gap-1 w-full h-fit" ref={nestedAnnotationsRef}>
+      {nestedAnnotations.map((annotation) => <Annotation key={annotation.id} data={annotation} isNested={true} /> )}
+    </div>
+    }
+  </div>
+}
+
+export default AnnotationFooter

--- a/src/components/panel/annotations/AnnotationsView.tsx
+++ b/src/components/panel/annotations/AnnotationsView.tsx
@@ -35,6 +35,7 @@ const AnnotationsView: FC = () => {
   useEffect(() => {
     if (!selectedAnnotation || annotationsMode !== 'list') return
     const selectedAnnotationEl = (scrollContainer.current as HTMLElement).querySelector(`div[data-annotation="${selectedAnnotation.id}"]`) as HTMLElement
+    if (!selectedAnnotationEl) return
     scrollIntoViewIfNeeded(selectedAnnotationEl, scrollContainer.current)
   }, [selectedAnnotation])
 

--- a/src/contexts/AnnotationsContext.tsx
+++ b/src/contexts/AnnotationsContext.tsx
@@ -1,16 +1,22 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
-import { getFilteredAnnotations } from '@/utils/annotations.ts'
+import { findTargets, getFilteredAnnotations, getNestedAnnotations } from '@/utils/annotations.ts'
 
 type State = {
-  filteredAnnotations: Annotation[]
+  filteredAnnotations: Annotation[],
+  nestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap,
+  setNestedMatchedAnnotationsMap: (newNestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap) => void,
+  hoveredNestedAnnotationIds: string[],
+  setHoveredNestedAnnotationIds: (newHoveredAnnotationIds: string[]) => void,
 }
 
 const AnnotationsContext = createContext<State>(null)
 
 export const AnnotationsProvider = ({ children }: { children: ReactNode }) => {
-  const { matchedAnnotationsMaps } = usePanel()
+  const { matchedAnnotationsMaps, panelState, annotationsMode } = usePanel()
   const [filteredAnnotations, setFilteredAnnotations] = useState<Annotation[]>([])
+  const [nestedMatchedAnnotationsMap, setNestedMatchedAnnotationsMap ] = useState<NestedMatchedAnnotationsMap>({})
+  const [hoveredNestedAnnotationIds, setHoveredNestedAnnotationIds ] = useState<string[]>([])
 
 
   useEffect(() => {
@@ -23,9 +29,27 @@ export const AnnotationsProvider = ({ children }: { children: ReactNode }) => {
     setFilteredAnnotations(newFiltered)
   }, [matchedAnnotationsMaps])
 
+  useEffect(() => {
+    const newNestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap = {}
+    panelState.annotations.forEach((annotation) => {
+      const nestedAnnotations = getNestedAnnotations(annotation, panelState.annotations)
+      const target = findTargets(annotation)
+      newNestedMatchedAnnotationsMap[annotation.id] = {
+        nestedAnnotations,
+        target,
+        annotation
+      }
+    })
+    setNestedMatchedAnnotationsMap(newNestedMatchedAnnotationsMap)
+  }, [panelState.annotations, annotationsMode])
+
   return (
     <AnnotationsContext.Provider value={{
-      filteredAnnotations
+      filteredAnnotations,
+      nestedMatchedAnnotationsMap,
+      setNestedMatchedAnnotationsMap,
+      hoveredNestedAnnotationIds,
+      setHoveredNestedAnnotationIds
     }}>
       {children}
     </AnnotationsContext.Provider>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -229,6 +229,26 @@ declare global {
     }
   }
 
+  // we want nestedMatchedAnnotationsMap to be accessible to every annotation.
+  // since some childAnnotations are not mounted yet, we can't know the HTMLElement of their targets
+  // We would need to maintain 'target': Element[] synchronized among all annotations -> that would require to update
+  // state `nestedMatchedAnnotationsMap`, which is not a good practice.
+  // Therefore let's keep `target`: string[], also an Array of selectors
+  interface NestedMatchedAnnotationsMap {
+    [annotationId: string]: {
+      annotation: Annotation,
+      nestedAnnotations: Annotation[],
+      target: string[]
+    }
+  }
+
+  interface FlippedNestedMatchedAnnotationsMap {
+    [targetSelector: string]: {
+      'el': HTMLElement,
+      'annotationIds': string[]
+    }
+  }
+
   interface MergedAnnotationEntry {
     target: Element
     annotations: Annotation[]

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -69,9 +69,79 @@ function computeNewSelectedAnnotationIndex(targetEntry: MergedAnnotationEntry, p
   return newSelectedAnnotationIndex
 }
 
+function getNestedAnnotations(annotation: Annotation, itemAnnotations: Annotation[]) {
+  if (itemAnnotations.length === 0) return []
+  return itemAnnotations.filter((annot)  => annot.target[0].source === annotation.id)
+}
+
+function findTargetsInsideAnnotation(annotationId: string, itemAnnotations: Annotation[]) {
+  const nestedAnnotations = itemAnnotations.filter((annot) => annot.target[0]?.source === annotationId)
+  const selectors: string[] = []
+
+  nestedAnnotations.forEach((annot) => {
+    const target = annot.target[0]
+    if (!target?.selector) return {}
+    const { selector } = target
+    let cssValue: string | null = null
+
+    if (selector.type === 'CssSelector')  cssValue = selector.value
+    // TODO: we need to handle Range selectors
+    if (cssValue) selectors.push(cssValue)
+  })
+  return selectors
+}
+
+function findTargets(annotation: Annotation): string[] {
+  return annotation.target.map((target) => {
+    if (target.selector.type === 'CssSelector') return target.selector.value
+    // TODO: include case of Range Selectors
+  })
+}
+
+function getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap) {
+  // append only the targets which are located in 'Annotation', but not in 'Text'
+  const flippedNestedMatchedAnnotationsMap: FlippedNestedMatchedAnnotationsMap = {}
+
+  Object.keys(nestedMatchedAnnotationsMap).forEach((annotationId) => {
+    const entry = nestedMatchedAnnotationsMap[annotationId]
+    const target = entry.target
+    const targetLocation = entry.annotation.target[0].source.endsWith('.html') ? 'text' : 'annotation'
+
+    if (targetLocation === 'text') return
+
+    target?.forEach((selector: string) => {
+      if (!Object.hasOwn(flippedNestedMatchedAnnotationsMap, selector)) {
+        const el = document.querySelector<HTMLElement>(selector)
+        flippedNestedMatchedAnnotationsMap[selector] = {
+          annotationIds: [annotationId],
+          el
+        }
+      }
+      else {
+        flippedNestedMatchedAnnotationsMap[selector].annotationIds.push(annotationId)
+      }
+    })
+  })
+
+  return flippedNestedMatchedAnnotationsMap
+}
+
+function getAnnotationIdsByEl(
+  flipped: Record<string, { el: HTMLElement, annotationIds: string[] }>,
+  el: HTMLElement
+): string[] {
+  const entry = Object.values(flipped).find(v => v.el === el)
+  return entry?.annotationIds ?? []
+}
+
 export {
   getSelectedTypes,
   getFilteredAnnotations,
   isSelected,
   computeNewSelectedAnnotationIndex,
+  findTargetsInsideAnnotation,
+  findTargets,
+  getNestedAnnotations,
+  getFlippedNestedMatchedAnnotationsMap,
+  getAnnotationIdsByEl
 }

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -110,7 +110,11 @@ function validateTheme(input: unknown): ValidationResult<TidoConfig['theme']> {
         : (() => {
           if (input !== undefined && inputObj && inputObj['primaryColor'] !== undefined) errors['theme.primaryColor'] = 'must be a valid rgb, hex, hsl or oklch color'
           return defaultConfig.theme?.primaryColor
-        })()
+        })(),
+    theme:
+      inputObj && (inputObj['theme'] === 'light' || inputObj['theme'] === 'dark' || inputObj['theme'] === 'system')
+        ? inputObj['theme'] as 'light' | 'dark' | 'system'
+        : defaultConfig.theme.theme
   }
   return { result, errors }
 }

--- a/src/utils/config/default-config.ts
+++ b/src/utils/config/default-config.ts
@@ -11,7 +11,8 @@ const defaultConfig: TidoConfig = {
   showPanelPlaceholder: true,
   showThemeToggle: true,
   theme: {
-    primaryColor: '#3456aa'
+    primaryColor: '#3456aa',
+    theme: 'system'
   },
   title: '',
   translations: {},

--- a/tests/mocks/example/book1/page1/rev1/annotationCollection.json
+++ b/tests/mocks/example/book1/page1/rev1/annotationCollection.json
@@ -3,7 +3,7 @@
   "id": "http://localhost:8181/example/book1/page1/rev1/annotationCollection.json",
   "type": "AnnotationCollection",
   "label": "Annotations for Pride and Prejudice, Chapter 1",
-  "total": 11,
+  "total": 17,
   "first": "http://localhost:8181/example/book1/page1/rev1/annotationPage.json",
   "last": "http://localhost:8181/example/book1/page1/rev1/annotationPage.json"
 }

--- a/tests/mocks/example/book1/page1/rev1/annotationPage.json
+++ b/tests/mocks/example/book1/page1/rev1/annotationPage.json
@@ -5,7 +5,7 @@
   "partOf": {
     "id": "http://localhost:8181/example/book1/page1/rev1/annotationCollection.json",
     "label": "Annotations for Pride and Prejudice, Chapter 1",
-    "total": 11
+    "total": 17
   },
   "next": null,
   "prev": null,
@@ -16,8 +16,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "This is one of the most famous opening lines in English literature. It sets the theme of marriage and social class that pervades the novel.",
-        "format": "text/plain",
+        "value": "This is one of the <span id=\"famous-opening-lines\">most famous opening lines in English literature</span>. It sets the theme of marriage and social class that pervades the novel.",
+        "format": "text/html",
         "x-content-type": "Literary Analysis"
       },
       "target": [
@@ -37,8 +37,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Refers to wealthy bachelors who were prime marriage candidates in Regency England.",
-        "format": "text/plain",
+        "value": "Refers to wealthy bachelors who were <span id=\"marriage-candidates\">prime marriage candidates in Regency England</span>.",
+        "format": "text/html",
         "x-content-type": "Historical Context"
       },
       "target": [
@@ -58,8 +58,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Mr. Bennet - The patriarch of the Bennet family, known for his wit and sarcasm.",
-        "format": "text/plain",
+        "value": "Mr. Bennet - The patriarch of the Bennet family, known for his <span id=\"wit-and-sarcasm\">wit and sarcasm</span>.",
+        "format": "text/html",
         "x-content-type": "Character"
       },
       "target": [
@@ -79,8 +79,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Netherfield Park - The estate rented by Mr. Bingley, which becomes central to the plot.",
-        "format": "text/plain",
+        "value": "Netherfield Park - <span id=\"netherfield-park-estate\">The estate rented by Mr. Bingley</span>, which becomes central to the plot.",
+        "format": "text/html",
         "x-content-type": "Place"
       },
       "target": [
@@ -100,8 +100,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Mrs. Long - A neighbor who serves as a source of gossip and information.",
-        "format": "text/plain",
+        "value": "Mrs. Long - <span id=\"mrs-long-character\">A neighbor who serves as a source of gossip and information</span>.",
+        "format": "text/html",
         "x-content-type": "Character"
       },
       "target": [
@@ -117,12 +117,33 @@
       ]
     },
     {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-6",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "A <span id=\"neighbourhood-visiting\">neighbourhood in Regency England typically meant families within a day's visiting distance</span>, roughly a five-mile radius.",
+        "format": "text/html",
+        "x-content-type": "Historical Context"
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/book1/page1/rev1/content.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#neighbourhood"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
       "id": "http://localhost:8181/example/book1/page1/rev1/annotation-diplomatic-1",
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "This phrase appears in early manuscripts with variant punctuation.",
-        "format": "text/plain",
+        "value": "This phrase appears <span id=\"famous-opening-lines\">with variant</span> in early manuscripts This phrase appears in early manuscripts This phrase appears in early manuscripts <span id=\"famous-opening-lines-2\">with variant</span>This phrase appears in early manuscripts  punctuation.",
+        "format": "text/html",
         "x-content-type": "Textual Variant"
       },
       "target": [
@@ -142,8 +163,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Original manuscript shows \"rightfull propertie\" with period spelling.",
-        "format": "text/plain",
+        "value": "Original manuscript shows <span id=\"rightfull-propertie\">\"rightfull propertie\" with period spelling</span>.",
+        "format": "text/html",
         "x-content-type": "Orthographic Feature"
       },
       "target": [
@@ -163,8 +184,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Manuscript shows this phrase with interlinear revision.",
-        "format": "text/plain",
+        "value": "Manuscript shows this phrase with <span id=\"interlinear-revision\">interlinear revision</span>.",
+        "format": "text/html",
         "x-content-type": "Authorial Revision"
       },
       "target": [
@@ -184,8 +205,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Modern usage would be \"who possesses\" but period phrasing preserved.",
-        "format": "text/plain",
+        "value": "Modern usage would be \"who possesses\" but <span id=\"period-phrasing\">period phrasing preserved</span>.",
+        "format": "text/html",
         "x-content-type": "Stylistic Note"
       },
       "target": [
@@ -205,8 +226,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Editorial note: Refers to the local gentry within visiting distance.",
-        "format": "text/plain",
+        "value": "Editorial note: Refers to the <span id=\"local-gentry\">local gentry within visiting distance</span>.",
+        "format": "text/html",
         "x-content-type": "Contextual Note"
       },
       "target": [
@@ -226,8 +247,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Standardized from original \"answer'd he had not\".",
-        "format": "text/plain",
+        "value": "Standardized from <span id=\"answered-he-had-not\">original \"answer'd he had not\"</span>.",
+        "format": "text/html",
         "x-content-type": "Modernization"
       },
       "target": [
@@ -241,6 +262,159 @@
           "language": "eng"
         }
       ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-1",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "This literary analysis is rooted in the 20th-century <span id=\"austen-scholarship\">Austen scholarship tradition</span> established by critics such as Reuben Brower.",
+        "format": "text/html",
+        "x-content-type": "Scholarly Commentary"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-diplomatic-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#famous-opening-lines-2"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-1b",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "The variant punctuation in early manuscripts reflects <span id=\"scribal-practice\">scribal practice of the period</span>, where comma usage was not yet standardized.",
+        "format": "text/html",
+        "x-content-type": "Codicological Note"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-diplomatic-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#famous-opening-lines"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-1c",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Cross-referencing with the <span id=\"chapman-edition\">R.W. Chapman 1923 edition</span> reveals that this variant was silently regularized in most 20th-century reprints.",
+        "format": "text/html",
+        "x-content-type": "Editorial History"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-diplomatic-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#famous-opening-lines"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-1d",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "This textual variant is significant because <span id=\"punctuation-meaning\">punctuation changes can subtly alter the ironic tone</span> of the sentence as read aloud.",
+        "format": "text/html",
+        "x-content-type": "Rhetorical Analysis"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-diplomatic-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#famous-opening-lines"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-2",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "The historical context note draws primarily on <span id=\"vickery-georgian\">Amanda Vickery's work on Georgian England</span> and the marriage market.",
+        "format": "text/html",
+        "x-content-type": "Bibliographic Reference"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-2",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#marriage-candidates"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-3",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "The character description overlooks Mr. Bennet's <span id=\"ironic-detachment\">deliberate ironic detachment from his own social standing</span>.",
+        "format": "text/html",
+        "x-content-type": "Critical Objection"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-3",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#wit-and-sarcasm"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L3-1",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Agreed — see also the influence of <span id=\"leavis-criticism\">F.R. Leavis on this strand of Austen criticism</span>, particularly his emphasis on moral seriousness.",
+        "format": "text/html",
+        "x-content-type": "Agreement"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#austen-scholarship"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L3-2",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Counter-point: Vickery's framing has been contested by <span id=\"post-colonial-readings\">more recent post-colonial readings of Austen's domestic sphere</span>.",
+        "format": "text/html",
+        "x-content-type": "Counter-argument"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-L2-2",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#vickery-georgian"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-L4-1",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "<span id=\"leavis-great-tradition\">Leavis's 'The Great Tradition' (1948)</span> is the canonical reference here, though it subordinates Austen to later novelists. His framework has itself been heavily critiqued since the 1970s.",
+        "format": "text/html",
+        "x-content-type": "Bibliographic Note"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page1/rev1/annotation-L3-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#leavis-criticism"
+        }
+      }]
     }
   ]
 }

--- a/tests/mocks/example/book1/page2/rev1/annotationPage.json
+++ b/tests/mocks/example/book1/page2/rev1/annotationPage.json
@@ -5,7 +5,7 @@
   "partOf": {
     "id": "http://localhost:8181/example/book1/page2/rev1/annotationCollection.json",
     "label": "Annotations for Pride and Prejudice, Chapter 2",
-    "total": 7
+    "total": 12
   },
   "next": null,
   "prev": null,
@@ -16,8 +16,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Charles Bingley - A wealthy, amiable young gentleman who rents Netherfield Park. He becomes attracted to Jane Bennet.",
-        "format": "text/plain",
+        "value": "Charles Bingley - <span id=\"bingley-character\">A wealthy, amiable young gentleman who rents Netherfield Park</span>. He becomes attracted to Jane Bennet.",
+        "format": "text/html",
         "x-content-type": "Character"
       },
       "target": [
@@ -37,8 +37,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Lizzy - Affectionate nickname for Elizabeth Bennet, the novel's protagonist.",
-        "format": "text/plain",
+        "value": "Lizzy - <span id=\"lizzy-nickname\">Affectionate nickname for Elizabeth Bennet, the novel's protagonist</span>.",
+        "format": "text/html",
         "x-content-type": "Character"
       },
       "target": [
@@ -58,8 +58,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Public assemblies were social gatherings where dancing and socializing took place, important venues for courtship in Regency England.",
-        "format": "text/plain",
+        "value": "Public assemblies were <span id=\"assembly-gatherings\">social gatherings where dancing and socializing took place</span>, important venues for courtship in Regency England.",
+        "format": "text/html",
         "x-content-type": "Historical Context"
       },
       "target": [
@@ -79,8 +79,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Manuscript variant: \"amongst the earliest\" found in draft.",
-        "format": "text/plain",
+        "value": "Manuscript variant: <span id=\"earliest-variant\">\"amongst the earliest\" found in draft</span>, suggesting Austen softened the phrasing in revision.",
+        "format": "text/html",
         "x-content-type": "Textual Variant"
       },
       "target": [
@@ -100,8 +100,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Original shows \"trimming an hat\" with period article usage.",
-        "format": "text/plain",
+        "value": "Original shows <span id=\"period-article-usage\">\"trimming an hat\" with period article usage</span> before words beginning with a consonantal 'h'.",
+        "format": "text/html",
         "x-content-type": "Grammatical Feature"
       },
       "target": [
@@ -121,8 +121,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Clarified from archaic construction for modern readers.",
-        "format": "text/plain",
+        "value": "<span id=\"archaic-construction\">Clarified from archaic construction for modern readers</span>; the original idiom \"to the last\" means \"right up until the end\".",
+        "format": "text/html",
         "x-content-type": "Clarification"
       },
       "target": [
@@ -142,8 +142,8 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "Period idiom meaning \"have no means of knowing\".",
-        "format": "text/plain",
+        "value": "Period idiom meaning <span id=\"period-idiom\">\"have no means of knowing\"</span>, reflecting the social constraints on women's access to information.",
+        "format": "text/html",
         "x-content-type": "Idiomatic Expression"
       },
       "target": [
@@ -157,6 +157,91 @@
           "language": "eng"
         }
       ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page2/rev1/annotation-L2-1",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Bingley's easy temperament contrasts deliberately with Darcy's reserve — <span id=\"bingley-foil\">Austen uses him as a social foil to highlight class anxiety</span> in the marriage market.",
+        "format": "text/html",
+        "x-content-type": "Literary Analysis"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page2/rev1/annotation-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#bingley-character"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page2/rev1/annotation-L2-2",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "The use of \"Lizzy\" here signals <span id=\"family-intimacy\">the informality of the Bennet household's domestic register</span>, in contrast to the formal address used in public scenes.",
+        "format": "text/html",
+        "x-content-type": "Stylistic Note"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page2/rev1/annotation-2",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#lizzy-nickname"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page2/rev1/annotation-L2-3",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "The variant \"amongst the earliest\" points to <span id=\"textual-transmission\">an early layer of composition before Austen's systematic revision</span> of Chapter 2's opening.",
+        "format": "text/html",
+        "x-content-type": "Scholarly Commentary"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page2/rev1/annotation-diplomatic-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#earliest-variant"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page2/rev1/annotation-L3-1",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "This reading of Bingley as foil aligns with <span id=\"bingley-darcy-dynamic\">D.A. Miller's argument on the complementary pairing of Bingley and Darcy</span> as a structural device throughout the novel.",
+        "format": "text/html",
+        "x-content-type": "Bibliographic Reference"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page2/rev1/annotation-L2-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#bingley-foil"
+        }
+      }]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page2/rev1/annotation-L4-1",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Miller's structural reading has been <span id=\"miller-critique\">challenged by feminist narratologists who prioritise voice over character pairing</span> as the organising principle of Austen's irony.",
+        "format": "text/html",
+        "x-content-type": "Counter-argument"
+      },
+      "target": [{
+        "source": "http://localhost:8181/example/book1/page2/rev1/annotation-L3-1",
+        "selector": {
+          "type": "CssSelector",
+          "value": "#bingley-darcy-dynamic"
+        }
+      }]
     }
   ]
 }


### PR DESCRIPTION
This is a first implementation of `Annotations in Annotations` feat. 
Please notice the following
1. I considered only a single selection of target in this PR. I didn't consider a second selection, which can select the next annotation in multi-annotations target or deselect it.
2. I did not aim to solve the expanding of annotations inside another annotation in Align Mode. The changes I include here should improve a bit the current solution and pave the way to the next PR on actually using this feature in Align Mode.

Closes #874 