### PR TITLE
refactor: use paddingTop prop directly as value in GenericTextRenderer

### DIFF
--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -47,7 +47,7 @@ interface Props {
   source: string
   onSelect?: () => void
   ignoreFilters?: boolean
-  paddingTop?: boolean
+  paddingTop?: number // tailwind scale value i.e 16 for pt-16
 }
 const GenericTextRenderer: FC<Props> = memo(({
   htmlString,
@@ -56,7 +56,7 @@ const GenericTextRenderer: FC<Props> = memo(({
   source,
   onSelect,
   ignoreFilters = false,
-  paddingTop = false
+  paddingTop = 0
 }) => {
   const { annotations: annotationsConfig } = useConfig()
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
@@ -452,7 +452,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     activeTargetRef.current = null
   }
 
-  return <div data-text-wrapper ref={textWrapperRef} className={`relative ${paddingTop ? 'pt-16' : 'pt-2'}`}>
+  return <div data-text-wrapper ref={textWrapperRef} className="relative" style={{ paddingTop: `${paddingTop * 0.25}rem` }}>
     <AnnotationPopoverContainer
       target={tooltipTargetElement}
       wrapper={textWrapperRef.current}

--- a/src/components/panel/renderers/text/TextRenderer.tsx
+++ b/src/components/panel/renderers/text/TextRenderer.tsx
@@ -55,7 +55,7 @@ const TextRenderer: FC<Props> = memo(({ htmlString, onReady }) => {
       source={activeContentUrl.current}
       onSelect={onSelect}
       onUpdateMatchedAnnotationsMap={onMatchedMapUpdate}
-      paddingTop={showContentTypeToggle}
+      paddingTop={showContentTypeToggle ? 16 : 2}
     />
   </div>
 })


### PR DESCRIPTION
- Refactor the prop `paddingTop` in GenericTextRenderer - now it is a number and not extract it implicitly from another variable such as `showContentTypeToggle`
- this fixes the cropped annotation in 3 lines, which looks badly cropped

Closes #1036 