### PR TITLE
fix: handle click event on target without filtered annotations

### DIFF
--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -82,6 +82,7 @@ const GenericTextRenderer: FC<Props> = memo(({
   const targetsRef = useRef<HTMLElement[]>(null)
   const hoveredAnnotationsRef = useRef<string[] | null>(null)
   const activeTargetRef = useRef<HTMLElement | null>(null)
+  const selectedAnnotationTypesRef = useRef<AnnotationTypesDict | null>(null)
 
   // Document object that is only recreated when htmlString changes - e.g. on item change or content type change
   const parsedDom: Element = React.useMemo(() => {
@@ -296,7 +297,7 @@ const GenericTextRenderer: FC<Props> = memo(({
 
     setMatchedMap(resultMap)
     if (onUpdateMatchedAnnotationsMap) onUpdateMatchedAnnotationsMap(resultMap)
-
+    selectedAnnotationTypesRef.current = selectedAnnotationTypes
   }, [selectedAnnotationTypes])
 
   const onMouseEnterTarget = (e: Event) => {
@@ -317,6 +318,18 @@ const GenericTextRenderer: FC<Props> = memo(({
     setHoveredAnnotations(hoveredAnnotationsRef.current?.filter(a => !idsArray.includes(a)) ?? null)
   }
 
+  function isFilteredAnnotation(annotation: Annotation, selectedAnnotationTypes: AnnotationTypesDict) {
+    // filter Variant Annotations based on witnesses in selectedAnnotationTypes
+    // filter all other annotations which have type as key in selectedAnnotation types
+    const annotationType = annotation.body['x-content-type']
+    if (annotationType === 'Variant') {
+      return selectedAnnotationTypes?.['Variant']?.some(witness => annotation.body.witnesses.includes(witness))
+    }
+    else {
+      return Object.keys(selectedAnnotationTypes).includes(annotationType)
+    }
+  }
+
 
   const onClickTarget = async (e: Event) => {
     // Generic click listener
@@ -325,6 +338,13 @@ const GenericTextRenderer: FC<Props> = memo(({
 
     const target = e.currentTarget as Element
     const targetEntry: MergedAnnotationEntry = flippedMatchedMapRef.current.filter(entry => entry.target === target)[0]
+
+    let hasFilteredAnnotations = false
+    targetEntry?.annotations.forEach(annotation => {
+      if (isFilteredAnnotation(annotation, selectedAnnotationTypesRef.current)) hasFilteredAnnotations = true
+    })
+
+    if (!hasFilteredAnnotations) return
 
     if (!containsChildren(targetsRef.current, target as HTMLElement)) {
       // handle only click events on 'deepest' target -> ignore click events on its containing targets while selection
@@ -349,7 +369,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     const newRelatedAnnotations = (flippedMatchedMapRef.current ?? [])
       .filter(entry => entry.target === target || entry.target.contains(target as HTMLElement))
       .flatMap(entry => entry.annotations)
-      .filter(a => !seen.has(a.id) && seen.add(a.id) && getAnnotationContentType(a) !== crossRefContentType)
+      .filter(a => !seen.has(a.id) && seen.add(a.id) && isFilteredAnnotation(a, selectedAnnotationTypesRef.current))
 
     const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 
@@ -357,7 +377,7 @@ const GenericTextRenderer: FC<Props> = memo(({
       ? newRelatedAnnotations
       : newRelatedAnnotations.filter(a => !tooltipTypes.includes((a.body as AnnotationBody).annotationType))
 
-    const openTooltip = !(normalAnnotations.length === 1 && newRelatedAnnotations.length === 1 && crossRefAnnotations.length === 0)
+    const openTooltip = !([0,1].includes(normalAnnotations.length) && [0,1].includes(newRelatedAnnotations.length) && crossRefAnnotations.length === 0)
 
     if (openTooltip) {
       setTooltipOpen(true)

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -28,7 +28,6 @@ import {
   removeSelectedStyle
 } from '@/utils/text.ts'
 import {
-  getAnnotationContentType,
   getNestedAnnotations,
   getSource,
   isFiltered
@@ -116,8 +115,7 @@ const GenericTextRenderer: FC<Props> = memo(({
           return acc
         }
 
-        const isCrossRefAnnotation = source.endsWith('.html') ? (cur.body as AnnotationBody)?.annotationType === 'CrossRef' : (cur.body as AnnotationBodyCrossRef)?.source?.annotationType === 'CrossRef'
-        if (isCrossRefAnnotation) {
+        if (cur.body.annotationType === annotationsConfig?.crossRefContentType) {
           Array.from(parsedDom.querySelectorAll(selector)).forEach(el => {
             addCrossRefTargetStyle(el)
           })
@@ -321,7 +319,7 @@ const GenericTextRenderer: FC<Props> = memo(({
   function isFilteredAnnotation(annotation: Annotation, selectedAnnotationTypes: AnnotationTypesDict) {
     // filter Variant Annotations based on witnesses in selectedAnnotationTypes
     // filter all other annotations which have type as key in selectedAnnotation types
-    const annotationType = annotation.body['x-content-type']
+    const annotationType = annotation.body.annotationType
     if (annotationType === 'Variant') {
       return selectedAnnotationTypes?.['Variant']?.some(witness => annotation.body.witnesses.includes(witness))
     }
@@ -354,7 +352,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     const crossRefAnnotations = annotations
       .filter(a => {
         const isInSource = a.target?.[0].source === source
-        const isCrossRef = getAnnotationContentType(a) === annotationsConfig?.crossRefContentType
+        const isCrossRef = a.body.annotationType === annotationsConfig?.crossRefContentType
         return isInSource && isCrossRef
       })
       .filter(a => {

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -363,7 +363,6 @@ const GenericTextRenderer: FC<Props> = memo(({
         return Array.from(parsedDom.querySelectorAll(selector)).includes(target)
       })
 
-    const crossRefContentType = annotationsConfig?.crossRefContentType
     const seen = new Set<string>()
     // compute related annotations: all annotations for the clicked target and its parent targets
     const newRelatedAnnotations = (flippedMatchedMapRef.current ?? [])

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -34,7 +34,7 @@ declare global {
 
 
   interface Annotation {
-    body: AnnotationBody | AnnotationBodyCrossRef
+    body: AnnotationBody
     target: AnnotationTarget[]
     type: string
     id: string
@@ -46,16 +46,12 @@ declare global {
     format: AnnotationContentFormat
     annotationType: string
     witnesses?: string[]
-  }
-
-  interface AnnotationBodyCrossRef {
-    source: {
+    source?: {
       id: string
       collection: string
       manifest: string
       item: string
-      annotationType: string
-    },
+    }
     selector?: CssSelector
   }
 
@@ -88,7 +84,8 @@ declare global {
 
   type CssSelector = {
     type: 'CssSelector'
-    value: string
+    value: string,
+    conformsTo?: string
   }
 
   interface CrossRefInfo {

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -115,7 +115,7 @@ async function getCrossRefInfo(annotation: Annotation) {
   // annotation: CrossRefAnnotation which contains the cross ref data, from which we extract the desired information
   const isCrossRefInAnnotation = !getSource(annotation?.target[0]).id.endsWith('.html')
 
-  const source = (annotation.body as AnnotationBodyCrossRef).source
+  const source = annotation.body.source
   const refItemData = await apiRequest<Item>(source.item)
   const refAnnotationId = source?.id
   let refAnnotation
@@ -128,7 +128,7 @@ async function getCrossRefInfo(annotation: Annotation) {
     contentUrl = getSource(refAnnotation?.target?.[0]).id
   }
 
-  if (!isCrossRefInAnnotation) contentUrl = (annotation.body as AnnotationBodyCrossRef)?.source?.id
+  if (!isCrossRefInAnnotation) contentUrl = annotation.body.source?.id
   const refContentType = refItemData.contents?.find(c => c.id === contentUrl)?.contentType?.split('type=')[1]
 
   return {
@@ -138,7 +138,7 @@ async function getCrossRefInfo(annotation: Annotation) {
     textType: isCrossRefInAnnotation ? 'annotation': 'text',
     contentType: refContentType,
     ...(isCrossRefInAnnotation && { selectedAnnotation: refAnnotation }),
-    ...(!isCrossRefInAnnotation && { selector: (annotation.body as AnnotationBodyCrossRef)?.selector?.value }),
+    ...(!isCrossRefInAnnotation && { selector: annotation.body.selector?.value }),
     refItemData
   }
 }
@@ -148,12 +148,6 @@ function getSource(target: AnnotationTarget): AnnotationTargetSource {
     return target.source
   }
   return { id: target.source }
-}
-
-function getAnnotationContentType(annotation: Annotation) {
-  const body = annotation.body
-  if ('x-content-type' in body) return body.annotationType
-  return body.source?.annotationType
 }
 
 export {
@@ -166,6 +160,5 @@ export {
   getNestedAnnotations,
   getAnnotationIdsByEl,
   getCrossRefInfo,
-  getSource,
-  getAnnotationContentType
+  getSource
 }


### PR DESCRIPTION
- prevent click on this target
- show the correct number of filtered annotations which belong to target

How I tested this PR: Well I used another branch `fix-scroll-selected-annotation` which does not include the newest PR which adapts TIDO with TextAPI 2.0. 
As data for bdn I use the current data, which is not yet migrated to 2.0 

Closes #1015 