### PR TITLE
refactor: use visible state to toggle panel views instead of re-mounting

### DIFF
--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -18,10 +18,11 @@ const PanelContent: FC = React.memo(() => {
   const [contentPanes, setContentPanes] = useState([])
 
   useEffect(() => {
-    const panes = panelState.panelViews.filter(v => v.visible).map((v) => {
+    const panes = panelState.panelViews.map((v) => {
       const key = `${v.view}-${v.label || 'default'}`
+      const visible = v.visible ?? true
       if (v.view === 'image') return <ImageView key={key} />
-      else return <TextView key={key} label={v.label} contentTypes={v.contentTypes} />
+      else return <TextView key={key} label={v.label} contentTypes={v.contentTypes} visible={visible} />
     })
 
     setContentPanes(panes)
@@ -62,9 +63,12 @@ const PanelContent: FC = React.memo(() => {
             <PanelHeader />
             <div className="flex-1">
               <Allotment proportionalLayout={true}>
-                {contentPanes.map((pane) => <Allotment.Pane key={pane.key}>
-                  {pane}
-                </Allotment.Pane>)}
+                {contentPanes.map((pane, index) => {
+                  const visible = panelState.panelViews[index]?.visible ?? true
+                  return <Allotment.Pane key={pane.key} visible={visible}>
+                    {pane}
+                  </Allotment.Pane>
+                })}
               </Allotment>
             </div>
           </div>

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -2,6 +2,7 @@ import {
   FC,
   memo,
   useEffect,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -55,7 +56,7 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   } = usePanel()
 
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
-  const { matchedAnnotationsMap, setMatchedAnnotationsMap, activeContentUrl } = useTextView()
+  const { matchedAnnotationsMap, setMatchedAnnotationsMap, activeContentUrl, visible } = useTextView()
 
   const [portals, setPortals] = useState([])
 
@@ -65,13 +66,17 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   const flippedMatchedAnnotationsMapRef = useRef<MergedAnnotationEntry[]>(null)
   const targetsRef = useRef<HTMLElement[]>(null)
 
+  // This is the actual value for matched annotations that is used for rendering.
+  // With the state "matchedAnnotationsMap" we create a data-driven version of the map while with "displayedMap"
+  // we create a UI-driven value. This applies when the user toggles on/off the TextView.
+  const displayedMap = useMemo(() => visible ? matchedAnnotationsMap : {}, [visible, matchedAnnotationsMap])
+
   function containsChildren(targets: HTMLElement[], target: HTMLElement) {
     for(const t of targets) {
       if (target.contains(t) && target !== t) return true
     }
     return false
   }
-
 
   const onClickTarget = (e: Event) => {
     // Generic click listener
@@ -109,7 +114,6 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   useEffect(() => {
     annotationsModeRef.current = annotationsMode
   }, [annotationsMode])
-
 
   const onMouseEnterTarget = (e: Event) => {
     const target = e.currentTarget as HTMLElement
@@ -150,7 +154,7 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   useEffect(() => {
     if (!panelState.annotations || !parsedDom) return
 
-    const result: MatchedAnnotationsMap = panelState.annotations.reduce<MatchedAnnotationsMap>((acc, cur) => {
+    const result = panelState.annotations.reduce<MatchedAnnotationsMap>((acc, cur) => {
       const isSource = cur.target[0].source === activeContentUrl.current
       const selector = (cur.target[0].selector as CssSelector)?.value
 
@@ -219,8 +223,8 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
 
   // Apply highlighting styles on every map update
   useEffect(() => {
-    if (!matchedAnnotationsMap) return
-    const flippedMatchedAnnotationsMap = flipMatchedAnnotationsMap(matchedAnnotationsMap)
+    if (!displayedMap) return
+    const flippedMatchedAnnotationsMap = flipMatchedAnnotationsMap(displayedMap)
     targetsRef.current = getTextTargets(flippedMatchedAnnotationsMap)
     flippedMatchedAnnotationsMapRef.current = assignNestedTargetsInFlippedMatched(targetsRef.current, flippedMatchedAnnotationsMap)
 
@@ -247,14 +251,14 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
         addHighlightStyle(target)
       }
     })
-  }, [matchedAnnotationsMap])
+  }, [displayedMap])
 
   // Apply selected styles on every selectedAnnotation update
   useEffect(() => {
-    if (!matchedAnnotationsMap) return
+    if (!displayedMap) return
     const targetsOfSelectedAnnotation =
-      selectedAnnotation && !!(matchedAnnotationsMap[selectedAnnotation.id])
-        ? matchedAnnotationsMap[selectedAnnotation.id].target
+      selectedAnnotation && !!(displayedMap[selectedAnnotation.id])
+        ? displayedMap[selectedAnnotation.id].target
         : []
 
     flippedMatchedAnnotationsMapRef.current.forEach(fa => {
@@ -281,7 +285,7 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
         addHighlightStyle(target)
       }
     })
-  }, [selectedAnnotation, matchedAnnotationsMap])
+  }, [selectedAnnotation, displayedMap])
 
   return <div className="relative flex">
     <div data-text-wrapper ref={textWrapperRef} className="pt-16"></div>

--- a/src/components/panel/views/TextView.tsx
+++ b/src/components/panel/views/TextView.tsx
@@ -8,13 +8,14 @@ import { TextViewProvider } from '@/contexts/TextViewContext.tsx'
 interface Props {
   contentTypes: string[]
   label?: string
+  visible: boolean
 }
-const TextView: FC<Props> = ({ contentTypes, label }) => {
+const TextView: FC<Props> = ({ contentTypes, label, visible }) => {
   const { panelState } = usePanel()
 
   return <div className={`bg-background relative flex h-full w-full overflow-hidden`}>
     <ErrorBoundary FallbackComponent={TextViewError} resetKeys={[panelState.item?.id]}>
-      <TextViewProvider contentTypes={contentTypes} label={label}>
+      <TextViewProvider contentTypes={contentTypes} label={label} visible={visible}>
         <TextViewContent />
       </TextViewProvider>
     </ErrorBoundary>

--- a/src/contexts/TextViewContext.tsx
+++ b/src/contexts/TextViewContext.tsx
@@ -14,6 +14,7 @@ type State = {
   setActiveContentType: (contentType: string) => void
   label: string
   text: string
+  visible: boolean
   matchedAnnotationsMap: MatchedAnnotationsMap
   setMatchedAnnotationsMap: (map: MatchedAnnotationsMap) => void
 }
@@ -23,10 +24,12 @@ const TextViewContext = createContext<State>(null)
 export const TextViewProvider = ({
   contentTypes,
   label,
+  visible,
   children
 }: {
   contentTypes: string[]
   label: string
+  visible: boolean
   children: ReactNode
 }) => {
   const { panelState, loading: loadingPanel, usePanelTranslation, matchedAnnotationsMaps, updateMatchedAnnotationsMap } = usePanel()
@@ -118,6 +121,7 @@ export const TextViewProvider = ({
       setActiveContentType,
       label,
       text,
+      visible,
       matchedAnnotationsMap,
       setMatchedAnnotationsMap
     }}>


### PR DESCRIPTION
Trying to use "visible" feature of Allotment in order to toggle panel views. Problem was, that by mapping through the panelViews Allotment panes would be rendered conditionally. That would re-mount TextView and ImageView component with all consequences e.g. triggering API requests. 

The new suggestion is to update matchedAnnotationsMap also on change of "visible", this might have other consequences but let's see. 