### PR TITLE
Generic text rendering - generic component which includes main text functionalities of TextRenderer

### DIFF
--- a/src/components/GenericTextRenderer.tsx
+++ b/src/components/GenericTextRenderer.tsx
@@ -3,7 +3,7 @@ import {
   addAnnotationId, addHighlightStyle,
   addHoverStyle,
   addNestedTargetStyle,
-  flipMatchedAnnotationsMap,
+  flipMatchedAnnotationsMap, getAnnotationIds,
   getHoveredAnnotationsIds,
   getRootCrossRefElements,
   getTargetsHoveredAnnotations,
@@ -16,9 +16,11 @@ import {
 } from '@/utils/text.ts'
 import { createPortal } from 'react-dom'
 import CrossRefLink from '@/components/panel/CrossRef/CrossRefLink.tsx'
-import { createMatchedAnnotationsMap, isFiltered } from '@/utils/annotations.ts'
+import { computeNewSelectedAnnotationIndex, createMatchedAnnotationsMap, isFiltered } from '@/utils/annotations.ts'
 import { useText } from '@/contexts/TextContext.tsx'
 import { usePanel } from '@/contexts/PanelContext.tsx'
+
+import { containsChildren } from '@/utils/text.ts'
 
 interface Props {
   htmlString?: string,
@@ -27,15 +29,15 @@ interface Props {
   updateMatchedAnnotationsMap?: (newMatchedAnnotationsMap: object) => void,
   annotations: Annotation[],
   source: string,
-  onClickTarget?: (e: Event) => void,
+  onTargetClick?: () => void,
   onMouseLeaveTarget?: (e: Event) => void,
   isAnnotation: boolean
 }
 const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnnotationsMap, annotations, source, isAnnotation
-  , selectedAnnotationTypes, onClickTarget, onMouseLeaveTarget }) => {
+  , selectedAnnotationTypes, onTargetClick ,onMouseLeaveTarget }) => {
 
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
-  const { selectedAnnotation, panelId } = usePanel()
+  const { selectedAnnotation, setSelectedAnnotation, panelId } = usePanel()
 
   const [portals, setPortals] = useState([])
   const textWrapperRef = useRef<HTMLDivElement>(null)
@@ -44,6 +46,7 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
   const flippedMatchedAnnotationsMapRef = useRef<MergedAnnotationEntry[]>(null)
   const matchedAnnotationsMapRef = useRef<MatchedAnnotationsMap>(null)
   const targetsRef = useRef<HTMLElement[]>(null)
+  const prevClickedTargetIndexRef = useRef<number>(null)
 
 
   // Document object that is only recreated when htmlString changes - e.g. on item change or content type change
@@ -77,6 +80,38 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
 
     setHoveredAnnotations(idsArray)
   }
+
+  const onClickTarget = (e: Event) => {
+    // Generic click listener
+    // TODO:  Be careful with state here. This listener will be added once a new map is created.
+    //  So this function will be called with those state values which existed at the time of adding.
+
+    const target = e.currentTarget as Element
+    const targetEntry: MergedAnnotationEntry = flippedMatchedAnnotationsMapRef.current.filter(entry => entry.target === target)[0]
+
+    if (!containsChildren(targetsRef.current, target as HTMLElement)) {
+      // handle only click events on 'deepest' target -> ignore click events on its containing targets while selection
+      e.stopPropagation()
+    }
+
+    const idsValue = getAnnotationIds(target)
+    if (!idsValue) return
+
+    targetEntry.selectedAnnotationIndex = computeNewSelectedAnnotationIndex(targetEntry, prevClickedTargetIndexRef.current, flippedMatchedAnnotationsMapRef.current)
+
+    const annotation = targetEntry.selectedAnnotationIndex !== -1 ? targetEntry.annotations[targetEntry.selectedAnnotationIndex] : null
+
+    if (annotation) {
+      setSelectedAnnotation(annotation)
+      prevClickedTargetIndexRef.current = flippedMatchedAnnotationsMapRef.current.findIndex(entry => targetEntry === entry)
+      if (onTargetClick) onTargetClick()
+    }
+    else {
+      setSelectedAnnotation(null)
+    }
+  }
+
+
 
   useEffect(() => {
     // get all targets of hoveredAnnotations

--- a/src/components/GenericTextRenderer.tsx
+++ b/src/components/GenericTextRenderer.tsx
@@ -41,12 +41,10 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
   , selectedAnnotationTypes, onTargetClick ,onMouseLeaveTarget }) => {
 
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
-  const { selectedAnnotation, setSelectedAnnotation, panelId } = usePanel()
-
+  const { selectedAnnotation, setSelectedAnnotation } = usePanel()
   const [portals, setPortals] = useState([])
+
   const textWrapperRef = useRef<HTMLDivElement>(null)
-
-
   const flippedMatchedAnnotationsMapRef = useRef<MergedAnnotationEntry[]>(null)
   const matchedAnnotationsMapRef = useRef<MatchedAnnotationsMap>(null)
   const targetsRef = useRef<HTMLElement[]>(null)
@@ -81,7 +79,6 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
     const target = e.currentTarget as HTMLElement
     const idsArray = getHoveredAnnotationsIds(target, targetsRef.current)
     if (idsArray.length === 0) return
-
     setHoveredAnnotations(idsArray)
   }
 
@@ -114,7 +111,6 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
       setSelectedAnnotation(null)
     }
   }
