### PR TITLE
fix: sync sidebar with scrolled text in the right time - after the he…

### DIFF
--- a/src/components/panel/PanelContent.tsx
+++ b/src/components/panel/PanelContent.tsx
@@ -20,7 +20,6 @@ const PanelContent: FC = React.memo(() => {
   const [showSidebarContent, setShowSidebarContent] = useState(panelState.showSidebar)
   const [contentPanes, setContentPanes] = useState([])
   const allotmentRef = useRef<AllotmentHandle>(null)
-  console.log('re-render')
 
   const visibleCount = panelState.panelViews.filter(v => v.visible ?? true).length
   // equal preferred size is computed before rendering - when we call allotment.reset() -> Allotment uses the updated preferred sizes

--- a/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
+++ b/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
@@ -21,6 +21,7 @@ const AlignAnnotationsList: FC = () => {
   const [toggledAnnotation, setToggledAnnotation] = useState(null)
 
   const ref = useRef(null)
+  const contentUrlRef = useRef<string | null>(null)
 
   function isClickedElAnnotation(clickedEl: HTMLElement) {
     return clickedEl.closest('[data-annotation]')
@@ -33,8 +34,8 @@ const AlignAnnotationsList: FC = () => {
     if (!selectedAnnotation) return
     const { annotation, origin } = selectedAnnotation
     if (origin === 'text') {
-      const scroller = getScroller()
-      scroller.syncSidebarToText(selectedAnnotation.annotation.target[0]?.source)
+      const { contentUrl } = selectedAnnotation
+      contentUrlRef.current = contentUrl
       trackTopChange()
     } else if (origin  === 'other') {
       // selectedAnnotation comes from Bookmarking or config
@@ -130,11 +131,12 @@ const AlignAnnotationsList: FC = () => {
     if (filteredAnnotations?.length === 0) {
       setElements([])
     } else {
-      const scroller = getScroller()
-      const firstTextView = panelState.panelViews.find(v => v.view === 'text')
-      const contentUrl = panelState.item?.contents.find(c =>
-        c.contentType.includes(firstTextView?.activeContentType))?.id
-      scroller.syncSidebarToText(contentUrl)
+      if (!selectedAnnotation) {
+        // intial opening of sidebar - we just
+        const firstTextView = panelState.panelViews.find(v => v.view === 'text')
+        contentUrlRef.current = panelState.item?.contents.find(c =>
+          c.contentType.includes(firstTextView?.activeContentType))?.id
+      }
 
       const annotationEls = Array.from(ref.current?.childNodes ?? [])
       const _elements = annotationEls.map(el => {
@@ -162,6 +164,13 @@ const AlignAnnotationsList: FC = () => {
   }, [filteredAnnotations])
 
   useEffect(() => {
+    if (elements.length > 0 && contentUrlRef.current) {
+      // this useEffect happens after the above useEffect [filteredAnnotation]. In the [filteredAnnotations] the
+      // height of sidebar is set equal to that of textContainer -> sidebar height is now larger then default fixed height -> scrolling can happen
+      getScroller().syncSidebarToText(contentUrlRef.current)
+      contentUrlRef.current = null
+    }
+
     let resizeObserver: ResizeObserver | undefined
     let timeout: ReturnType<typeof setTimeout> | undefined
     if (elements.length > 0) {

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -413,7 +413,8 @@ const GenericTextRenderer: FC<Props> = memo(({
       } else {
         const selectedAnnotation = {
           annotation: normalAnnotations[0],
-          origin: 'text'
+          origin: 'text',
+          contentUrl: source
         } as SelectedAnnotation
 
         setSelectedAnnotation(selectedAnnotation)

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -306,7 +306,8 @@ export interface TidoContentStateTarget {
 // "other" refers to origin in [bookmarking, config]
 export interface SelectedAnnotation {
   annotation: Annotation,
-  origin: 'text' | 'annotation' | 'other'
+  origin: 'text' | 'annotation' | 'other',
+  contentUrl?: string
 }
 
 export interface PanelViewContentState {


### PR DESCRIPTION
- sync sidebar with scrolled text in the right time - after the height of sidebar is now scrollable AND align sidebar with the respective text pane
- introduce contentUrl in selectedAnnotation, to have the exact text pane among possible multiple ones

Closes #1040