### PR TITLE
fix: add visible padding between container and image in ImageTextRender

### DIFF
--- a/src/components/panel/renderers/image/ImageRenderer.tsx
+++ b/src/components/panel/renderers/image/ImageRenderer.tsx
@@ -39,6 +39,7 @@ const ImageRenderer: FC = () => {
     })
 
     viewerRef.current.addHandler('open', function () {
+      viewerRef.current.viewport.zoomTo(viewerRef.current.viewport.getHomeZoom() * 0.9, undefined, true)
       setLoading(false)
     })
 


### PR DESCRIPTION
Closes #885 

Addition of this PR: Fit image to 90% of it's container size in runtime