### PR TITLE
Sort target popover annotations based on deepest clicked target

### DIFF
--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useRef, useState } from 'react'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 import { getCrossRefInfo } from '@/utils/annotations.ts'
 import TooltipItem from '@/components/panel/annotations/popover/items/TooltipItem.tsx'
@@ -7,55 +7,78 @@ import BaseItem from '@/components/panel/annotations/popover/items/BaseItem.tsx'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 
 interface Props {
+  target: Element,
   crossRefAnnotations: Annotation[],
   relatedAnnotations: Annotation[]
   onClose: () => void
 }
 
 
-const AnnotationPopoverContent: FC<Props> = ({ crossRefAnnotations, relatedAnnotations, onClose }) => {
+const AnnotationPopoverContent: FC<Props> = ({ target, crossRefAnnotations, relatedAnnotations, onClose }) => {
 
-  const { usePanelTranslation } = usePanel()
+  const { usePanelTranslation, panelId } = usePanel()
   const { annotations: annotationsConfig } = useConfig()
   const { t } = usePanelTranslation()
   const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 
   const [crossRefInfos, setCrossRefInfos] = useState<CrossRefInfo[]>([])
-  const tooltipAnnotations = relatedAnnotations.filter(a => tooltipTypes.includes((a.body as AnnotationBody)['x-content-type']))
-  const normalAnnotations = relatedAnnotations.filter(a => !tooltipTypes.includes((a.body as AnnotationBody)['x-content-type']))
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_, setDisplayAnnotations] = useState(null)
+  const tooltipAnnotationsRef = useRef<Annotation[]>(null)
+  const normalAnnotationsRef = useRef<Annotation[]>(null)
+
+  useEffect(() => {
+    const panelEl = panelId ? document.getElementById(panelId) : null
+    const deepestTargetAnnotation = (annotation: Annotation) =>
+      annotation.target.some(t => Array.from(panelEl?.querySelectorAll((t.selector as CssSelector).value)
+        ?? []).includes(target as Element))
+
+    function sortByDirectTarget(a: Annotation, b: Annotation) {
+      if (deepestTargetAnnotation(a) && !deepestTargetAnnotation(b)) return -1
+      if (!deepestTargetAnnotation(a) && deepestTargetAnnotation(b)) return 1
+      return 0
+    }
+
+    async function computeCrossRefInfos(annotations: Annotation[]) {
+      const infos: CrossRefInfo[] = await Promise.all(annotations.map(a => getCrossRefInfo(a)))
+      setCrossRefInfos(infos)
+    }
+
+    tooltipAnnotationsRef.current = relatedAnnotations.filter(a =>
+      tooltipTypes.includes((a.body as AnnotationBody)['x-content-type'])).sort(sortByDirectTarget)
+    normalAnnotationsRef.current = relatedAnnotations.filter(a =>
+      !tooltipTypes.includes((a.body as AnnotationBody)['x-content-type'])).sort(sortByDirectTarget)
+
+    setDisplayAnnotations(true)
+    computeCrossRefInfos(crossRefAnnotations)
+  }, [target])
+
 
   function handleCrossRefSelection() {
     setCrossRefInfos([])
     onClose()
   }
 
-  useEffect(() => {
-    async function computeCrossRefInfos(annotations: Annotation[]) {
-      const infos: CrossRefInfo[] = await Promise.all(annotations.map(a => getCrossRefInfo(a)))
-      setCrossRefInfos(infos)
-    }
-    computeCrossRefInfos(crossRefAnnotations)
-  }, [crossRefAnnotations])
 
   function renderLabel(label: string) {
     return <p className="py-1 mb-1 text-xs font-medium text-muted-foreground">{label}</p>
   }
 
   return <div className="flex flex-col gap-4">
-    {tooltipAnnotations.length > 0 && (
+    {tooltipAnnotationsRef.current?.length > 0 && (
       <div className={crossRefInfos.length > 0 ? 'border-b border-border' : ''}>
         {renderLabel(t('tooltip'))}
-        {tooltipAnnotations.map((ta) => <div className="mb-2"><TooltipItem key={ta.id} annotation={ta} /></div>)}
+        {tooltipAnnotationsRef.current?.map((ta) => <div className="mb-2"><TooltipItem key={ta.id} annotation={ta} /></div>)}
       </div>
     )}
     {crossRefInfos.length > 0 && <div className="flex flex-col gap-1">
       {renderLabel(t('reference'))}
       {crossRefInfos.map((info, i) => <CrossRefItem key={i} crossRefInfo={info} onSelect={handleCrossRefSelection} />)}
     </div>}
-    {normalAnnotations.length > 0 && (
-      <div className={`flex flex-col gap-2 ${(crossRefInfos.length > 0 || tooltipAnnotations.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
-        {renderLabel(tooltipAnnotations.length === 0 && crossRefInfos.length === 0 ? t('annotations') : t('more_annotations'))}
-        {normalAnnotations.map(na => <BaseItem key={na.id} annotation={na} />)}
+    {normalAnnotationsRef.current?.length > 0 && (
+      <div className={`flex flex-col gap-2 ${(crossRefInfos.length > 0 || tooltipAnnotationsRef.current?.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
+        {renderLabel(tooltipAnnotationsRef.current?.length === 0 && crossRefInfos.length === 0 ? t('annotations') : t('more_annotations'))}
+        {normalAnnotationsRef.current?.map(na => <BaseItem key={na.id} annotation={na} />)}
       </div>
     )}
   </div>

--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -16,14 +16,14 @@ interface Props {
 
 const AnnotationPopoverContent: FC<Props> = ({ target, crossRefAnnotations, relatedAnnotations, onClose }) => {
 
-  const { usePanelTranslation, panelId } = usePanel()
   const { annotations: annotationsConfig } = useConfig()
+  const { usePanelTranslation, panelId } = usePanel()
   const { t } = usePanelTranslation()
   const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 
   const [crossRefInfos, setCrossRefInfos] = useState<CrossRefInfo[]>([])
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_, setDisplayAnnotations] = useState(null)
+  const [loading, setLoading] = useState(true)
+
   const tooltipAnnotationsRef = useRef<Annotation[]>(null)
   const normalAnnotationsRef = useRef<Annotation[]>(null)
 
@@ -49,7 +49,7 @@ const AnnotationPopoverContent: FC<Props> = ({ target, crossRefAnnotations, rela
     normalAnnotationsRef.current = relatedAnnotations.filter(a =>
       !tooltipTypes.includes((a.body as AnnotationBody)['x-content-type'])).sort(sortByDirectTarget)
 
-    setDisplayAnnotations(true)
+    setLoading(false)
     computeCrossRefInfos(crossRefAnnotations)
   }, [target])
 
@@ -64,6 +64,7 @@ const AnnotationPopoverContent: FC<Props> = ({ target, crossRefAnnotations, rela
     return <p className="py-1 mb-1 text-xs font-medium text-muted-foreground">{label}</p>
   }
 
+  if (loading) return <div>Loading ...</div>
   return <div className="flex flex-col gap-4">
     {tooltipAnnotationsRef.current?.length > 0 && (
       <div className={crossRefInfos.length > 0 ? 'border-b border-border' : ''}>

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -419,6 +419,7 @@ const GenericTextRenderer: FC<Props> = memo(({
       open={tooltipOpen}
       onClose={closeTooltip}>
       <AnnotationPopoverContent
+        target={tooltipTargetElement}
         crossRefAnnotations={crossRefAnnotations}
         relatedAnnotations={relatedAnnotations}
         onClose={closeTooltip}


### PR DESCRIPTION
Closes #1009 

I think we can sort the tooltip annotations and then display the content. Therefore we just to updatea boolean variable as state through `setDisplayAnnotations` when we finish sorting the annotations 