-
 
 
   useEffect(() => {
@@ -164,11 +160,10 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
   function assignFilteredInMap(matchedMap: MatchedAnnotationsMap, selectedAnnotationTypes: AnnotationTypesDict, annotations: Annotation[]) {
     const newMap = { ...matchedMap }
     annotations.forEach((annotation) => {
-      if (newMap.hasOwnProperty(annotation.id)) newMap[annotation.id].filtered = !selectedAnnotationTypes || isFiltered(annotation, selectedAnnotationTypes)
+      if (Object.prototype.hasOwnProperty.call(newMap, annotation.id)) newMap[annotation.id].filtered = !selectedAnnotationTypes || isFiltered(annotation, selectedAnnotationTypes)
     })
     return newMap
   }
-
 
   // Create and set matchedAnnotationsMap by identifying target nodes. Add click listeners to targets.
   useEffect(() => {

--- a/src/components/GenericTextRenderer.tsx
+++ b/src/components/GenericTextRenderer.tsx
@@ -16,7 +16,11 @@ import {
 } from '@/utils/text.ts'
 import { createPortal } from 'react-dom'
 import CrossRefLink from '@/components/panel/CrossRef/CrossRefLink.tsx'
-import { computeNewSelectedAnnotationIndex, createMatchedAnnotationsMap, isFiltered } from '@/utils/annotations.ts'
+import {
+  computeNewSelectedAnnotationIndex,
+  getNestedAnnotations,
+  isFiltered
+} from '@/utils/annotations.ts'
 import { useText } from '@/contexts/TextContext.tsx'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 
@@ -121,10 +125,9 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
     const matchedAnnotationsMap = matchedAnnotationsMapRef.current
 
     if (!matchedAnnotationsMap) return
-    const panelEl = document.getElementById(panelId)
     const targetsOfHoveredAnnotations = getTargetsHoveredAnnotations(hoveredAnnotations, targetsRef.current, matchedAnnotationsMap)
     const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedAnnotationsMap[selectedAnnotation.id]) ?
-      matchedAnnotationsMap[selectedAnnotation.id].target.map((selector) => panelEl.querySelector(selector)) : []
+      matchedAnnotationsMap[selectedAnnotation.id].target : []
 
     flippedMatchedAnnotationsMapRef.current?.forEach(fa => {
       const target = fa.target as HTMLElement
@@ -171,17 +174,9 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
   useEffect(() => {
     if (!annotations || !parsedDom) return
 
-    let matchedAnnotationsMap: MatchedAnnotationsMap = {}
-
     const annotationsInText = annotations.filter(annotation => annotation.target[0].source === source)
-    matchedAnnotationsMap = createMatchedAnnotationsMap(annotationsInText, isAnnotation)
-    matchedAnnotationsMapRef.current = matchedAnnotationsMap
 
-    if (!isAnnotation) matchedAnnotationsMap = assignFilteredInMap(matchedAnnotationsMap, selectedAnnotationTypes, annotations)
-    flippedMatchedAnnotationsMapRef.current = flipMatchedAnnotationsMap(matchedAnnotationsMap)
-    targetsRef.current = getTextTargets(flippedMatchedAnnotationsMapRef.current)
-
-
+    let matchedAnnotationsMap: MatchedAnnotationsMap = {}
     annotations.forEach((annotation) => {
       const isSource = annotation.target[0].source === source
       const selector = (annotation.target[0].selector as CssSelector)?.value
@@ -193,6 +188,14 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
 
       const matchedNodes = Array.from(parsedDom.querySelectorAll(selector))
 
+      const nestedAnnotations = getNestedAnnotations(annotation, annotationsInText)
+      matchedAnnotationsMap[annotation.id] = {
+        nestedAnnotations,
+        target: matchedNodes,
+        annotation
+      }
+      if (isAnnotation) matchedAnnotationsMap[annotation.id].filtered = true
+
       if (matchedNodes.length > 0) {
         matchedNodes.forEach(target => {
           addAnnotationId(target, annotation.id)
@@ -201,6 +204,11 @@ const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnno
           target.addEventListener('mouseleave', onMouseLeaveTarget)
         })
       }})
+
+    if (!isAnnotation) matchedAnnotationsMap = assignFilteredInMap(matchedAnnotationsMap, selectedAnnotationTypes, annotations)
+    matchedAnnotationsMapRef.current = matchedAnnotationsMap
+    flippedMatchedAnnotationsMapRef.current = flipMatchedAnnotationsMap(matchedAnnotationsMap)
+    targetsRef.current = getTextTargets(flippedMatchedAnnotationsMapRef.current)
 
     if (!isAnnotation) updateMatchedAnnotationsMap(matchedAnnotationsMap)
   }, [parsedDom, annotations])

--- a/src/components/GenericTextRenderer.tsx
+++ b/src/components/GenericTextRenderer.tsx
@@ -1,0 +1,179 @@
+import React, { FC, useEffect, useRef, useState } from 'react'
+import {
+  addAnnotationId, addHighlightStyle,
+  addHoverStyle,
+  addNestedTargetStyle,
+  flipMatchedAnnotationsMap,
+  getHoveredAnnotationsIds,
+  getRootCrossRefElements,
+  getTargetsHoveredAnnotations,
+  getTextTargets,
+  isParentHovered,
+  isTargetPartOfSelectedAnnotation,
+  removeHighlightStyle,
+  removeHoverStyle,
+  removeNestedTargetStyle
+} from '@/utils/text.ts'
+import { createPortal } from 'react-dom'
+import CrossRefLink from '@/components/panel/CrossRef/CrossRefLink.tsx'
+import { createMatchedAnnotationsMap, isFiltered } from '@/utils/annotations.ts'
+import { useText } from '@/contexts/TextContext.tsx'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+
+interface Props {
+  htmlString?: string,
+  onReady?: () => void,
+  selectedAnnotationTypes?: AnnotationTypesDict,
+  updateMatchedAnnotationsMap?: (newMatchedAnnotationsMap: object) => void,
+  annotations: Annotation[],
+  source: string,
+  onClickTarget?: (e: Event) => void,
+  onMouseLeaveTarget?: (e: Event) => void,
+  isAnnotation: boolean
+}
+const GenericTextRenderer: FC<Props> = ({ htmlString, onReady, updateMatchedAnnotationsMap, annotations, source, isAnnotation
+  , selectedAnnotationTypes, onClickTarget, onMouseLeaveTarget }) => {
+
+  const { hoveredAnnotations, setHoveredAnnotations } = useText()
+  const { selectedAnnotation, panelId } = usePanel()
+
+  const [portals, setPortals] = useState([])
+  const textWrapperRef = useRef<HTMLDivElement>(null)
+
+
+  const flippedMatchedAnnotationsMapRef = useRef<MergedAnnotationEntry[]>(null)
+  const matchedAnnotationsMapRef = useRef<MatchedAnnotationsMap>(null)
+  const targetsRef = useRef<HTMLElement[]>(null)
+
+
+  // Document object that is only recreated when htmlString changes - e.g. on item change or content type change
+  const parsedDom: Element = React.useMemo(() => {
+    if (htmlString === '') return
+    const doc = new DOMParser().parseFromString(`${htmlString}`, 'text/html')
+    return doc.querySelector('body')
+  }, [htmlString])
+
+  // Make the text visible - set the content of the Document object as children of textWrapperRef.
+  // Create cross ref links with portals.
+  useEffect(() => {
+    if (!parsedDom) return
+
+    const links = getRootCrossRefElements(parsedDom)
+    setPortals(links.map(link => {
+      const mount = document.createElement(link.tagName)
+      link.replaceWith(mount)
+      return createPortal(<CrossRefLink node={link as HTMLElement} />, mount)
+    }))
+
+    textWrapperRef.current.replaceChildren(parsedDom)
+    if (onReady) onReady()
+  }, [parsedDom])
+
+
+  const onMouseEnterTarget = (e: Event) => {
+    const target = e.currentTarget as HTMLElement
+    const idsArray = getHoveredAnnotationsIds(target, targetsRef.current)
+    if (idsArray.length === 0) return
+
+    setHoveredAnnotations(idsArray)
+  }
+
+  useEffect(() => {
+    // get all targets of hoveredAnnotations
+    // get all targets of selectedAnnotations
+    // if necessary update styles of targets
+
+    const matchedAnnotationsMap = matchedAnnotationsMapRef.current
+
+    if (!matchedAnnotationsMap) return
+    const panelEl = document.getElementById(panelId)
+    const targetsOfHoveredAnnotations = getTargetsHoveredAnnotations(hoveredAnnotations, targetsRef.current, matchedAnnotationsMap)
+    const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedAnnotationsMap[selectedAnnotation.id]) ?
+      matchedAnnotationsMap[selectedAnnotation.id].target.map((selector) => panelEl.querySelector(selector)) : []
+
+    flippedMatchedAnnotationsMapRef.current?.forEach(fa => {
+      const target = fa.target as HTMLElement
+      const annotations = fa.annotations
+
+      let someFiltered = false
+
+      // Look if some of the annotations are visible and add the ids of those to the node
+      annotations.forEach((_, i) => {
+        if (!fa.filtered[i]) return
+        someFiltered = !someFiltered ? fa.filtered[i] : true
+      })
+
+      if (someFiltered) {
+        removeHoverStyle(target)
+        removeNestedTargetStyle(target)
+        removeHighlightStyle(target)
+
+        const hasParentHovered = isParentHovered(targetsOfHoveredAnnotations, fa.parents)
+
+        if (targetsOfHoveredAnnotations.includes(target))  {
+          addHoverStyle(target)
+          if (hasParentHovered) {
+            addNestedTargetStyle(target)
+          }
+        } else if (!isTargetPartOfSelectedAnnotation(target, targetsOfSelectedAnnotation)) {
+          addHighlightStyle(target)
+        }
+      }
+    })
+  }, [hoveredAnnotations])
+
+
+  function assignFilteredInMap(matchedMap: MatchedAnnotationsMap, selectedAnnotationTypes: AnnotationTypesDict, annotations: Annotation[]) {
+    const newMap = { ...matchedMap }
+    annotations.forEach((annotation) => {
+      if (newMap.hasOwnProperty(annotation.id)) newMap[annotation.id].filtered = !selectedAnnotationTypes || isFiltered(annotation, selectedAnnotationTypes)
+    })
+    return newMap
+  }
+
+
+  // Create and set matchedAnnotationsMap by identifying target nodes. Add click listeners to targets.
+  useEffect(() => {
+    if (!annotations || !parsedDom) return
+
+    let matchedAnnotationsMap: MatchedAnnotationsMap = {}
+
+    const annotationsInText = annotations.filter(annotation => annotation.target[0].source === source)
+    matchedAnnotationsMap = createMatchedAnnotationsMap(annotationsInText, isAnnotation)
+    matchedAnnotationsMapRef.current = matchedAnnotationsMap
+
+    if (!isAnnotation) matchedAnnotationsMap = assignFilteredInMap(matchedAnnotationsMap, selectedAnnotationTypes, annotations)
+    flippedMatchedAnnotationsMapRef.current = flipMatchedAnnotationsMap(matchedAnnotationsMap)
+    targetsRef.current = getTextTargets(flippedMatchedAnnotationsMapRef.current)
+
+
+    annotations.forEach((annotation) => {
+      const isSource = annotation.target[0].source === source
+      const selector = (annotation.target[0].selector as CssSelector)?.value
+
+      if (!isSource || !selector) {
+        if (!selector) console.error('Annotation error','Selector value of target is empty for this annotation', annotation)
+        return
+      }
+
+      const matchedNodes = Array.from(parsedDom.querySelectorAll(selector))
+
+      if (matchedNodes.length > 0) {
+        matchedNodes.forEach(target => {
+          addAnnotationId(target, annotation.id)
+          target.addEventListener('click', onClickTarget)
+          target.addEventListener('mouseenter', onMouseEnterTarget)
+          target.addEventListener('mouseleave', onMouseLeaveTarget)
+        })
+      }})
+
+    if (!isAnnotation) updateMatchedAnnotationsMap(matchedAnnotationsMap)
+  }, [parsedDom, annotations])
+
+
+  return <div ref={textWrapperRef}>
+    {portals}
+  </div>
+}
+
+export default GenericTextRenderer

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -82,11 +82,13 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   }
 
 
+
   // Apply highlighting styles on every map update
   useEffect(() => {
     if (!displayedMap) return
     const flippedMatchedAnnotationsMap = flipMatchedAnnotationsMap(displayedMap)
     targetsRef.current = getTextTargets(flippedMatchedAnnotationsMap)
+    console.log('targets', targetsRef.current)
     flippedMatchedAnnotationsMapRef.current = assignNestedTargetsInFlippedMatched(targetsRef.current, flippedMatchedAnnotationsMap)
 
     flippedMatchedAnnotationsMapRef.current.forEach(fa => {
@@ -119,7 +121,7 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
     if (!displayedMap) return
     const targetsOfSelectedAnnotation =
       selectedAnnotation && !!(displayedMap[selectedAnnotation.id])
-        ? displayedMap[selectedAnnotation.id].target.map((selector) => document.querySelector(selector))
+        ? displayedMap[selectedAnnotation.id].target
         : []
 
     flippedMatchedAnnotationsMapRef.current.forEach(fa => {

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -4,40 +4,30 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState
 } from 'react'
 
-import React from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
-import CrossRefLink from '@/components/panel/CrossRef/CrossRefLink.tsx'
 import { scrollIntoViewIfNeeded } from '@/utils/dom.ts'
 import { useText } from '@/contexts/TextContext.tsx'
 import {
   addAnnotationBaseStyle,
   addAnnotationId,
   addHighlightStyle,
-  addHoverStyle, addNestedTargetStyle,
   addSelectedStyle,
   assignNestedTargetsInFlippedMatched,
   flipMatchedAnnotationsMap,
   getAnnotationIds,
-  getHoveredAnnotationsIds,
-  getRootCrossRefElements,
-  getTargetsHoveredAnnotations,
   getTextTargets,
-  isParentHovered,
   isTargetPartOfSelectedAnnotation,
   removeAnnotationBaseStyle,
   removeAnnotationIds,
   removeHighlightStyle,
-  removeHoverStyle,
-  removeNestedTargetStyle,
   removeSelectedStyle
 } from '@/utils/text.ts'
-import { createPortal } from 'react-dom'
-import { computeNewSelectedAnnotationIndex, isFiltered } from '@/utils/annotations.ts'
+import { computeNewSelectedAnnotationIndex } from '@/utils/annotations.ts'
 import { useTextView } from '@/contexts/TextViewContext.tsx'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
+import GenericTextRenderer from '@/components/GenericTextRenderer.tsx'
 
 interface Props {
   htmlString: string
@@ -46,22 +36,20 @@ interface Props {
 }
 
 const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
-  const textWrapperRef = useRef<HTMLInputElement>(null)
   const { showContentTypeToggle } = useConfig()
   const {
     panelState,
     selectedAnnotationTypes,
     setSelectedAnnotation,
     updatePanel,
+    annotations,
     selectedAnnotation,
     annotationsMode,
-    annotations,
   } = usePanel()
 
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
   const { matchedAnnotationsMap, setMatchedAnnotationsMap, activeContentUrl, visible } = useTextView()
 
-  const [portals, setPortals] = useState([])
 
   const prevClickedTargetIndexRef = useRef<number>(null)
   const hoveredAnnotationsRef = useRef<string[] | null>(null)
@@ -118,13 +106,6 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
     annotationsModeRef.current = annotationsMode
   }, [annotationsMode])
 
-  const onMouseEnterTarget = (e: Event) => {
-    const target = e.currentTarget as HTMLElement
-    const idsArray = getHoveredAnnotationsIds(target, targetsRef.current)
-    if (idsArray.length === 0) return
-
-    setHoveredAnnotations(idsArray)
-  }
 
   const onMouseLeaveTarget = (e: Event) => {
     // hoveredAnnotations can contain parent targets.
@@ -137,100 +118,6 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
     setHoveredAnnotations(hoveredAnnotationsRef.current?.filter(a => !idsArray.includes(a)) ?? null)
   }
 
-  // Document object that is only recreated when htmlString changes - e.g. on item change or content type change
-  const parsedDom: Element = React.useMemo(() => {
-    if (htmlString === '') return
-    const doc = new DOMParser().parseFromString(`${htmlString}`, 'text/html')
-    return doc.querySelector('body')
-  }, [htmlString])
-
-  // Make the text visible - set the content of the Document object as children of textWrapperRef.
-  // Create cross ref links with portals.
-  useEffect(() => {
-    if (!parsedDom) return
-
-    const links = getRootCrossRefElements(parsedDom)
-    setPortals(links.map(link => {
-      const mount = document.createElement(link.tagName)
-      link.replaceWith(mount)
-      return createPortal(<CrossRefLink node={link as HTMLElement} />, mount)
-    }))
-
-    textWrapperRef.current.replaceChildren(parsedDom)
-    onReady()
-  }, [parsedDom])
-
-  // Create and set matchedAnnotationsMap by identifying target nodes. Add click listeners to targets.
-  useEffect(() => {
-    if (!annotations || !parsedDom) return
-
-    const result = annotations.reduce<MatchedAnnotationsMap>((acc, cur) => {
-      const isSource = cur.target[0].source === activeContentUrl.current
-      const selector = (cur.target[0].selector as CssSelector)?.value
-
-      if (!isSource || !selector) {
-        if (!selector) console.error('Annotation error','Selector value of target is empty for this annotation', cur)
-        return acc
-      }
-
-      const matchedNodes = Array.from(parsedDom.querySelectorAll(selector))
-
-      if (matchedNodes.length > 0) {
-        matchedNodes.forEach(target => {
-          target.addEventListener('click', onClickTarget)
-          target.addEventListener('mouseenter', onMouseEnterTarget)
-          target.addEventListener('mouseleave', onMouseLeaveTarget)
-        })
-
-        acc[cur.id] = {
-          target: matchedNodes,
-          filtered: !selectedAnnotationTypes || isFiltered(cur, selectedAnnotationTypes),
-          annotation: cur
-        }
-      }
-      return acc
-    }, {})
-
-    setMatchedAnnotationsMap(result)
-  }, [parsedDom, annotations])
-
-  // Update hover styles each time hoveredAnnotation changes
-  useEffect(() => {
-    hoveredAnnotationsRef.current = hoveredAnnotations
-    if (!matchedAnnotationsMap) return
-    const targetsOfHoveredAnnotations = getTargetsHoveredAnnotations(hoveredAnnotations, targetsRef.current, matchedAnnotationsMap)
-    const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedAnnotationsMap[selectedAnnotation.id]) ? matchedAnnotationsMap[selectedAnnotation.id].target : []
-
-    flippedMatchedAnnotationsMapRef.current?.forEach(fa => {
-      const target = fa.target as HTMLElement
-      const annotations = fa.annotations
-
-      let someFiltered = false
-
-      // Look if some of the annotations are visible and add the ids of those to the node
-      annotations.forEach((_, i) => {
-        if (!fa.filtered[i]) return
-        someFiltered = !someFiltered ? fa.filtered[i] : true
-      })
-
-      if (someFiltered) {
-        removeHoverStyle(target)
-        removeNestedTargetStyle(target)
-        removeHighlightStyle(target)
-
-        const hasParentHovered = isParentHovered(targetsOfHoveredAnnotations, fa.parents)
-
-        if (targetsOfHoveredAnnotations.includes(target))  {
-          addHoverStyle(target)
-          if (hasParentHovered) {
-            addNestedTargetStyle(target)
-          }
-        } else if (!isTargetPartOfSelectedAnnotation(target, targetsOfSelectedAnnotation)) {
-          addHighlightStyle(target)
-        }
-      }
-    })
-  }, [hoveredAnnotations])
 
   // Apply highlighting styles on every map update
   useEffect(() => {
@@ -269,7 +156,7 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
     if (!displayedMap) return
     const targetsOfSelectedAnnotation =
       selectedAnnotation && !!(displayedMap[selectedAnnotation.id])
-        ? displayedMap[selectedAnnotation.id].target
+        ? displayedMap[selectedAnnotation.id].target.map((selector) => document.querySelector(selector))
         : []
 
     flippedMatchedAnnotationsMapRef.current.forEach(fa => {
@@ -299,8 +186,10 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   }, [selectedAnnotation, displayedMap])
 
   return <div className="relative flex">
-    <div data-text-wrapper ref={textWrapperRef} className={showContentTypeToggle ? 'pt-16' : 'pt-2'}></div>
-    {portals}
+    <div data-text-wrapper  className={showContentTypeToggle ? 'pt-16' : 'pt-2'}>
+      <GenericTextRenderer  htmlString={htmlString} onReady={onReady} source={activeContentUrl.current} annotations={annotations} selectedAnnotationTypes={selectedAnnotationTypes} onClickTarget={onClickTarget}
+        onMouseLeaveTarget={onMouseLeaveTarget} isAnnotation={false} updateMatchedAnnotationsMap={setMatchedAnnotationsMap} />
+    </div>
   </div>
 })
 

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -88,7 +88,6 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
     if (!displayedMap) return
     const flippedMatchedAnnotationsMap = flipMatchedAnnotationsMap(displayedMap)
     targetsRef.current = getTextTargets(flippedMatchedAnnotationsMap)
-    console.log('targets', targetsRef.current)
     flippedMatchedAnnotationsMapRef.current = assignNestedTargetsInFlippedMatched(targetsRef.current, flippedMatchedAnnotationsMap)
 
     flippedMatchedAnnotationsMapRef.current.forEach(fa => {

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -24,7 +24,6 @@ import {
   removeHighlightStyle,
   removeSelectedStyle
 } from '@/utils/text.ts'
-import { computeNewSelectedAnnotationIndex } from '@/utils/annotations.ts'
 import { useTextView } from '@/contexts/TextViewContext.tsx'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 import GenericTextRenderer from '@/components/GenericTextRenderer.tsx'
@@ -40,18 +39,15 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   const {
     panelState,
     selectedAnnotationTypes,
-    setSelectedAnnotation,
     updatePanel,
     annotations,
     selectedAnnotation,
     annotationsMode,
   } = usePanel()
 
-  const { hoveredAnnotations, setHoveredAnnotations } = useText()
+  const { setHoveredAnnotations } = useText()
   const { matchedAnnotationsMap, setMatchedAnnotationsMap, activeContentUrl, visible } = useTextView()
 
-
-  const prevClickedTargetIndexRef = useRef<number>(null)
   const hoveredAnnotationsRef = useRef<string[] | null>(null)
   const annotationsModeRef = useRef<'aligned' | 'list'>(null)
   const flippedMatchedAnnotationsMapRef = useRef<MergedAnnotationEntry[]>(null)
@@ -62,43 +58,10 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   // we create a UI-driven value. This applies when the user toggles on/off the TextView.
   const displayedMap = useMemo(() => visible ? matchedAnnotationsMap : {}, [visible, matchedAnnotationsMap])
 
-  function containsChildren(targets: HTMLElement[], target: HTMLElement) {
-    for(const t of targets) {
-      if (target.contains(t) && target !== t) return true
-    }
-    return false
-  }
 
-  const onClickTarget = (e: Event) => {
-    // Generic click listener
-    // TODO:  Be careful with state here. This listener will be added once a new map is created.
-    //  So this function will be called with those state values which existed at the time of adding.
-
-    const target = e.currentTarget as Element
-    const targetEntry: MergedAnnotationEntry = flippedMatchedAnnotationsMapRef.current.filter(entry => entry.target === target)[0]
-
-    if (!containsChildren(targetsRef.current, target as HTMLElement)) {
-      // handle only click events on 'deepest' target -> ignore click events on its containing targets while selection
-      e.stopPropagation()
-    }
-
-    const idsValue = getAnnotationIds(target)
-    if (!idsValue) return
-
-    targetEntry.selectedAnnotationIndex = computeNewSelectedAnnotationIndex(targetEntry, prevClickedTargetIndexRef.current, flippedMatchedAnnotationsMapRef.current)
-
-    const annotation = targetEntry.selectedAnnotationIndex !== -1 ? targetEntry.annotations[targetEntry.selectedAnnotationIndex] : null
-
-    if (annotation) {
-      if (!panelState.showSidebar) {
-        updatePanel({ showSidebar: true })
-      }
-
-      setSelectedAnnotation(annotation)
-      prevClickedTargetIndexRef.current = flippedMatchedAnnotationsMapRef.current.findIndex(entry => targetEntry === entry)
-    }
-    else {
-      setSelectedAnnotation(null)
+  function onTargetClick() {
+    if (!panelState.showSidebar) {
+      updatePanel({ showSidebar: true })
     }
   }
 
@@ -187,8 +150,8 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
 
   return <div className="relative flex">
     <div data-text-wrapper  className={showContentTypeToggle ? 'pt-16' : 'pt-2'}>
-      <GenericTextRenderer  htmlString={htmlString} onReady={onReady} source={activeContentUrl.current} annotations={annotations} selectedAnnotationTypes={selectedAnnotationTypes} onClickTarget={onClickTarget}
-        onMouseLeaveTarget={onMouseLeaveTarget} isAnnotation={false} updateMatchedAnnotationsMap={setMatchedAnnotationsMap} />
+      <GenericTextRenderer  htmlString={htmlString} onReady={onReady} source={activeContentUrl.current} annotations={annotations} selectedAnnotationTypes={selectedAnnotationTypes}
+        onTargetClick={onTargetClick} onMouseLeaveTarget={onMouseLeaveTarget} isAnnotation={false} updateMatchedAnnotationsMap={setMatchedAnnotationsMap} />
     </div>
   </div>
 })

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -82,7 +82,6 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   }
 
 
-
   // Apply highlighting styles on every map update
   useEffect(() => {
     if (!displayedMap) return

--- a/src/components/panel/annotations/AlignAnnotationsList.tsx
+++ b/src/components/panel/annotations/AlignAnnotationsList.tsx
@@ -130,6 +130,10 @@ const AlignAnnotationsList: FC = () => {
         const annotation = filteredAnnotations.find(a => a.id === (el as HTMLElement).getAttribute('data-annotation'))
         if (!annotation) return
         const target: HTMLElement = document.getElementById(panelId).querySelector((annotation.target[0].selector as CssSelector).value)
+        if (!target) {
+          console.error('There exists no target in text from the selector value of this annotation', annotation)
+          return
+        }
         return {
           target,
           el,
@@ -137,7 +141,7 @@ const AlignAnnotationsList: FC = () => {
           annotation
         }
       })
-      setElements(_elements)
+      setElements(_elements.filter(Boolean))
     }
 
     return () => {

--- a/src/components/panel/annotations/Annotation.tsx
+++ b/src/components/panel/annotations/Annotation.tsx
@@ -29,7 +29,6 @@ interface Props {
   isNested?: boolean
 }
 
-
 const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = false }) => {
   const { annotations: annotationsConfig } = useConfig()
   const { selectedAnnotation, setSelectedAnnotation, annotationsMode, panelId } = usePanel()
@@ -44,7 +43,6 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
   const [showNestedAnnotations, setShowNestedAnnotations] = useState(false)
 
   const nestedAnnotationsRef = useRef(null)
-
   const { t } = useTranslation()
 
   const type = data.body['x-content-type']
@@ -87,11 +85,9 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
     setShowNestedAnnotations(true)
   }
 
-
   function onMouseLeaveTarget() {
     setHoveredNestedAnnotationIds([])
   }
-
 
   useEffect(() => {
     if (!annotationBodyRef.current) return
@@ -100,7 +96,6 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
 
     nestedAnnotationsRef.current = nestedMatchedAnnotationsMap[data.id]['nestedAnnotations']
   }, [])
-
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
     // we should get the deepest level annotation as selected

--- a/src/components/panel/annotations/Annotation.tsx
+++ b/src/components/panel/annotations/Annotation.tsx
@@ -15,10 +15,7 @@ import {
   removeHighlightStyle,
   removeSelectedStyle
 } from '@/utils/text.ts'
-import {
-  getAnnotationIdsByEl,
-  getFlippedNestedMatchedAnnotationsMap
-} from '@/utils/annotations.ts'
+import { getFlippedNestedMatchedAnnotationsMap } from '@/utils/annotations.ts'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import GenericTextRenderer from '@/components/GenericTextRenderer.tsx'
@@ -81,28 +78,13 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
     })
   }, [data, selectedAnnotation])
 
-
-  function onClickTarget(e: Event) {
+  function onTargetClick() {
     // expand parentAnnotation of target when clicking it
     //  clicking at a target -> expands the nested annotations
     //    -> since the nested annotations are expanded, then we show the full parent annotation
     //      -> reason: makes easier the functionality of showing another selected target when clicking at another nested annotation whose target is not initially shown in parentAnnotation
     setIsExpanded(true)
-
-    const nestedAnnotations = nestedAnnotationsRef.current
-    if (nestedAnnotations && nestedAnnotations.length > 0) {
-      // from flippedMatchedAnnotationsMap select its first nested annotation
-      const flippedNestedMatchedAnnotationsMap = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
-      const targetAnnotationIds = getAnnotationIdsByEl(flippedNestedMatchedAnnotationsMap, e.target as HTMLElement)
-      // get the first nested annotation which belongs to the selected target
-      for (let i = 0; i< nestedAnnotations.length; i++ ) {
-        if (targetAnnotationIds.includes(nestedAnnotations[i].id)) {
-          setShowNestedAnnotations(true)
-          setSelectedAnnotation(nestedAnnotations[i])
-          break
-        }
-      }
-    }
+    setShowNestedAnnotations(true)
   }
 
 
@@ -204,7 +186,7 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
       <div ref={annotationBodyRef} className={`transition-[height] duration-400 ease-in-out ${isLong && !isExpanded ? 'h-18 overflow-y-hidden' : 'h-fit'}`}  >
         { type === 'Variant' && <VariantContent body={data.body} /> }
         { type !== 'Variant' && <GenericTextRenderer htmlString={data.body.value} source={data.id} annotations={nestedAnnotationsRef.current}
-          isAnnotation={true} onMouseLeaveTarget={onMouseLeaveTarget} onClickTarget={onClickTarget}  /> }
+          isAnnotation={true} onMouseLeaveTarget={onMouseLeaveTarget} onTargetClick={onTargetClick}  /> }
       </div>
       { isLong && !isExpanded && renderViewButton('view-more')}
       { isLong && isExpanded && renderViewButton('view-less') }

--- a/src/components/panel/annotations/Annotation.tsx
+++ b/src/components/panel/annotations/Annotation.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useEffect, useRef, useState } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import { Badge } from '@/components/ui/badge.tsx'
-import AnnotationContent from '@/components/panel/annotations/AnnotationContent.tsx'
 import VariantContent from '@/components/panel/annotations/VariantContent.tsx'
 import { useText } from '@/contexts/TextContext.tsx'
 import { Button } from '@/components/ui/button.tsx'
@@ -11,18 +10,18 @@ import AnnotationFooter from '@/components/panel/annotations/AnnotationFooter.ts
 import { useAnnotations } from '@/contexts/AnnotationsContext.tsx'
 import {
   addHighlightStyle,
-  addHoverStyle, addSelectedStyle, isTargetPartOfSelectedAnnotation,
+  addSelectedStyle,
+  isTargetPartOfSelectedAnnotation,
   removeHighlightStyle,
-  removeHoverStyle,
   removeSelectedStyle
 } from '@/utils/text.ts'
 import {
-  findTargetsInsideAnnotation,
   getAnnotationIdsByEl,
   getFlippedNestedMatchedAnnotationsMap
 } from '@/utils/annotations.ts'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 import { ChevronDown, ChevronUp } from 'lucide-react'
+import GenericTextRenderer from '@/components/GenericTextRenderer.tsx'
 
 const THRESHOLD_LONG_ANNOTATION_BODY_HEIGHT = 72
 
@@ -36,8 +35,8 @@ interface Props {
 
 const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = false }) => {
   const { annotations: annotationsConfig } = useConfig()
-  const { selectedAnnotation, setSelectedAnnotation, annotationsMode, annotations, panelId } = usePanel()
-  const { nestedMatchedAnnotationsMap, hoveredNestedAnnotationIds, setHoveredNestedAnnotationIds  } = useAnnotations()
+  const { selectedAnnotation, setSelectedAnnotation, annotationsMode, panelId } = usePanel()
+  const { nestedMatchedAnnotationsMap, setHoveredNestedAnnotationIds  } = useAnnotations()
   const { setHoveredAnnotations, hoveredAnnotations } = useText()
   const ref = useRef(null)
   const annotationBodyRef = useRef(null)
@@ -46,7 +45,6 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
   const [isLong, setIsLong] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const [showNestedAnnotations, setShowNestedAnnotations] = useState(false)
-
 
   const nestedAnnotationsRef = useRef(null)
 
@@ -64,6 +62,7 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
     const panelEl = document.getElementById(panelId) as HTMLElement
     const targetsOfSelectedAnnotation = selectedAnnotation && !!(nestedMatchedAnnotationsMap[selectedAnnotation.id]) ? nestedMatchedAnnotationsMap[selectedAnnotation.id].target.map((selector: string) => panelEl.querySelector(selector)) : []
 
+    // TODO: flippedNestedMatched should be created each time a new item is navigated and used here
     const flippedNestedMatched = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
     Object.keys(flippedNestedMatched).forEach((targetSelector) => {
       const targetEl = document.querySelector(targetSelector)
@@ -81,34 +80,6 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
       }
     })
   }, [data, selectedAnnotation])
