### PR TITLE
Bug clicking on cross ref link nothing is shown

### DIFF
--- a/src/components/panel/annotations/popover/items/CrossRefItem.tsx
+++ b/src/components/panel/annotations/popover/items/CrossRefItem.tsx
@@ -3,6 +3,7 @@ import { usePanel } from '@/contexts/PanelContext.tsx'
 import { validateCrossRefNode } from '@/utils/cross-ref.ts'
 import { CustomError } from '@/utils/custom-error.ts'
 import CrossRefLink from '@/components/panel/annotations/popover/cross-ref/CrossRefLink.tsx'
+import { existsTargetInText } from '@/utils/dom.ts'
 
 interface Props {
   crossRefInfo: CrossRefInfo,
@@ -30,8 +31,9 @@ const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect }) => {
             manifestLabel: (manifestData as Manifest).label,
             itemLabel: newItemLabel
           }
-          // TODO: if (!await existsTargetInText(extendedCrossRefInfoRef.current.refItemData, extendedCrossRefInfoRef.current.contentType, extendedCrossRefInfoRef.current.selector)) throw new CustomError('cross_ref_error_title', 'referenced_element_not_found')
-          loadedData.current = true
+          const targetExists = await existsTargetInText(extendedCrossRefInfoRef.current.refItemData, extendedCrossRefInfoRef.current.contentType, extendedCrossRefInfoRef.current.selector)
+          if (!targetExists) setError(new CustomError(t('cross_ref_error_title'), t('referenced_element_not_found')))
+          else loadedData.current = true
         } catch(e) {
           setError(new CustomError(t(e.name), t(e.message)))
         } finally {

--- a/src/components/panel/annotations/popover/items/CrossRefItem.tsx
+++ b/src/components/panel/annotations/popover/items/CrossRefItem.tsx
@@ -3,7 +3,7 @@ import { usePanel } from '@/contexts/PanelContext.tsx'
 import { validateCrossRefNode } from '@/utils/cross-ref.ts'
 import { CustomError } from '@/utils/custom-error.ts'
 import CrossRefLink from '@/components/panel/annotations/popover/cross-ref/CrossRefLink.tsx'
-import { existsTargetInText } from '@/utils/dom.ts'
+import { apiRequest } from '@/utils/api.ts'
 
 interface Props {
   crossRefInfo: CrossRefInfo,
@@ -31,9 +31,17 @@ const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect }) => {
             manifestLabel: (manifestData as Manifest).label,
             itemLabel: newItemLabel
           }
-          const targetExists = await existsTargetInText(extendedCrossRefInfoRef.current.refItemData, extendedCrossRefInfoRef.current.contentType, extendedCrossRefInfoRef.current.selector)
-          if (!targetExists) setError(new CustomError(t('cross_ref_error_title'), t('referenced_element_not_found')))
-          else loadedData.current = true
+          if (crossRefInfo.textType === 'text') {
+            // for cross ref referring to text part. Throw error when referenced el cannot be found due to a false selector
+            const contentIndex = itemData.content.findIndex(c => c.type.split('=')[1] === crossRefInfo.contentType)
+            const parser = new DOMParser()
+            const referencedText: string = await apiRequest(itemData.content[contentIndex].url)
+            const textEl = parser.parseFromString(referencedText, 'text/html')
+            const targetExists = textEl.querySelector(crossRefInfo.selector)
+            if (!targetExists) setError(new CustomError(t('cross_ref_error_title'), t('referenced_element_not_found')))
+          }
+
+          loadedData.current = true
         } catch(e) {
           setError(new CustomError(t(e.name), t(e.message)))
         } finally {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -138,7 +138,8 @@ declare global {
     selector?: string,
     selectedAnnotation?: Annotation,
     manifestLabel?: string,
-    itemLabel?: string
+    itemLabel?: string,
+    textType: 'text' | 'annotation',     // referenced text
   }
 
   interface DataIntegrity {

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -129,8 +129,7 @@ async function getCrossRefInfo(annotation: Annotation) {
   }
 
   if (!isCrossRefInAnnotation) contentUrl = (annotation.body as AnnotationBodyCrossRef)?.source?.id
-  // TODO: In Popover show error when refAnnotation is not found, due to error in CrossRef Information
-  const refContentType = refItemData.content.find(c => c.url === contentUrl)?.type?.split('type=')[1]
+  const refContentType = refItemData.content?.find(c => c.url === contentUrl)?.type?.split('type=')[1]
 
   return {
     collection: source.collection,

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -135,6 +135,7 @@ async function getCrossRefInfo(annotation: Annotation) {
     collection: source.collection,
     manifest: source.manifest,
     item: source.item,
+    textType: isCrossRefInAnnotation ? 'annotation': 'text',
     contentType: refContentType,
     ...(isCrossRefInAnnotation && { selectedAnnotation: refAnnotation }),
     ...(!isCrossRefInAnnotation && { selector: (annotation.body as AnnotationBodyCrossRef)?.selector?.value }),

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,5 +1,3 @@
-import { apiRequest } from '@/utils/api.ts'
-
 function waitForElementInDom(selector: string, textSelector: string, callback: (el: Element) => void) {
   // selector: refers to a container element
   // textSelector: refers to a text part inside the container element
@@ -43,16 +41,8 @@ function scrollIntoViewIfNeeded(target: HTMLElement, container: HTMLElement) {
   }
 }
 
-async function existsTargetInText(item: Item, contentType: string,  selector: string) {
-  const contentIndex = item.content.findIndex(c => c.type.split('=')[1] === contentType)
-  const parser = new DOMParser()
-  const textString: string = await apiRequest(item.content[contentIndex].url)
-  const textEl = parser.parseFromString(textString, 'text/html')
-  return textEl.querySelector(selector)
-}
-
 function validateSelector(selector: string) {
   return selector.startsWith('#') || selector.startsWith('.')
 }
 
-export { waitForElementInDom, scrollIntoViewIfNeeded, validateSelector, existsTargetInText }
+export { waitForElementInDom, scrollIntoViewIfNeeded, validateSelector }


### PR DESCRIPTION
Closes #1012 

The crossRefData is not correctly given, due to having in source.collection a root Collection url and not a leaf collection. As a consequence the manifest and item data are not valid data structure.

In `annotations.ts` we have function getCrossRefInfo. When refItemData is wrong data, i.e does not have 'content' attribute, then the code should not break and return the retrieved data from crossRefAnnotation.
We already handle errors in crossRef Data in `CrossRefItem`.
By making this small fix then we would see the content as in following screenshot <br/> <br/>
<img width="1304" height="929" alt="image" src="https://github.com/user-attachments/assets/01c3257e-b7e9-4d90-9b9c-902fa3f9577f" />

Additionally I just restore the validation function of the existence of target in referenced html text