### PR TITLE
Reload on pane error

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -89,6 +89,7 @@
     "report_bug": "Fehler melden",
     "source_code": "Source Code",
     "retry": "Erneut versuchen",
+    "loading_data": "Daten werden geladen",
     "text_loading_failed": "Text konnte nicht geladen werden",
     "dismiss": "Verwerfen",
     "text_not_displayed_correctly": "Der Text wird vermutlich nicht korrekt dargestellt, da er unerlaubte HTML-Elemente enthielt.",

--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -89,7 +89,7 @@
     "report_bug": "Fehler melden",
     "source_code": "Source Code",
     "retry": "Erneut versuchen",
-    "loading_data": "Daten werden geladen",
+    "loading_panel_data": "Daten des Panels werden geladen",
     "text_loading_failed": "Text konnte nicht geladen werden",
     "dismiss": "Verwerfen",
     "text_not_displayed_correctly": "Der Text wird vermutlich nicht korrekt dargestellt, da er unerlaubte HTML-Elemente enthielt.",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -84,6 +84,7 @@
     "report_bug": "Report A Bug",
     "source_code": "Source Code",
     "retry": "Retry",
+    "loading_data": "Loading data",
     "text_loading_failed": "Text loading failed",
     "dismiss": "Dismiss",
     "text_not_displayed_correctly": "The text is probably not displayed correctly because it contained unallowed HTML elements.",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -84,7 +84,7 @@
     "report_bug": "Report A Bug",
     "source_code": "Source Code",
     "retry": "Retry",
-    "loading_data": "Loading data",
+    "loading_panel_data": "Loading Panel data",
     "text_loading_failed": "Text loading failed",
     "dismiss": "Dismiss",
     "text_not_displayed_correctly": "The text is probably not displayed correctly because it contained unallowed HTML elements.",

