### PR TITLE
Bug action areas mha

### DIFF
--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -319,9 +319,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     const crossRefAnnotations = annotations
       .filter(a => {
         const isInSource = a.target?.[0].source === source
-        const isCrossRef = source.endsWith('.html')
-          ? (a.body as AnnotationBody)?.['x-content-type'] === annotationsConfig?.crossRefContentType
-          : (a.body as AnnotationBodyCrossRef)?.source?.['x-content-type'] === annotationsConfig?.crossRefContentType
+        const isCrossRef = getAnnotationContentType(a) === annotationsConfig?.crossRefContentType
         return isInSource && isCrossRef
       })
       .filter(a => {

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -28,6 +28,7 @@ import {
   removeSelectedStyle
 } from '@/utils/text.ts'
 import {
+  getAnnotationContentType,
   getNestedAnnotations,
   getSource,
   isFiltered
@@ -335,8 +336,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     const newRelatedAnnotations = (flippedMatchedMapRef.current ?? [])
       .filter(entry => entry.target === target || entry.target.contains(target as HTMLElement))
       .flatMap(entry => entry.annotations)
-      .filter(a => !seen.has(a.id) && seen.add(a.id))
-      .filter(a => (a.body as AnnotationBody)['x-content-type'] !== crossRefContentType)
+      .filter(a => !seen.has(a.id) && seen.add(a.id) && getAnnotationContentType(a) !== crossRefContentType)
 
     const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -138,6 +138,12 @@ function getSource(target: AnnotationTarget): AnnotationTargetSource {
   return { id: target.source }
 }
 
+function getAnnotationContentType(annotation: Annotation) {
+  const body = annotation.body
+  if ('source' in body) return (body as AnnotationBodyCrossRef).source['x-content-type']
+  return (body as AnnotationBody)['x-content-type']
+}
+
 export {
   getSelectedTypes,
   getFilteredAnnotations,
@@ -147,5 +153,6 @@ export {
   getNestedAnnotations,
   getAnnotationIdsByEl,
   getCrossRefInfo,
-  getSource
+  getSource,
+  getAnnotationContentType
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -140,8 +140,8 @@ function getSource(target: AnnotationTarget): AnnotationTargetSource {
 
 function getAnnotationContentType(annotation: Annotation) {
   const body = annotation.body
-  if ('source' in body) return (body as AnnotationBodyCrossRef).source['x-content-type']
-  return (body as AnnotationBody)['x-content-type']
+  if ('x-content-type' in body) return body['x-content-type']
+  return body.source?.['x-content-type']
 }
 
 export {


### PR DESCRIPTION
Closes #1002 

- correctly exclude cross ref annotations from the ones that we render in tooltip

Let's talk in the next meeting on maybe setting the 'x-content-type' only inside 'body' object. Then we wouldn't need at all the function to retrieve the `content type` of annotation. 