-
-  useEffect(() => {
-    setIsHovered(hoveredNestedAnnotationIds?.includes(data.id))
-
-    const selectorsHoveredAnnotations = hoveredNestedAnnotationIds?.flatMap(id =>
-      nestedMatchedAnnotationsMap[id]?.target ?? []
-    )
-
-    const panelEl = document.getElementById(panelId) as HTMLElement
-    const targetsOfSelectedAnnotation = selectedAnnotation &&
-    !!(nestedMatchedAnnotationsMap[selectedAnnotation.id]) ? nestedMatchedAnnotationsMap[selectedAnnotation.id].target.map((selector: string) => panelEl.querySelector(selector)) : []
-
-    const flippedNestedMatched = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
-    Object.keys(flippedNestedMatched).forEach((targetSelector) => {
-      const targetEl = panelEl.querySelector(targetSelector)
-      if (targetEl) {
-        removeHighlightStyle(targetEl)
-        removeHoverStyle(targetEl)
-
-        if (selectorsHoveredAnnotations?.includes(targetSelector)) {
-          addHoverStyle(targetEl)
-        }
-        else if (!isTargetPartOfSelectedAnnotation(targetEl, targetsOfSelectedAnnotation)) {
-          addHighlightStyle(targetEl)
-        }
-      }
-    })
-  }, [hoveredNestedAnnotationIds])
 
 
   function onClickTarget(e: Event) {
@@ -135,13 +106,6 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
   }
 
 
