### PR TITLE
feat: scroll to selected Annotation (text -> annotation, bookmarking, config selectedAnnotationId)

### DIFF
--- a/src/components/panel/annotations/popover/items/BaseItem.tsx
+++ b/src/components/panel/annotations/popover/items/BaseItem.tsx
@@ -16,13 +16,19 @@ const BaseItem: FC<Props> = ({ annotation }) => {
 
   const [text, setText] = useState('')
 
-  const type = (annotation.body as AnnotationBody).annotationType
+  const type = annotation.body.annotationType
   const typeLabel = annotationsConfig?.types?.[type]?.label ?? type
   const content = (annotation.body as AnnotationBody).value
-  const isSelected = selectedAnnotation?.id === annotation.id
+  const isSelected = selectedAnnotation?.annotation.id === annotation.id
 
   function handleSelection() {
-    updatePanel({ selectedAnnotation: isSelected ? null : annotation, showSidebar: true })
+    updatePanel(
+      { selectedAnnotation: isSelected ? null : {
+        annotation,
+        origin: 'text'
+      },
+      showSidebar: true }
+    )
   }
 
   useEffect(() => {

--- a/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
+++ b/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
@@ -2,11 +2,12 @@ import { FC, useEffect, useRef, useState } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import Annotation from '@/components/panel/annotations/sidebar/Annotation.tsx'
 import { useAnnotations } from '@/contexts/AnnotationsContext.tsx'
+import { scrollIntoViewIfNeeded } from '@/utils/dom.ts'
 
 const ANNOTATION_GAP = 5
 
 const AlignAnnotationsList: FC = () => {
-  const { panelId, selectedAnnotation, setSelectedAnnotation } = usePanel()
+  const { panelId, selectedAnnotation, setSelectedAnnotation, getScroller, panelState } = usePanel()
   const { filteredAnnotations } = useAnnotations()
 
   // Elements represents an array of several infos for each visible annotation. These infos are needed to update the top
@@ -26,10 +27,23 @@ const AlignAnnotationsList: FC = () => {
   }
 
   useEffect(() => {
-    trackTopChange()
-
     const panelEl = document.getElementById(panelId) as HTMLElement
     const annotationsSideBarEl = panelEl?.querySelector('div[data-sidebar-container="true"]') as HTMLElement
+
+    if (!selectedAnnotation) return
+    const { annotation, origin } = selectedAnnotation
+    if (origin === 'text') {
+      const scroller = getScroller()
+      scroller.syncSidebarToText(selectedAnnotation.annotation.target[0]?.source)
+      trackTopChange()
+    } else if (origin  === 'other') {
+      // selectedAnnotation comes from Bookmarking or config
+      const target = annotation.target[0]
+      const targetSourceUrl = target.source
+      const textEl = panelEl.querySelector(`div[data-content-url="${targetSourceUrl}"]`)
+      const targetEl = textEl.querySelector(target.selector.value)
+      scrollIntoViewIfNeeded(targetEl, textEl as HTMLElement)
+    }
 
     async function deselectAnnotationOnOutsideClick(event: MouseEvent) {
       // if we click at an annotation - we return false
@@ -79,7 +93,7 @@ const AlignAnnotationsList: FC = () => {
       // Next, we decide if that minimum value is even needed or if the desiredY is more below and therefore should be used instead.
       const actualY = i === 0 ? annotationEl.desiredY : Math.max(annotationEl.desiredY, minY)
 
-      if (selectedAnnotation && annotationEl.annotation.id === selectedAnnotation.id && actualY !== annotationEl.desiredY) {
+      if (selectedAnnotation && annotationEl.annotation.id === selectedAnnotation.annotation.id && actualY !== annotationEl.desiredY) {
         // If this is a selectedAnnotation, and it has some other annotations above
         // (which caused the current to move down, for example if the selected annotation is in the same row with multiple other annotations),
         // we want to move those annotations further above, so our selected one can be placed to the desiredY
@@ -116,6 +130,12 @@ const AlignAnnotationsList: FC = () => {
     if (filteredAnnotations?.length === 0) {
       setElements([])
     } else {
+      const scroller = getScroller()
+      const firstTextView = panelState.panelViews.find(v => v.view === 'text')
+      const contentUrl = panelState.item?.contents.find(c =>
+        c.contentType.includes(firstTextView?.activeContentType))?.id
+      scroller.syncSidebarToText(contentUrl)
+
       const annotationEls = Array.from(ref.current?.childNodes ?? [])
       const _elements = annotationEls.map(el => {
         const annotation = filteredAnnotations.find(a => a.id === (el as HTMLElement).getAttribute('data-annotation'))

--- a/src/components/panel/annotations/sidebar/Annotation.tsx
+++ b/src/components/panel/annotations/sidebar/Annotation.tsx
@@ -50,7 +50,7 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
   }, [data, hoveredAnnotations])
 
   useEffect(() => {
-    setIsSelected(selectedAnnotation && selectedAnnotation.id === data.id)
+    setIsSelected(selectedAnnotation && selectedAnnotation.annotation.id === data.id)
   }, [data, selectedAnnotation])
 
   function onSelect() {
@@ -86,14 +86,17 @@ const Annotation: FC<Props> = React.memo(({ data, top, onToggle, isNested = fals
     const clickedEl = e.target
     if (targetsRef.current.includes(clickedEl)) return
 
-    if (selectedAnnotation && selectedAnnotation.id === data.id) {
+    if (selectedAnnotation && selectedAnnotation.annotation.id === data.id) {
       setIsSelected(false)
       setTimeout(() => setSelectedAnnotation(null), 100)
       return
     }
 
     setIsSelected(true)
-    setTimeout(() => setSelectedAnnotation(data), 100)
+    setTimeout(() => setSelectedAnnotation({
+      annotation: data,
+      origin: 'annotation'
+    }), 100)
   }
 
   function handleMouseEnter() {

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -38,6 +38,7 @@ import { containsChildren } from '@/utils/text.ts'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
 import AnnotationPopoverContainer from '@/components/panel/annotations/popover/AnnotationPopoverContainer.tsx'
 import AnnotationPopoverContent from '@/components/panel/annotations/popover/AnnotationPopoverContent.tsx'
+import { SelectedAnnotation } from '@/types'
 
 interface Props {
   htmlString?: string
@@ -77,7 +78,7 @@ const GenericTextRenderer: FC<Props> = memo(({
 
   const textWrapperRef = useRef<HTMLDivElement>(null)
   const flippedMatchedMapRef = useRef<MergedAnnotationEntry[]>(null)
-  const selectedAnnotationRef = useRef<Annotation | null>(null)
+  const selectedAnnotationRef = useRef<SelectedAnnotation | null>(null)
   const targetsRef = useRef<HTMLElement[]>(null)
   const hoveredAnnotationsRef = useRef<string[] | null>(null)
   const activeTargetRef = useRef<HTMLElement | null>(null)
@@ -215,8 +216,8 @@ const GenericTextRenderer: FC<Props> = memo(({
     if (!matchedMap) return
     hoveredAnnotationsRef.current = hoveredAnnotations
     const targetsOfHoveredAnnotations = getTargetsHoveredAnnotations(hoveredAnnotations, targetsRef.current, matchedMap)
-    const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedMap[selectedAnnotation.id]) ?
-      matchedMap[selectedAnnotation.id].target : []
+    const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedMap[selectedAnnotation.annotation.id]) ?
+      matchedMap[selectedAnnotation.annotation.id].target : []
 
     flippedMatchedMapRef.current?.forEach(fa => {
       const target = fa.target as HTMLElement
@@ -253,8 +254,8 @@ const GenericTextRenderer: FC<Props> = memo(({
     if (!matchedMap) return
 
     selectedAnnotationRef.current = selectedAnnotation
-    const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedMap[selectedAnnotation.id])
-      ? matchedMap[selectedAnnotation.id].target
+    const targetsOfSelectedAnnotation = selectedAnnotation && !!(matchedMap[selectedAnnotation.annotation.id])
+      ? matchedMap[selectedAnnotation.annotation.id].target
       : []
 
     if (!flippedMatchedMapRef.current) return
@@ -319,6 +320,8 @@ const GenericTextRenderer: FC<Props> = memo(({
   function isFilteredAnnotation(annotation: Annotation, selectedAnnotationTypes: AnnotationTypesDict) {
     // filter Variant Annotations based on witnesses in selectedAnnotationTypes
     // filter all other annotations which have type as key in selectedAnnotation types
+    if (!selectedAnnotationTypes) return true
+
     const annotationType = annotation.body.annotationType
     if (annotationType === 'Variant') {
       return selectedAnnotationTypes?.['Variant']?.some(witness => annotation.body.witnesses.includes(witness))
@@ -388,13 +391,17 @@ const GenericTextRenderer: FC<Props> = memo(({
     // when we have only one normal annotation then we should select the annotation in Sidebar and not open tooltip. (select + deselect annotation)
     if (!openTooltip && normalAnnotations.length === 1) {
       // we need selectedAnnotationRef since the click listener has not an updated value of selectedAnnotation, it has the 'null' when it was initially created
-      if (targetEntry.annotations[0].id === selectedAnnotationRef.current?.id) {
+      if (targetEntry.annotations[0].id === selectedAnnotationRef.current?.annotation.id) {
         setSelectedAnnotation(null)
         selectedAnnotationRef.current = null
       }
       else {
-        setSelectedAnnotation(normalAnnotations[0])
-        selectedAnnotationRef.current = normalAnnotations[0]
+        const selectedAnnotation = {
+          annotation: normalAnnotations[0],
+          origin: 'text'
+        }
+        setSelectedAnnotation(selectedAnnotation)
+        selectedAnnotationRef.current = selectedAnnotation
         if (onSelect) onSelect()
       }
     }

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -394,12 +394,12 @@ const GenericTextRenderer: FC<Props> = memo(({
       if (targetEntry.annotations[0].id === selectedAnnotationRef.current?.annotation.id) {
         setSelectedAnnotation(null)
         selectedAnnotationRef.current = null
-      }
-      else {
+      } else {
         const selectedAnnotation = {
           annotation: normalAnnotations[0],
           origin: 'text'
-        }
+        } as SelectedAnnotation
+
         setSelectedAnnotation(selectedAnnotation)
         selectedAnnotationRef.current = selectedAnnotation
         if (onSelect) onSelect()

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -7,7 +7,7 @@ import { apiRequest, getAnnotationPage, getFirstItem, getFirstManifest } from '@
 import { getContentTypes, isNewManifest } from '@/utils/panel.ts'
 import { getAssets } from '@/utils/support-styling.ts'
 import { PanelResizer } from '@/utils/panel-resizer.ts'
-import { FilterNodeWithSelection, PanelConfig, PanelView } from '@/types'
+import { FilterNodeWithSelection, PanelConfig, PanelView, SelectedAnnotation } from '@/types'
 import { useTranslation, UseTranslationResponse } from 'react-i18next'
 import { getCollectionSlug } from '@/utils/tree.ts'
 import { setColors } from '@/utils/witness-colors.ts'
@@ -35,8 +35,8 @@ interface PanelContextType {
   selectedAnnotationTypes: AnnotationTypesDict | null,
   setSelectedAnnotationTypes: (value: AnnotationTypesDict) => void,
   annotations: Annotation[] | null,
-  selectedAnnotation: Annotation | null,
-  setSelectedAnnotation: (value: Annotation | null) => void
+  selectedAnnotation: SelectedAnnotation | null,
+  setSelectedAnnotation: (value: SelectedAnnotation | null) => void
   showTextOptions: boolean,
   setShowTextOptions: (value: boolean) => void,
   usePanelTranslation: () =>  UseTranslationResponse<'common', undefined>
@@ -225,9 +225,13 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
           }
 
           setAnnotations(annotations)
-          if (config.selectedAnnotation) {
-            updatePanel({ selectedAnnotation: annotations.find(a => a.id === config.selectedAnnotation) ?? null })
-          }
+          if (config.selectedAnnotationId) {
+            updatePanel({ selectedAnnotation: {
+              annotation: annotations.find(a => a.id === config.selectedAnnotationId) ?? null,
+              origin: 'other'
+            },
+            showSidebar: true
+            })          }
         } catch (e) {
           console.error(e)
           setAnnotationsError(e)
@@ -371,8 +375,8 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
     return scroller.current
   }
 
-  function setSelectedAnnotation(annotation: Annotation | null) {
-    updatePanel({ selectedAnnotation: annotation })
+  function setSelectedAnnotation(selectedAnnotation: SelectedAnnotation | null) {
+    updatePanel({ selectedAnnotation })
   }
 
   return (

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -95,7 +95,7 @@ declare global {
     contentType: string,
     refItemData: Item,
     selector?: string,
-    selectedAnnotation?: Annotation,
+    selectedAnnotation?: SelectedAnnotation,
     manifestLabel?: string,
     itemLabel?: string,
     textType: 'text' | 'annotation',     // referenced text
@@ -115,7 +115,7 @@ declare global {
     activeTargetIndex: number
     config: PanelConfig
     showSidebar: boolean
-    selectedAnnotation?: Annotation
+    selectedAnnotation?: SelectedAnnotation
     panelViews: PanelView[]
     contentTypes: string[]
   }
@@ -193,7 +193,7 @@ export interface PanelConfig {
   manifest?: string
   item?: string,
   views?: PanelView[]
-  selectedAnnotation?: string
+  selectedAnnotationId?: string
   showSidebar?: boolean
 }
 
@@ -301,6 +301,12 @@ export interface TidoContentStateTarget {
     views?: PanelViewContentState[]
     annotation?: string
   }
+}
+
+// "other" refers to origin in [bookmarking, config]
+export interface SelectedAnnotation {
+  annotation: Annotation,
+  origin: 'text' | 'annotation' | 'other'
 }
 
 export interface PanelViewContentState {

--- a/src/utils/bookmarking.ts
+++ b/src/utils/bookmarking.ts
@@ -88,7 +88,7 @@ function extractPanelConfig(target: TidoContentStateTarget): { collectionUrl: st
 function createContentState(panelStates: PanelState[]): TidoContentState {
 
   const target: TidoContentStateTarget[] = panelStates.map(({ selectedAnnotation, item, manifest, collectionId, }) => {
-    const state = selectedAnnotation ? { annotation: selectedAnnotation.id } : undefined
+    const state = selectedAnnotation ? { annotation: selectedAnnotation.annotation.id } : undefined
 
     return {
       id: item.id,

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -369,7 +369,7 @@ export async function mergeAndValidateConfig(
             collection: collectionUrl,
             ...(itemIndex > -1 && { item: itemUrl }),
             ...(manifestIndex > -1 && { manifest: manifestUrl }),
-            ...(selectedAnnotationId && { selectedAnnotation: selectedAnnotationId, showSidebar: true })
+            ...(selectedAnnotationId && { selectedAnnotationId, showSidebar: true })
           }
         }))
       }

--- a/src/utils/scroller.ts
+++ b/src/utils/scroller.ts
@@ -96,6 +96,10 @@ class Scroller {
     setTimeout(() => this.isSyncing = false, 20)
   }
 
+  syncSidebarToText(contentUrl: string | AnnotationTargetSource) {
+    this.syncScroll(this.texts[contentUrl], this.sidebar)
+  }
+
   handleSidebarScroll() {
     if (this.isSyncing || !this.sidebar) return
     const refY = this.sidebar.scrollTop + this.sidebar.clientHeight * SYNC_SCROLL_THRESHOLD_TOP


### PR DESCRIPTION
This PR aims to address following issue: when selecting at text and sidebar is not opened sidebar does not scroll to selected annotation.
Problem with current implementation: Sidebar sync scrolling with the text, only when the text scrolls. 
A use case of problem is for example when we scroll in text, sidebar is not opened and we click at target. 

This PR adds following
- clicking at a target when sidebar is closed, should "sync scroll" sidebar with the scrolled text AND trackTopChange() is applied
- clicking at an annotation should not apply trackTopChange()
- bookmarking a selected annotation -> scrolls the respective text to selectedAnnotation's target
- providing a selectedAnnotationId in config -> scrolls the respective text to selectedAnnotation's target

Approach: we perform different actions when the annotation is selected from the text or due to clicking the annotation itself. Therefore we need to know the origin of selection. 
I change selectedAnnotation structure to  {
   annotation,
   origin
} 

Closes #1014 