### PR TITLE
Implement panel fullscreen mode

### DIFF
--- a/public/translations/de.json
+++ b/public/translations/de.json
@@ -75,6 +75,8 @@
     "please_select_panel_mode": "Bitte wählen Sie einen Modus",
     "show_image": "Zum Bild",
     "show_text": "Zum Text",
+    "show_fullscreen": "Im Vollbildmodus anzeigen",
+    "exit_fullscreen": "Vollbildmodus beenden",
     "jump_to": "Springen zu",
     "reference": "Verweis",
     "text_type": "Texttyp",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -70,6 +70,8 @@
     "please_select_panel_mode": "Please select a panel mode",
     "show_image": "Show image",
     "show_text": "Show text",
+    "show_fullscreen": "Open fullscreen",
+    "exit_fullscreen": "Exit fullscreen",
     "reference": "Reference",
     "jump_to": "Jump to",
     "text_type": "Text type",

--- a/src/components/base/BaseTooltip.tsx
+++ b/src/components/base/BaseTooltip.tsx
@@ -1,12 +1,14 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip.tsx'
-import { FC, ReactNode } from 'react'
-
+import { FC, ReactNode, useContext } from 'react'
+import { PanelContext } from '@/contexts/PanelContext.tsx'
 
 interface Props {
   children: ReactNode,
   message: string
 }
 const BaseTooltip: FC<Props> = ({ children, message = '' }) => {
+  // since BaseTooltip can be used inside Panel. If there is containerRef in PanelContext - we can use it here to render for fullScreen
+  const panelContext = useContext(PanelContext)
 
   return <TooltipProvider delayDuration={400}>
     <Tooltip>
@@ -15,7 +17,7 @@ const BaseTooltip: FC<Props> = ({ children, message = '' }) => {
           { children }
         </div>
       </TooltipTrigger>
-      <TooltipContent>
+      <TooltipContent container={panelContext?.containerRef?.current}>
         <span className="leading-none">{ message }</span>
       </TooltipContent>
     </Tooltip>

--- a/src/components/panel/annotations/filters/AnnotationFilters.tsx
+++ b/src/components/panel/annotations/filters/AnnotationFilters.tsx
@@ -11,9 +11,8 @@ interface Props {
   className?: string
 }
 const AnnotationFilters: FC<Props> = ({ className }) => {
-  const { usePanelTranslation } = usePanel()
+  const { usePanelTranslation, annotationFilters, containerRef } = usePanel()
   const { t } = usePanelTranslation()
-  const { annotationFilters } = usePanel()
   const [open, setOpen] = useState(false)
 
   const hasFilters = annotationFilters && annotationFilters.length > 0
@@ -27,6 +26,7 @@ const AnnotationFilters: FC<Props> = ({ className }) => {
         align="start"
         className="h-fit overflow-y-auto flex flex-col overflow-hidden"
         style={{ 'width': `calc(${SIDEBAR_DEFAULT_WIDTH}px - 2 * 0.75rem)` }}
+        container={containerRef.current}
       >
         <AnnotationFiltersContent />
       </PopoverContent>

--- a/src/components/panel/annotations/popover/AnnotationPopoverContainer.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContainer.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from 'react'
 import { Popover, PopoverContent, PopoverAnchor } from '@/components/ui/popover.tsx'
 import { X } from 'lucide-react'
+import { usePanel } from '@/contexts/PanelContext.tsx'
 
 interface Props {
   target: HTMLElement | null
@@ -18,6 +19,7 @@ const AnnotationPopoverContainer: FC<Props> = memo(({
   onClose
 }) => {
 
+  const { containerRef } = usePanel()
   const wrapperRect = wrapper?.getBoundingClientRect()
   const targetRect = target?.getBoundingClientRect()
 
@@ -42,6 +44,7 @@ const AnnotationPopoverContainer: FC<Props> = memo(({
         side="bottom"
         onOpenAutoFocus={(e) => e.preventDefault()}
         hideWhenDetached={true}
+        container={containerRef.current}
       >
         <div
           onClick={onClose}

--- a/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
+++ b/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
@@ -3,6 +3,7 @@ import { usePanel } from '@/contexts/PanelContext.tsx'
 import Annotation from '@/components/panel/annotations/sidebar/Annotation.tsx'
 import { useAnnotations } from '@/contexts/AnnotationsContext.tsx'
 import { scrollIntoViewIfNeeded } from '@/utils/dom.ts'
+import { getSource } from '@/utils/annotations.ts'
 
 const ANNOTATION_GAP = 5
 
@@ -37,10 +38,10 @@ const AlignAnnotationsList: FC = () => {
       const { contentUrl } = selectedAnnotation
       contentUrlRef.current = contentUrl
       trackTopChange()
-    } else if (origin  === 'other') {
+    } else if (origin  === 'other' || origin === 'annotation') {
       // selectedAnnotation comes from Bookmarking or config
       const target = annotation.target[0]
-      const targetSourceUrl = target.source
+      const targetSourceUrl = getSource(target).id
       const textEl = panelEl.querySelector(`div[data-content-url="${targetSourceUrl}"]`)
       const targetEl = textEl.querySelector((target.selector as CssSelector).value) as HTMLElement
       scrollIntoViewIfNeeded(targetEl, textEl as HTMLElement)
@@ -192,6 +193,7 @@ const AlignAnnotationsList: FC = () => {
   if (filteredAnnotations.length > 0)
     return <div
       ref={ref}
+      data-cy="annotations-list"
       className={`transition-opacity ${loading ? 'opacity-0' : 'opacity-100'}`}
       style={{ height: `${height}px` }}
     >

--- a/src/components/panel/annotations/sidebar/AnnotationFooter.tsx
+++ b/src/components/panel/annotations/sidebar/AnnotationFooter.tsx
@@ -33,8 +33,8 @@ const AnnotationFooter: FC<Props> = ({ nestedAnnotations, showExpanded, onToggle
   }, [expanded])
 
 
-  return <div className="w-full h-fit flex flex-col border-t border-border bg-muted cursor-pointer">
-    <div className="flex footer-stripe pr-4 py-1 items-center justify-end text-xs text-muted-foreground" onClick={(e) => handleClick(e)}>
+  return <div className="w-full h-fit flex flex-col border-t border-border bg-muted cursor-pointer" data-cy="footer">
+    <div className="flex pr-4 py-1 items-center justify-end text-xs text-muted-foreground" onClick={(e) => handleClick(e)}>
       <span className="p-0.5">{nestedAnnotations.length} {nestedAnnotations.length > 1 ? t('nested_annotations') : t('nested_annotation')}</span>
       <span className="mt-0.5">{expanded ? <ChevronUp size={18} /> : <ChevronDown size={18} />}</span>
     </div>

--- a/src/components/panel/annotations/sidebar/AnnotationsList.tsx
+++ b/src/components/panel/annotations/sidebar/AnnotationsList.tsx
@@ -6,7 +6,7 @@ import { useAnnotations } from '@/contexts/AnnotationsContext.tsx'
 const AnnotationsList: FC = () => {
   const { filteredAnnotations } = useAnnotations()
 
-  if (filteredAnnotations.length > 0) return <div className={`transition-opacity pt-4`}>
+  if (filteredAnnotations.length > 0) return <div data-cy="annotations-list" className={`transition-opacity pt-4`}>
     {filteredAnnotations.map(a => <Annotation
       data={a}
       key={a.id}

--- a/src/components/panel/annotations/sidebar/EmptyAnnotations.tsx
+++ b/src/components/panel/annotations/sidebar/EmptyAnnotations.tsx
@@ -7,7 +7,7 @@ import { TableOfContents } from 'lucide-react'
 const EmptyAnnotations: FC = () => {
   const { usePanelTranslation } = usePanel()
   const { t } = usePanelTranslation()
-  return <Empty className="mt-16">
+  return <Empty className="mt-16" data-cy="empty-annotations-view">
     <EmptyHeader>
       <EmptyMedia variant="icon" className="bg-background text-muted-foreground">
         <TableOfContents />

--- a/src/components/panel/annotations/sidebar/WitnessChip.tsx
+++ b/src/components/panel/annotations/sidebar/WitnessChip.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const WitnessChip: FC<Props> = React.memo(({ idno }) => {
-  const { witnesses, usePanelTranslation } = usePanel()
+  const { witnesses, usePanelTranslation, containerRef } = usePanel()
   const { t } = usePanelTranslation()
 
   function getWitnessLabel(idno: string) {
@@ -33,7 +33,7 @@ const WitnessChip: FC<Props> = React.memo(({ idno }) => {
           {getWitnessLabel(idno)}
         </div>
       </TooltipTrigger>
-      <TooltipContent>
+      <TooltipContent container={containerRef.current}>
         <span className="leading-none">{getWitnessTitle(idno)}</span>
       </TooltipContent>
     </Tooltip>

--- a/src/components/panel/header/CollectionTitle.tsx
+++ b/src/components/panel/header/CollectionTitle.tsx
@@ -10,7 +10,7 @@ import { X } from 'lucide-react'
 
 
 const CollectionTitle: FC = () => {
-  const { panelState, usePanelTranslation } = usePanel()
+  const { panelState, usePanelTranslation, containerRef } = usePanel()
   const collection = useDataStore(
     (state) => panelState && panelState.collectionId ? state.collections[panelState.collectionId] : null
   )
@@ -41,7 +41,7 @@ const CollectionTitle: FC = () => {
             <span className="truncate">{ collection.titles[0] }</span>
           </Button>
         </PopoverTrigger>
-        <PopoverContent side="bottom" align="start" className="w-[400px] pr-0">
+        <PopoverContent side="bottom" align="start" className="w-[400px] pr-0" container={containerRef.current}>
           <div className="font-semibold mb-2">{t('choose_your_panel_content')}</div>
           <LocalTree collectionId={panelState.collectionId} onSelect={closeLocalTree} />
           <X

--- a/src/components/panel/header/FullScreenToggle.tsx
+++ b/src/components/panel/header/FullScreenToggle.tsx
@@ -1,0 +1,33 @@
+import { FC, memo } from 'react'
+import { Maximize2, Minimize2 } from 'lucide-react'
+import { Button } from '@/components/ui/button.tsx'
+import BaseTooltip from '@/components/base/BaseTooltip.tsx'
+import { usePanel } from '@/contexts/PanelContext.tsx'
+
+const FullScreenToggle: FC = memo(() => {
+  const { isFullscreen, enterFullscreen, usePanelTranslation } = usePanel()
+  const { t } = usePanelTranslation()
+
+  function toggle() {
+    if (isFullscreen)  {
+      document.exitFullscreen()
+    } else {
+      enterFullscreen()
+    }
+  }
+
+  return (
+    <BaseTooltip message={t(isFullscreen ? 'exit_fullscreen' : 'show_fullscreen')}>
+      <Button
+        size="icon"
+        variant="ghost"
+        onClick={toggle}
+        className=""
+      >
+        {isFullscreen ? <Minimize2 /> : <Maximize2 />}
+      </Button>
+    </BaseTooltip>
+  )
+})
+
+export default FullScreenToggle

--- a/src/components/panel/header/ItemLabel.tsx
+++ b/src/components/panel/header/ItemLabel.tsx
@@ -16,7 +16,7 @@ interface ItemLabelProps {
 }
 
 const ItemLabel: FC<ItemLabelProps> = ({ selectedManifest, onItemSelect }) => {
-  const { panelState, updatePanel, usePanelTranslation } = usePanel()
+  const { panelState, updatePanel, usePanelTranslation, containerRef } = usePanel()
   const { t } = usePanelTranslation()
   const collection = useDataStore().collections[panelState.collectionId]
   const manifest = panelState.manifest
@@ -101,7 +101,7 @@ const ItemLabel: FC<ItemLabelProps> = ({ selectedManifest, onItemSelect }) => {
           { getItemLabel() }
         </div>
       </DropdownMenuTrigger>
-      <DropdownMenuContent data-cy="items-dropdown" className="max-w-80">
+      <DropdownMenuContent data-cy="items-dropdown" className="max-w-80" container={containerRef.current}>
         {labels.map((item, i) => <DropdownMenuItem
           key={item.id + '_'+i}
           className={`cursor-pointer ${panelState.item?.id === item.id ? 'data-[highlighted]:text-primary text-primary' : ''} `}

--- a/src/components/panel/header/ManifestLabel.tsx
+++ b/src/components/panel/header/ManifestLabel.tsx
@@ -11,7 +11,7 @@ interface ManifestLabelProps {
 }
 
 const ManifestLabel: FC<ManifestLabelProps> = ({ selectedManifest, onManifestSelect }) => {
-  const { panelState } = usePanel()
+  const { panelState, containerRef } = usePanel()
   const collection = useDataStore().collections[panelState.collectionId]
   const manifest = panelState.manifest
   const [showModal, setShowModal] = useState(false)
@@ -65,7 +65,7 @@ const ManifestLabel: FC<ManifestLabelProps> = ({ selectedManifest, onManifestSel
           {selectedLabel}
         </div>
       </DropdownMenuTrigger>
-      <DropdownMenuContent data-cy="manifests-dropdown" className="max-w-80">
+      <DropdownMenuContent data-cy="manifests-dropdown" className="max-w-80" container={containerRef.current}>
         {manifestOptions.map((m, i) => <DropdownMenuItem
           key={m.id + '_'+i}
           className={`cursor-pointer ${panelState.manifest?.id === m.id ? 'text-primary' : ''} `}

--- a/src/components/panel/header/PanelHeader.tsx
+++ b/src/components/panel/header/PanelHeader.tsx
@@ -9,6 +9,7 @@ import Metadata from '@/components/metadata/Metadata.tsx'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import { PANEL_HEADER_HEIGHT } from '@/utils/constants.ts'
 import PanelViewsMenu from '@/components/panel/header/PanelViewsMenu.tsx'
+import FullScreenToggle from '@/components/panel/header/FullScreenToggle.tsx'
 import BaseTooltip from '@/components/base/BaseTooltip.tsx'
 import { getFilteredAnnotations } from '@/utils/annotations.ts'
 import { useConfig } from '@/contexts/ConfigContext.tsx'
@@ -54,7 +55,7 @@ const SidebarToggle = memo((props) => {
 })
 
 const PanelHeader: FC = () => {
-  const { usePanelTranslation, remove } = usePanel()
+  const { usePanelTranslation, remove, containerRef } = usePanel()
   const { t } = usePanelTranslation()
   const [showMetadataModal, setShowMetadataModal] = useState(false)
   const handleOpenChange = (open: boolean) => {
@@ -76,7 +77,7 @@ const PanelHeader: FC = () => {
               {<Info />}
             </Button>
           </PopoverTrigger>
-          <PopoverContent side="bottom" align="start" className="w-[400px] pr-0">
+          <PopoverContent side="bottom" align="start" className="w-[400px] pr-0" container={containerRef.current}>
             <Metadata />
             <X
               className="absolute right-3 top-4 text-zinc-600 hover:text-zinc-700 hover:cursor-pointer"
@@ -89,6 +90,7 @@ const PanelHeader: FC = () => {
         {<PanelTitle />}
       </div>
       <div className="absolute h-full top-0 right-2 flex items-center gap-1 @min-[600px]/panel:gap-2">
+        <FullScreenToggle />
         <PanelViewsMenu />
         <SidebarToggle />
         <BaseTooltip message={t('close_panel')}>

--- a/src/components/panel/header/PanelViewsMenu.tsx
+++ b/src/components/panel/header/PanelViewsMenu.tsx
@@ -14,7 +14,7 @@ interface PanelView {
 }
 
 const PanelViewsMenu: FC = () => {
-  const { panelState, usePanelTranslation, updatePanel } = usePanel()
+  const { panelState, usePanelTranslation, updatePanel, containerRef } = usePanel()
   const { t } = usePanelTranslation()
   const [data, setData] = useState<PanelView[]>([])
 
@@ -46,7 +46,7 @@ const PanelViewsMenu: FC = () => {
               <Button variant="outline" size="sm"><Settings2 /> <span className="hidden @min-[1000px]/panel:inline">{ t('view') }</span></Button>
             </PopoverTrigger>
           </BaseTooltip>
-          <PopoverContent data-cy="panel-mode-menu" className="p-1 gap-2">
+          <PopoverContent data-cy="panel-mode-menu" className="p-1 gap-2" container={containerRef.current}>
             {data.map((view, i) => {
               const Icon = view.icon
 

--- a/src/components/panel/views/text/ContentTypesToggle.tsx
+++ b/src/components/panel/views/text/ContentTypesToggle.tsx
@@ -12,7 +12,7 @@ import { ChevronDown } from 'lucide-react'
 import { useTextView } from '@/contexts/TextViewContext.tsx'
 
 const ContentTypesToggle: FC = () => {
-  const { usePanelTranslation } = usePanel()
+  const { usePanelTranslation, containerRef } = usePanel()
   const { t } = usePanelTranslation()
   const { label, contentTypes, activeContentType, setActiveContentType } = useTextView()
 
@@ -35,7 +35,7 @@ const ContentTypesToggle: FC = () => {
         <DropdownMenuTrigger asChild>
           { renderButton(true) }
         </DropdownMenuTrigger>
-        <DropdownMenuContent data-cy="content-types-dropdown">
+        <DropdownMenuContent data-cy="content-types-dropdown" container={containerRef.current}>
           <DropdownMenuLabel>{ t(label) } </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuRadioGroup value={activeContentType} onValueChange={handleTextTabClick}>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -32,10 +32,11 @@ const DropdownMenuTrigger = ({
 const DropdownMenuContent = ({
   className,
   sideOffset = 4,
+  container,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) => {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & { container?: HTMLElement | null }) => {
   return (
-    <DropdownMenuPrimitive.Portal container={document.querySelector('.tido')}>
+    <DropdownMenuPrimitive.Portal container={container ?? document.querySelector('.tido')}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -20,10 +20,11 @@ const PopoverContent = ({
   className,
   align = 'center',
   sideOffset = 4,
+  container,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) => {
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & { container?: HTMLElement | null }) => {
   return (
-    <PopoverPortal container={document.querySelector('.tido')}>
+    <PopoverPortal container={container ?? document.querySelector('.tido')}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -39,10 +39,11 @@ const TooltipContent = ({
   className,
   sideOffset = 0,
   children,
+  container,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) => {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & { container?: HTMLElement | null }) => {
   return (
-    <TooltipPortal container={document.querySelector('.tido')}>
+    <TooltipPortal container={container ?? document.querySelector('.tido')}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext, useState, FC, useEffect, useRef, SetStateAction, Dispatch } from 'react'
+import React, { ReactNode, createContext, useContext, useState, FC, useEffect, useRef, SetStateAction, Dispatch } from 'react'
 import { usePanelStore } from '@/store/PanelStore.tsx'
 import { useDataStore } from '@/store/DataStore.tsx'
 
@@ -26,6 +26,9 @@ interface PanelContextType {
   loading: boolean
   updatePanel: (data: Partial<PanelState>) => void
   remove: () => void
+  containerRef: React.RefObject<HTMLDivElement>
+  isFullscreen: boolean
+  enterFullscreen: () => void
   resizer: PanelResizer
   initResizer: (el: HTMLElement) => void
   hoveredAnnotation: string | null
@@ -66,6 +69,21 @@ interface PanelProviderProps {
 
 const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) => {
   const { annotations: annotationsConfig, panelViews: panelViewsConfig } = useConfig()
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  // The key reason of useEffect: when the user presses Escape to exit fullscreen, the browser exits fullscreen on its own without calling any React code.
+  //  Without that listener, isFullscreen would stay true in React even though the panel is no longer fullscreen
+  useEffect(() => {
+    const handler = () => setIsFullscreen(!!document.fullscreenElement)
+    document.addEventListener('fullscreenchange', handler)
+    return () => document.removeEventListener('fullscreenchange', handler)
+  }, [])
+
+  const enterFullscreen = () => {
+    wrapperRef.current?.requestFullscreen()
+  }
 
   const [loading, setLoading] = useState(true)
   const [resizer, setResizer] = useState<PanelResizer | null>(null)
@@ -389,6 +407,9 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
       updatePanel,
       loading,
       remove,
+      containerRef: wrapperRef,
+      isFullscreen,
+      enterFullscreen,
       resizer,
       initResizer,
       hoveredAnnotation,
@@ -420,7 +441,9 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
       updateSyncMap,
       setHoveredSyncAnnotations
     }}>
-      {children}
+      <div ref={wrapperRef} className="flex items-stretch">
+        {children}
+      </div>
     </PanelContext.Provider>
   )
 }
@@ -434,4 +457,4 @@ function usePanel(): PanelContextType {
   return context
 }
 
-export { PanelProvider, usePanel }
+export { PanelContext, PanelProvider, usePanel }

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -87,6 +87,12 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
 
   const [loading, setLoading] = useState(true)
   const [resizer, setResizer] = useState<PanelResizer | null>(null)
+
+  useEffect(() => {
+    if (!resizer) return
+    resizer.updateLayoutWidths(isFullscreen)
+  }, [isFullscreen, resizer])
+
   const [hoveredAnnotation, setHoveredAnnotation] = useState(null)
   const [matchedAnnotationsMaps, setMatchedAnnotationsMaps] = useState<{[contentUrl: string]: MatchedAnnotationsMap}>({})
   const [annotationFilters, setAnnotationFilters] = useState<FilterNodeWithSelection[]>( null)

--- a/src/utils/panel-resizer.ts
+++ b/src/utils/panel-resizer.ts
@@ -21,6 +21,7 @@ class PanelResizer {
   isResizing = false
   isSidebarResizing = false
   showSidebar = false
+  isFullscreen = false
   lastWidth: number | null = null
 
   private isDragToResizeInitialized = false
@@ -53,21 +54,30 @@ class PanelResizer {
 
   onResizePanel(newWidth: number) {
     this.lastWidth = newWidth
-    this.panelEl.style.width = `${newWidth}px`
+    this.applyWidths(this.isFullscreen ? window.innerWidth : newWidth)
+  }
+
+  private applyWidths(totalWidth: number) {
+    this.panelEl.style.width = `${totalWidth}px`
 
     if (this.showSidebar) {
-      const mainWidth = newWidth - this.sidebarWidth
+      const mainWidth = totalWidth - this.sidebarWidth
       this.mainContentEl.style.width = `${mainWidth - PANEL_BORDER_WIDTH * 2}px`
       this.sidebarEl.style.left = `${mainWidth - PANEL_BORDER_WIDTH * 2}px`
       this.sidebarEl.style.width = `${this.sidebarWidth}px`
     } else {
-      this.mainContentEl.style.width = `${newWidth - PANEL_BORDER_WIDTH * 2}px`
+      this.mainContentEl.style.width = `${totalWidth - PANEL_BORDER_WIDTH * 2}px`
       if (this.sidebarEl) {
         // when Panel is in error state -> PanelError is shown, Sidebar view is not mounted -> we need this check
-        this.sidebarEl.style.left = `${newWidth - PANEL_BORDER_WIDTH * 2}px`
+        this.sidebarEl.style.left = `${totalWidth - PANEL_BORDER_WIDTH * 2}px`
         this.sidebarEl.style.width = '0px'
       }
     }
+  }
+
+  updateLayoutWidths(value: boolean) {
+    this.isFullscreen = value
+    this.applyWidths(value ? window.innerWidth : this.lastWidth)
   }
 
   calculateWidth(wrapper: HTMLElement): number {

--- a/tests/cypress/e2e/annotations.cy.js
+++ b/tests/cypress/e2e/annotations.cy.js
@@ -63,7 +63,6 @@ describe('Annotations', () => {
 
       sidebar().find('[data-cy="annotations-list"] > div[data-annotation]').should('have.length',6)
 
-
       sidebar().contains('button', /filters/i).click()
         cy.get('[data-slot="popover-content"]').should('be.visible')
 
@@ -74,7 +73,6 @@ describe('Annotations', () => {
         })
 
       sidebar().find('[data-cy="empty-annotations-view"')
-
 
       cy.get('[data-slot="popover-content"] [data-slot="checkbox"]').each(($checkbox) => {
             if ($checkbox.attr('data-state') !== 'checked') {
@@ -97,23 +95,11 @@ describe('Annotations', () => {
     it('Should support view more/less on lengthy annotation body when available', () => {
         openSidebar()
 
-
         sidebar().find('[data-annotation]').should('exist')
 
-        sidebar().then(($container) => {
-            const viewMoreBtn = $container
-                .find('button')
-                .filter((_, el) => /view more/i.test(el.textContent))
-
-            if (!viewMoreBtn.length) {
-                cy.log('No view more button in this dataset, skipping')
-                return
-            }
-
-            cy.wrap(viewMoreBtn.first()).click()
-            cy.contains('button', /view less/i).should('exist').click()
-            cy.contains('button', /view more/i).should('exist')
-        })
+        sidebar().find('[data-annotation]').first().contains('button', /view more/i).click()
+        cy.contains('button', /view less/i).should('exist').click()
+        cy.contains('button', /view more/i).should('exist')
     })
 
     it('Should trigger hover events on first annotation', () => {

--- a/tests/cypress/e2e/annotations.cy.js
+++ b/tests/cypress/e2e/annotations.cy.js
@@ -61,7 +61,7 @@ describe('Annotations', () => {
     it('Should open filter popover and toggle filters off/on', () => {
       openSidebar()
 
-      sidebar().children().its('length').as('initialCount')
+      sidebar().find('[data-cy="annotations-list"] > div[data-annotation]').should('have.length',6)
 
 
       sidebar().contains('button', /filters/i).click()
@@ -81,28 +81,17 @@ describe('Annotations', () => {
                 cy.wrap($checkbox).click({ force: true })
             }
         })
+      sidebar().find('[data-cy="annotations-list"] > div[data-annotation]').should('have.length',6)
 
-        cy.get('@initialCount').then((initialCount) => {
-            sidebar().find('[data-cy="annotations-list"] > div[data-annotation]').should('have.length.gte', initialCount)
-        })
     })
 
     it('Should expand nested annotation footer if present', () => {
         openSidebar()
 
         sidebar().find('[data-annotation]').should('exist')
-
-        sidebar().then(($container) => {
-            const footerButton = $container.find('button').filter((_, el) => /nested annotation/i.test(el.textContent))
-            if (!footerButton.length) {
-                cy.log('No nested annotation footer in this dataset')
-                return
-            }
-
-            cy.wrap(footerButton.first()).click()
-            sidebar().find('[data-annotation]').should('have.length.at.least', 1)
-            cy.wrap(footerButton.first()).click()
-        })
+        const footer =  sidebar().find('div[data-cy="footer"]').first()
+        footer.click()
+        footer.find('div[data-annotation]').should('have.length.at.least', 1)
     })
 
     it('Should support view more/less on lengthy annotation body when available', () => {

--- a/tests/cypress/e2e/annotations.cy.js
+++ b/tests/cypress/e2e/annotations.cy.js
@@ -1,15 +1,16 @@
 describe('Annotations', () => {
 
     const apiUrl = Cypress.env('API_URL') || 'http://localhost:8181';
+    console.log('api url', apiUrl)
     const annotationConfig = `annotations.defaultMode=list&panels[0].collection=${apiUrl}/example/collections/example.json`;
 
     const selectors = {
         sidebarToggle: '[data-cy="sidebar-toggle"]',
-        sidebarContainer: '[data-sidebar-container]'
+        sidebarContainer: '#panels-wrapper .panel [data-sidebar-container]'
     }
 
-    const sidebar = () => cy.get(selectors.sidebarContainer)
-    const openSidebar = () => {
+  const sidebar = () => cy.get(selectors.sidebarContainer)
+  const openSidebar = () => {
         cy.get(selectors.sidebarToggle).click()
     }
 
@@ -58,11 +59,12 @@ describe('Annotations', () => {
     })
 
     it('Should open filter popover and toggle filters off/on', () => {
-        openSidebar()
+      openSidebar()
 
-        sidebar().find('[data-annotation]').its('length').as('initialCount')
+      sidebar().children().its('length').as('initialCount')
 
-        sidebar().contains('button', /filters/i).click()
+
+      sidebar().contains('button', /filters/i).click()
         cy.get('[data-slot="popover-content"]').should('be.visible')
 
         cy.get('[data-slot="popover-content"] [data-slot="checkbox"]').each(($checkbox) => {
@@ -71,18 +73,17 @@ describe('Annotations', () => {
             }
         })
 
-        cy.get('@initialCount').then((initialCount) => {
-            sidebar().find('[data-annotation]').should('have.length.lessThan', initialCount)
-        })
+      sidebar().find('[data-cy="empty-annotations-view"')
 
-        cy.get('[data-slot="popover-content"] [data-slot="checkbox"]').each(($checkbox) => {
+
+      cy.get('[data-slot="popover-content"] [data-slot="checkbox"]').each(($checkbox) => {
             if ($checkbox.attr('data-state') !== 'checked') {
                 cy.wrap($checkbox).click({ force: true })
             }
         })
 
         cy.get('@initialCount').then((initialCount) => {
-            sidebar().find('[data-annotation]').should('have.length.gte', initialCount)
+            sidebar().find('[data-cy="annotations-list"] > div[data-annotation]').should('have.length.gte', initialCount)
         })
     })
 

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -134,7 +134,9 @@ describe('Panel', () => {
   // })
 
   it('Should switch to next manifest', () => {
-    cy.validateLabel('item', 'Moby-Dick, Chapter 1 - Loomings')
+    cy.findPanelTitleAndNavArrows()
+      .find('[data-cy="item-label"]')
+      .should('contain.text', 'Moby-Dick, Chapter 1 - Loomings')
       .click()
     cy.get('[data-cy="items-dropdown"]')
       .children()
@@ -183,9 +185,10 @@ describe('Panel', () => {
     // item label is updated
     // text is updated
     // item modal is not anymore in DOM
-    cy.validateLabel('item', 'Moby-Dick, Chapter 1 - Loomings')
+    cy.findPanelTitleAndNavArrows()
+      .find('[data-cy="item-label"]')
+      .should('contain.text', 'Moby-Dick, Chapter 1 - Loomings')
       .click()
-
       .get('[data-cy="items-dropdown"]')
       .children().should('have.length', 3)
       .eq(2)
@@ -203,7 +206,9 @@ describe('Panel', () => {
   it('Should navigate in manifest and consecutively in item labels', () => {
 
     // validate Manifest Dropdown labels
-    cy.validateLabel('manifest', 'Moby-Dick')
+    cy.findPanelTitleAndNavArrows()
+      .find('[data-cy="manifest-label"]')
+      .should('contain.text', 'Moby-Dick')
       .click()
       .get('[data-cy="manifests-dropdown"]')
       .children().should('have.length', 3)

--- a/tests/mocks/example/annotations/annotationPage/book1-page1.json
+++ b/tests/mocks/example/annotations/annotationPage/book1-page1.json
@@ -16,7 +16,7 @@
       "type": "Annotation",
       "body": {
         "type": "TextualBody",
-        "value": "This is one of the <span id=\"famous-opening-lines\">most famous opening lines in English literature</span>. It sets the theme of marriage and social class that pervades the novel.",
+        "value": "This is one of the <span id=\"famous-opening-lines\">most famous opening lines in English literature</span>. It sets the theme of marriage and social class that pervades the novel. It sets the theme of marriage and social class that pervades the novel",
         "format": "text/html",
         "annotationType": "Literary Analysis"
       },


### PR DESCRIPTION
This PR adds following
- Clicking fullscreen button in panel should open it in Full Screen
- It should be possible to exit fullscreen by clicking the button or typing ESC key
- In fullscreen - opening annotations sidebar should accomodate place for that
- Clicking at any label in Panel should open respective dropdown, i.e in CollectionTItle, Manifest, Item Label, PanelViews

Approach: We use requestFullScreen browser function to open a certain html element in full screen. The problem with this is that the Popover, Radix elements since they are append to body by default, will not be shown. Thus I create a ref - container ref in the PanelContext. Each component which displays such Popover, Radix then uses this container to portal them into the container ref, in order to be able to see them in full screen. 

Closes #1047 