-  function onMouseEnterTarget(e: Event) {
-    const flippedNestedMatchedAnnotationsMap = getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap)
-    const annotationIds = getAnnotationIdsByEl(flippedNestedMatchedAnnotationsMap, e.currentTarget as HTMLElement)
-    // add hover style to annotation els
-    setHoveredNestedAnnotationIds(annotationIds)
-  }
-
   function onMouseLeaveTarget() {
     setHoveredNestedAnnotationIds([])
   }
@@ -153,19 +117,8 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
     if (annotBodyHeight > THRESHOLD_LONG_ANNOTATION_BODY_HEIGHT) setIsLong(true)
 
     nestedAnnotationsRef.current = nestedMatchedAnnotationsMap[data.id]['nestedAnnotations']
-
-    // for each new nested Annotation - we add highlighting once it is mounted.
-    const targetsInsideAnnotation = findTargetsInsideAnnotation(data.id, annotations)
-    targetsInsideAnnotation.forEach((selector) => {
-      const target = document.querySelector(selector)
-      if (target) {
-        addHighlightStyle(target)
-        target.addEventListener('click', onClickTarget)
-        target.addEventListener('mouseenter', onMouseEnterTarget)
-        target.addEventListener('mouseleave', onMouseLeaveTarget)
-      }
-    })
   }, [])
