### PR TITLE
feat: add target-based synced scrolling in text when scrolling the sidebar

### DIFF
--- a/src/components/GenericTextRenderer.tsx
+++ b/src/components/GenericTextRenderer.tsx
@@ -1,7 +1,8 @@
 import React, { FC, memo, useEffect, useRef, useState } from 'react'
 import {
   addAnnotationBaseStyle,
-  addAnnotationId, addCrossRefTargetStyle,
+  addAnnotationId,
+  addCrossRefTargetStyle,
   addHighlightStyle,
   addHoverStyle,
   addNestedTargetStyle,
@@ -40,6 +41,7 @@ interface Props {
   source: string
   onSelect?: () => void
   ignoreFilters?: boolean
+  paddingTop?: boolean
 }
 const GenericTextRenderer: FC<Props> = memo(({
   htmlString,
@@ -47,7 +49,8 @@ const GenericTextRenderer: FC<Props> = memo(({
   onUpdateMatchedAnnotationsMap,
   source,
   onSelect,
-  ignoreFilters = false
+  ignoreFilters = false,
+  paddingTop = false
 }) => {
   const { annotations: annotationsConfig } = useConfig()
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
@@ -248,9 +251,9 @@ const GenericTextRenderer: FC<Props> = memo(({
     // hoveredAnnotations can contain parent targets.
     // So on mouse leave, we want to remove the hover style only for the current target's annotation IDs.
     const target = e.currentTarget as HTMLElement
-    const annotIds = getAnnotationIds(target)
-    const idsArray = annotIds?.split(',')
-    if (idsArray?.length === 0) return
+    const annotIds = getAnnotationIds(target) ?? ''
+    const idsArray = annotIds.split(',')
+    if (idsArray.length === 0) return
 
     setHoveredAnnotations(hoveredAnnotationsRef.current?.filter(a => !idsArray.includes(a)) ?? null)
   }
@@ -323,8 +326,15 @@ const GenericTextRenderer: FC<Props> = memo(({
     setHoveredAnnotations([])
   }
 
-  return <div data-text-wrapper ref={textWrapperRef} className="relative">
-    <TargetTooltip annotation={tooltipAnnotation} targetElement={tooltipTargetElement} wrapperRef={textWrapperRef} open={tooltipOpen} onClose={closeTooltip} crossRefInfo={crossRefInfo} />
+  return <div data-text-wrapper ref={textWrapperRef} className={`relative ${paddingTop ? 'pt-16' : 'pt-2'}`}>
+    <TargetTooltip
+      annotation={tooltipAnnotation}
+      targetElement={tooltipTargetElement}
+      wrapperRef={textWrapperRef}
+      open={tooltipOpen}
+      onClose={closeTooltip}
+      crossRefInfo={crossRefInfo}
+    />
   </div>
 })
 

--- a/src/components/panel/TextRenderer.tsx
+++ b/src/components/panel/TextRenderer.tsx
@@ -48,13 +48,14 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
   }, [annotationsMode])
 
 
-  return <div className={`relative flex ${showContentTypeToggle ? 'pt-16' : 'pt-2'}`}>
+  return <div className="relative flex">
     <GenericTextRenderer
       htmlString={htmlString}
       onReady={onReady}
       source={activeContentUrl.current}
       onSelect={onSelect}
       onUpdateMatchedAnnotationsMap={onMatchedMapUpdate}
+      paddingTop={showContentTypeToggle}
     />
   </div>
 })

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -287,6 +287,8 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
   }, [selectedAnnotationTypes])
 
   useEffect(() => {
+    getSidebarScroller().setMatchedMap(matchedAnnotationsMaps)
+
     // This is for the case where no specific annotation filters were configured.
     // We extract all occurring types from the annotations that match the text.
     if (annotationsConfig.filters) return

--- a/src/utils/sidebar-scroller.ts
+++ b/src/utils/sidebar-scroller.ts
@@ -2,6 +2,8 @@ class SidebarScroller {
   private sidebar: HTMLElement | null = null
   private text: HTMLElement | null = null
   private isSyncing = false
+  private focusedAnnotationId: string | null = null
+  private matchedMap: {[contentUrl: string]: MatchedAnnotationsMap} = {}
   private handleSidebarScrollBound: EventListener
   private handleTextScrollBound: EventListener
 
@@ -16,6 +18,10 @@ class SidebarScroller {
 
   setText(element: HTMLElement) {
     this.text = element
+  }
+
+  setMatchedMap(map: {[contentUrl: string]: MatchedAnnotationsMap}) {
+    this.matchedMap = map
   }
 
   getSidebar() {
@@ -34,7 +40,34 @@ class SidebarScroller {
   }
 
   handleSidebarScroll() {
-    this.syncScroll(this.sidebar, this.text)
+    if (this.isSyncing) return
+    const refY = this.sidebar.scrollTop + this.sidebar.clientHeight * 0.35
+
+    const mapEntries = Object
+      .values(this.matchedMap)
+      .flatMap(map => Object.values(map))
+      .filter(item => item.filtered)
+
+    const entry = mapEntries.find(entry => {
+      const card = this.sidebar.querySelector(`[data-annotation="${entry.annotation.id}"]`) as HTMLElement
+      const top = parseInt(card.style.top)
+      const bottom = top + card.offsetHeight
+      return refY >= top && refY < bottom
+    })
+
+    if (!entry || entry.annotation.id === this.focusedAnnotationId) return
+
+    this.focusedAnnotationId = entry.annotation.id
+    this.isSyncing = true
+    const targetElement = entry.target[0]
+    if (targetElement) {
+      const textRect = this.text.getBoundingClientRect()
+      const targetRect = targetElement.getBoundingClientRect()
+      const targetTop = targetRect.top - textRect.top + this.text.scrollTop
+      const targetOffset = this.text.clientHeight * 0.35
+      this.text.scrollTop = targetTop - targetOffset
+    }
+    setTimeout(() => this.isSyncing = false, 20)
   }
 
   handleTextScroll() {


### PR DESCRIPTION
closes #972 

- open bdn
- scroll in sidebar
- targets will align to 35% of the text's height

there is 1 focused annotation, it is identified when it's body intersects 35% of sidebar's height, then the text's target is being aligned

things to improve later: 
- make the target "drive" together with the annotation in the sidebar when no other annotation intersects the line
- scroll more smoothly in the text
