### PR TITLE
fix: preserve the selected views in a panel when toggling some off and navigate to a new item

### DIFF
--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -191,7 +191,9 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
         }
       }
 
-      const resultPanelViews: PanelView[] =
+      // next line we prioritize the views changed from the user on the current panel. I.e toggle off views and navigate to a new item on same panel
+      // we should preserve the selected views from user for this panel
+      const resultPanelViews: PanelView[] = panelState.panelViews && panelState.panelViews.length > 0 ? panelState.panelViews:
         config.views && config.views.length > 0
           ? config.views.map((view, i) => ({
             ...(panelViewsConfig[i] ?? {}),


### PR DESCRIPTION
Scenario
- A user defines in panelViews 3 views
- In one Panel he toggles one view off.
- Navigating to a new item currently shows 3 views

Expected behavior
- Navigate to a new item in this panel should show two remaining views and not the configured ones
- Adding a new panel should show initially 3 views as they are configured

Closes #1031 