+
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
     // we should get the deepest level annotation as selected
@@ -189,10 +142,6 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
   }
 
   function handleMouseEnter() {
-    if (!data.target[0].source.endsWith('.html')) {
-      setHoveredNestedAnnotationIds([data.id])
-      return
-    }
     setHoveredAnnotations([data.id])
   }
 
@@ -254,7 +203,8 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
       <Badge variant="accent" className="mb-1">{ typeLabel }</Badge>
       <div ref={annotationBodyRef} className={`transition-[height] duration-400 ease-in-out ${isLong && !isExpanded ? 'h-18 overflow-y-hidden' : 'h-fit'}`}  >
         { type === 'Variant' && <VariantContent body={data.body} /> }
-        { type !== 'Variant' && <AnnotationContent body={data.body} /> }
+        { type !== 'Variant' && <GenericTextRenderer htmlString={data.body.value} source={data.id} annotations={nestedAnnotationsRef.current}
+          isAnnotation={true} onMouseLeaveTarget={onMouseLeaveTarget} onClickTarget={onClickTarget}  /> }
       </div>
       { isLong && !isExpanded && renderViewButton('view-more')}
       { isLong && isExpanded && renderViewButton('view-less') }

--- a/src/contexts/AnnotationsContext.tsx
+++ b/src/contexts/AnnotationsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react'
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import {
   createMatchedAnnotationsMap,

--- a/src/contexts/AnnotationsContext.tsx
+++ b/src/contexts/AnnotationsContext.tsx
@@ -1,11 +1,14 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { createContext, useContext, useEffect, useState, ReactNode, useRef } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
-import { findTargets, getFilteredAnnotations, getNestedAnnotations } from '@/utils/annotations.ts'
+import {
+  createMatchedAnnotationsMap,
+  getFilteredAnnotations,
+} from '@/utils/annotations.ts'
 
 type State = {
   filteredAnnotations: Annotation[],
-  nestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap,
-  setNestedMatchedAnnotationsMap: (newNestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap) => void,
+  nestedMatchedAnnotationsMap: MatchedAnnotationsMap,
+  setNestedMatchedAnnotationsMap: (newNestedMatchedAnnotationsMap: MatchedAnnotationsMap) => void,
   hoveredNestedAnnotationIds: string[],
   setHoveredNestedAnnotationIds: (newHoveredAnnotationIds: string[]) => void,
 }
@@ -15,7 +18,7 @@ const AnnotationsContext = createContext<State>(null)
 export const AnnotationsProvider = ({ children }: { children: ReactNode }) => {
   const { matchedAnnotationsMaps, annotations } = usePanel()
   const [filteredAnnotations, setFilteredAnnotations] = useState<Annotation[]>([])
-  const [nestedMatchedAnnotationsMap, setNestedMatchedAnnotationsMap ] = useState<NestedMatchedAnnotationsMap>({})
+  const [nestedMatchedAnnotationsMap, setNestedMatchedAnnotationsMap ] = useState<MatchedAnnotationsMap>({})
   const [hoveredNestedAnnotationIds, setHoveredNestedAnnotationIds ] = useState<string[]>([])
 
 
@@ -31,16 +34,7 @@ export const AnnotationsProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     if (!annotations) return
-    const newNestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap = {}
-    annotations.forEach((annotation) => {
-      const nestedAnnotations = getNestedAnnotations(annotation, annotations)
-      const target = findTargets(annotation)
-      newNestedMatchedAnnotationsMap[annotation.id] = {
-        nestedAnnotations,
-        target,
-        annotation
-      }
-    })
+    const newNestedMatchedAnnotationsMap = createMatchedAnnotationsMap(annotations)
     setNestedMatchedAnnotationsMap(newNestedMatchedAnnotationsMap)
   }, [annotations])
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -229,7 +229,7 @@ declare global {
   // Therefore let's keep `target`: string[], also an Array of selectors
   interface MatchedAnnotationsMap {
     [annotationId: string]: {
-      target: string[],
+      target: Element[],
       filtered?: boolean,
       annotation: Annotation,
       nestedAnnotations: Annotation[]

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -221,31 +221,26 @@ declare global {
     modules?: Module[]
   }
 
-  interface MatchedAnnotationsMap {
-    [annotationId: string]: {
-      target: Element[],
-      filtered: boolean,
-      annotation: Annotation
-    }
-  }
 
   // we want nestedMatchedAnnotationsMap to be accessible to every annotation.
   // since some childAnnotations are not mounted yet, we can't know the HTMLElement of their targets
   // We would need to maintain 'target': Element[] synchronized among all annotations -> that would require to update
   // state `nestedMatchedAnnotationsMap`, which is not a good practice.
   // Therefore let's keep `target`: string[], also an Array of selectors
-  interface NestedMatchedAnnotationsMap {
+  interface MatchedAnnotationsMap {
     [annotationId: string]: {
+      target: string[],
+      filtered?: boolean,
       annotation: Annotation,
-      nestedAnnotations: Annotation[],
-      target: string[]
+      nestedAnnotations: Annotation[]
     }
   }
 
   interface FlippedNestedMatchedAnnotationsMap {
     [targetSelector: string]: {
       'el': HTMLElement,
-      'annotationIds': string[]
+      'annotationIds': string[],
+      parents: Element[]
     }
   }
 

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -67,6 +67,23 @@ function computeNewSelectedAnnotationIndex(targetEntry: MergedAnnotationEntry, p
   return newSelectedAnnotationIndex
 }
 
+function createMatchedAnnotationsMap(annotations: Annotation[], isAnnotation: boolean) {
+  if (!annotations) return
+  const matchedAnnotationsMap: MatchedAnnotationsMap = {}
+  annotations.forEach((annotation) => {
+    const nestedAnnotations = getNestedAnnotations(annotation, annotations)
+    const target = findTargets(annotation)
+    matchedAnnotationsMap[annotation.id] = {
+      nestedAnnotations,
+      target,
+      annotation
+    }
+    if (isAnnotation) matchedAnnotationsMap[annotation.id].filtered = true
+  })
+
+  return matchedAnnotationsMap
+}
+
 function getNestedAnnotations(annotation: Annotation, itemAnnotations: Annotation[]) {
   if (itemAnnotations.length === 0) return []
   return itemAnnotations.filter((annot)  => annot.target[0].source === annotation.id)
@@ -96,7 +113,7 @@ function findTargets(annotation: Annotation): string[] {
   })
 }
 
-function getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap: NestedMatchedAnnotationsMap) {
+function getFlippedNestedMatchedAnnotationsMap(nestedMatchedAnnotationsMap: MatchedAnnotationsMap) {
   // append only the targets which are located in 'Annotation', but not in 'Text'
   const flippedNestedMatchedAnnotationsMap: FlippedNestedMatchedAnnotationsMap = {}
 
@@ -149,6 +166,7 @@ export {
   getFilteredAnnotations,
   isFiltered,
   computeNewSelectedAnnotationIndex,
+  createMatchedAnnotationsMap,
   findTargetsInsideAnnotation,
   findTargets,
   getNestedAnnotations,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -132,17 +132,18 @@ function flipMatchedAnnotationsMap(map: MatchedAnnotationsMap): MergedAnnotation
     const { target, annotation, filtered } = entry
 
     for (const el of target) {
-      let merged = elementMap.get(el)
+      const targetEl = document.querySelector(el)
+      let merged = elementMap.get(targetEl)
 
       if (!merged) {
         merged = {
-          target: el,
+          target: targetEl,
           annotations: [],
           filtered: [],
           selectedAnnotationIndex: -1,
           parents: []
         }
-        elementMap.set(el, merged)
+        elementMap.set(targetEl, merged)
       }
 
       merged.annotations.push(annotation)
@@ -216,7 +217,7 @@ function getTargetsHoveredAnnotations(hoveredAnnotations: string[], targets: Ele
 
   const annotationsTargets = hoveredAnnotations
     .filter(key => !!(matchedAnnotationsMap[key]))
-    .map(key => matchedAnnotationsMap[key].target).flat()
+    .map(key => document.querySelector(matchedAnnotationsMap[key].target)).flat()
   const uniqueAnnotationTargets = [...new Set(annotationsTargets)]
 
   targets.forEach(t => {
@@ -229,7 +230,7 @@ function getTargetsHoveredAnnotations(hoveredAnnotations: string[], targets: Ele
 }
 
 function isParentHovered(hoveredTargets: Element[], parentsEl: Element[]) {
-  return parentsEl.some(parent =>
+  return parentsEl?.some(parent =>
     hoveredTargets.some(ht => ht.contains(parent))
   )
 }
@@ -253,6 +254,7 @@ export {
   getTextTargets,
   getHoveredAnnotationsIds,
   isSelected,
+  getParents,
   isTargetPartOfSelectedAnnotation,
   assignNestedTargetsInFlippedMatched,
   getTargetsHoveredAnnotations,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -235,6 +235,13 @@ function isParentHovered(hoveredTargets: Element[], parentsEl: Element[]) {
   )
 }
 
+function containsChildren(targets: HTMLElement[], target: HTMLElement) {
+  for(const t of targets) {
+    if (target.contains(t) && target !== t) return true
+  }
+  return false
+}
+
 export {
   addAnnotationId,
   removeAnnotationIds,
@@ -247,6 +254,7 @@ export {
   addSelectedStyle,
   removeSelectedStyle,
   addHighlightStyle,
+  containsChildren,
   removeHighlightStyle,
   getAnnotationIds,
   getRootCrossRefElements,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -132,18 +132,17 @@ function flipMatchedAnnotationsMap(map: MatchedAnnotationsMap): MergedAnnotation
     const { target, annotation, filtered } = entry
 
     for (const el of target) {
-      const targetEl = document.querySelector(el)
-      let merged = elementMap.get(targetEl)
+      let merged = elementMap.get(el)
 
       if (!merged) {
         merged = {
-          target: targetEl,
+          target: el,
           annotations: [],
           filtered: [],
           selectedAnnotationIndex: -1,
           parents: []
         }
-        elementMap.set(targetEl, merged)
+        elementMap.set(el, merged)
       }
 
       merged.annotations.push(annotation)
@@ -217,7 +216,7 @@ function getTargetsHoveredAnnotations(hoveredAnnotations: string[], targets: Ele
 
   const annotationsTargets = hoveredAnnotations
     .filter(key => !!(matchedAnnotationsMap[key]))
-    .map(key => document.querySelector(matchedAnnotationsMap[key].target)).flat()
+    .map(key => matchedAnnotationsMap[key].target).flat()
   const uniqueAnnotationTargets = [...new Set(annotationsTargets)]
 
   targets.forEach(t => {


### PR DESCRIPTION
Closes #976 
We add a component GenericTextRenderer which renders HTML text and CrossRefs Nodes. In addition it takes care of following text-annotation functionalities

- Highlights targets of an html string given its annotations
- Hovers bidirectionally targets and annotations
- New for child annotations: Multi-annotation target selection: Handles the mechanism when click at a target
- New: now we use only the related annotations for the text i.e for Annotation text we use only its child annotations to highlight targets and create MatchedMap

Any HTML string which has a certain set of annotations can use the above functionalities by only using GenericTextRenderer.