--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -15,7 +15,7 @@ import Loading from '@/components/ui/loading.tsx'
 import { useTranslation } from 'react-i18next'
 
 const PanelContent: FC = React.memo(() => {
-  const { panelState, resizer, error, init, loading } = usePanel()
+  const { init, panelState, resizer, error, loading } = usePanel()
   const { t } = useTranslation()
   const [showSidebarContent, setShowSidebarContent] = useState(panelState.showSidebar)
   const [contentPanes, setContentPanes] = useState([])
@@ -57,25 +57,27 @@ const PanelContent: FC = React.memo(() => {
     }
   }, [panelState.showSidebar])
 
-  if (loading) return <div className="main-content w-full h-full flex pt-[30%] justify-center bg-gray-100">
-    <div>
-      {t('loading_data')}...
-      <div><Loading size={36} /> </div>
-    </div>
-  </div>
 
-  if (error) return <PanelError error={error} resetErrorBoundary={() => init(panelState.config)} />
+  if (error && !loading) return <PanelError error={error} resetErrorBoundary={() =>  init(panelState.config)} />
 
-  return (
-    <TextProvider>
-      <div
-        className={`h-full flex flex-col relative overflow-hidden`} style={{
-          '--sash-hover-size': '2px',
-          '--focus-border': 'rgb(var(--tido-color-primary))'
-        } as React.CSSProperties}>
-        <div className="h-full w-full overflow-hidden relative" data-cy="panel-container">
-          <div className="main-content flex flex-col h-full @container/panel">
-            <PanelHeader />
+  return (<TextProvider>
+    <div
+      className={`h-full flex flex-col relative overflow-hidden`} style={{
+        '--sash-hover-size': '2px',
+        '--focus-border': 'rgb(var(--tido-color-primary))'
+      } as React.CSSProperties}>
+      <div className="h-full w-full overflow-hidden relative" data-cy="panel-container">
+        {loading &&
+          <div className="absolute inset-0 flex justify-center top-[30%] z-10">
+            <div className="text-center">
+              {t('loading_panel_data')}
+              <div><Loading size={36} /></div>
+            </div>
+          </div>
+        }
+        <div className="main-content flex flex-col h-full @container/panel">
+          <PanelHeader />
+          {!loading && <>
             <div className="flex-1">
               <Allotment ref={allotmentRef} proportionalLayout={true}>
                 {contentPanes.map((pane, index) => {
@@ -86,15 +88,16 @@ const PanelContent: FC = React.memo(() => {
                 })}
               </Allotment>
             </div>
-          </div>
-          <div className="sidebar absolute h-full top-0">
-            <div className="absolute inset-y-0 left-0 w-px bg-border z-40" />
-            { showSidebarContent && <ResizeHandle className="-left-1.5 z-50" data-sidebar-resize-handle /> }
-            { showSidebarContent && <SidebarView /> }
-          </div>
+          </>}
+        </div>
+        <div className="sidebar absolute h-full top-0">
+          <div className="absolute inset-y-0 left-0 w-px bg-border z-40" />
+          { showSidebarContent && <ResizeHandle className="-left-1.5 z-50" data-sidebar-resize-handle /> }
+          { showSidebarContent && <SidebarView /> }
         </div>
       </div>
-    </TextProvider>
+    </div>
+  </TextProvider>
   )
 })
 

--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -13,7 +13,7 @@ import PanelError from '@/components/panel/PanelError.tsx'
 import ResizeHandle from '@/components/panel/ResizeHandle.tsx'
 
 const PanelContent: FC = React.memo(() => {
-  const { panelState, resizer, error } = usePanel()
+  const { panelState, resizer, error, init } = usePanel()
   const [showSidebarContent, setShowSidebarContent] = useState(panelState.showSidebar)
   const [contentPanes, setContentPanes] = useState([])
   const allotmentRef = useRef<AllotmentHandle>(null)
@@ -55,8 +55,7 @@ const PanelContent: FC = React.memo(() => {
   }, [panelState.showSidebar])
 
 
-  if (error) return <PanelError error={error} resetErrorBoundary={() => {}} />
-
+  if (error) return <PanelError error={error} resetErrorBoundary={() => init(panelState.config)} />
 
   return (
     <TextProvider>

--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -11,9 +11,12 @@ import { Allotment, AllotmentHandle } from 'allotment'
 import SidebarView from '@/components/panel/views/sidebar/SidebarView.tsx'
 import PanelError from '@/components/panel/PanelError.tsx'
 import ResizeHandle from '@/components/panel/ResizeHandle.tsx'
+import Loading from '@/components/ui/loading.tsx'
+import { useTranslation } from 'react-i18next'
 
 const PanelContent: FC = React.memo(() => {
-  const { panelState, resizer, error, init } = usePanel()
+  const { panelState, resizer, error, init, loading } = usePanel()
+  const { t } = useTranslation()
   const [showSidebarContent, setShowSidebarContent] = useState(panelState.showSidebar)
   const [contentPanes, setContentPanes] = useState([])
   const allotmentRef = useRef<AllotmentHandle>(null)
@@ -54,6 +57,12 @@ const PanelContent: FC = React.memo(() => {
     }
   }, [panelState.showSidebar])
 
+  if (loading) return <div className="w-full h-full flex pt-[30%] justify-center bg-gray-100">
+    <div>
+      {t('loading_data')}...
+      <div><Loading size={36} /> </div>
+    </div>
+  </div>
 
   if (error) return <PanelError error={error} resetErrorBoundary={() => init(panelState.config)} />
 

--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -57,7 +57,7 @@ const PanelContent: FC = React.memo(() => {
     }
   }, [panelState.showSidebar])
 
-  if (loading) return <div className="w-full h-full flex pt-[30%] justify-center bg-gray-100">
+  if (loading) return <div className="main-content w-full h-full flex pt-[30%] justify-center bg-gray-100">
     <div>
       {t('loading_data')}...
       <div><Loading size={36} /> </div>

--- a/src/components/tree/GlobalTree.tsx
+++ b/src/components/tree/GlobalTree.tsx
@@ -43,10 +43,13 @@ const GlobalTree: FC = () => {
 
   useEffect(() => {
     const loadNodes = async (nodes: TreeNode[]) => {
-      const treeNodes = nodes.length > 1 ? nodes : nodes.length === 1 ? [await getExpandedNode(nodes[0])] : []
-      setTreeNodes(treeNodes)
+      try {
+        const treeNodes = nodes.length > 1 ? nodes : nodes.length === 1 ? [await getExpandedNode(nodes[0])] : []
+        setTreeNodes(treeNodes)
+      } catch {
+        console.error('error while loading data in Global tree')
+      }
     }
-
     loadNodes(nodes)
   }, [nodes])
 

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -38,21 +38,27 @@ export const ConfigProvider = ({ userConfig, children }: ConfigProviderProps) =>
 
   useEffect(() => {
     async function initApp() {
-      setLoading(true)
-      const { config, errors } = await mergeAndValidateConfig(userConfig, defaultConfig)
-      if (Object.keys(errors).length > 0) console.error(errors)
-      initI18n(config.translations, config.lang)
-      createThemeStyles(config)
+      try {
+        setLoading(true)
+        const { config, errors } = await mergeAndValidateConfig(userConfig, defaultConfig)
+        if (Object.keys(errors).length > 0) console.error(errors)
+        initI18n(config.translations, config.lang)
+        createThemeStyles(config)
 
-      createTreeNodes(config.rootCollections)
+        createTreeNodes(config.rootCollections)
 
-      // add rootCollection in Collections map
-      config.rootCollections.forEach((collectionUrl, i) => {
-        promiseWithCache(`initCollection${i}`, () => useDataStore.getState().initCollection(collectionUrl))
-      })
+        setConfig(config)
+        await Promise.all(
+          config.rootCollections.map((collectionUrl, i) =>
+            promiseWithCache(`initCollection${i}`, () => useDataStore.getState().initCollection(collectionUrl))
+          )
+        )
 
-      setConfig(config)
-      setLoading(false)
+      } catch(e) {
+        console.error(e)
+      } finally {
+        setTimeout(() => setLoading(false), 400)
+      }
     }
 
     initApp()

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -57,7 +57,7 @@ export const ConfigProvider = ({ userConfig, children }: ConfigProviderProps) =>
       } catch(e) {
         console.error(e)
       } finally {
-        setTimeout(() => setLoading(false), 400)
+        setLoading(false)
       }
     }
 

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -258,7 +258,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
       setTimeout(() => {
         onLoaded()
         setLoading(false)
-      }, 100)
+      }, 500)
     }
   }
 

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -34,6 +34,7 @@ interface PanelContextType {
   setAnnotationFilters:  Dispatch<SetStateAction<FilterNodeWithSelection[]>>,
   selectedAnnotationTypes: AnnotationTypesDict | null,
   setSelectedAnnotationTypes: (value: AnnotationTypesDict) => void,
+  setError : (error: CustomError | null) => void,
   annotations: Annotation[] | null,
   selectedAnnotation: SelectedAnnotation | null,
   setSelectedAnnotation: (value: SelectedAnnotation | null) => void
@@ -410,6 +411,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
       setAnnotationsMode,
       getScroller: getScroller,
       error,
+      setError,
       annotationsError,
       annotationsLoading,
       matchedAnnotationsMaps,

--- a/src/utils/panel-resizer.ts
+++ b/src/utils/panel-resizer.ts
@@ -62,8 +62,11 @@ class PanelResizer {
       this.sidebarEl.style.width = `${this.sidebarWidth}px`
     } else {
       this.mainContentEl.style.width = `${newWidth - PANEL_BORDER_WIDTH * 2}px`
-      this.sidebarEl.style.left = `${newWidth - PANEL_BORDER_WIDTH * 2}px`
-      this.sidebarEl.style.width = '0px'
+      if (this.sidebarEl) {
+        // when Panel is in error state -> PanelError is shown, Sidebar view is not mounted -> we need this check
+        this.sidebarEl.style.left = `${newWidth - PANEL_BORDER_WIDTH * 2}px`
+        this.sidebarEl.style.width = '0px'
+      }
     }
   }
 


### PR DESCRIPTION
- reinitialize Panel again when we are in Panel error state and click "Retry button"
- add try/catch block when in Initializing App in ConfigContext 
- add try/catch blocks when loading data in Global tree
- add loading state for Panel when loading data + increase the loading time to make it visible for user

Closes #928 