### PR TITLE
Fix cross ref in annotations

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
+  video: true,
   viewportWidth: 1400,
   viewportHeight: 800,
   experimentalSourceRewriting: true,

--- a/examples/config/example.json
+++ b/examples/config/example.json
@@ -2,7 +2,7 @@
   "panels": [
     {
       "collection": "http://localhost:8181/example/collections/example.json",
-      "manifest": "http://localhost:8181/example/manifests/book2.json"
+      "manifest": "http://localhost:8181/example/manifests/book1.json"
     }
   ],
   "rootCollections": [

--- a/examples/config/example.json
+++ b/examples/config/example.json
@@ -2,7 +2,7 @@
   "panels": [
     {
       "collection": "http://localhost:8181/example/collections/example.json",
-      "manifest": "http://localhost:8181/example/manifests/book1.json"
+      "manifest": "http://localhost:8181/example/manifests/book2.json"
     }
   ],
   "rootCollections": [

--- a/examples/config/example.json
+++ b/examples/config/example.json
@@ -7,5 +7,8 @@
   ],
   "rootCollections": [
     "http://localhost:8181/example/collections/example.json"
-  ]
+  ],
+  "annotations": {
+    "crossRefContentType": "CrossRef"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2904,6 +2904,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",

--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -1,5 +1,6 @@
 import { FC, useEffect, useRef, useState } from 'react'
 import { getCrossRefInfos } from '@/utils/annotations.ts'
+import { CustomError } from '@/utils/custom-error.ts'
 import TooltipItem from '@/components/panel/annotations/popover/items/TooltipItem.tsx'
 import CrossRefItem from '@/components/panel/annotations/popover/items/CrossRefItem.tsx'
 import BaseItem from '@/components/panel/annotations/popover/items/BaseItem.tsx'
@@ -25,6 +26,7 @@ const AnnotationPopoverContent: FC<Props> = ({
   const { t } = usePanelTranslation()
 
   const [crossRefInfos, setCrossRefInfos] = useState<CrossRefInfo[]>([])
+  const [crossRefErrors, setCrossRefErrors] = useState<CustomError[]>([])
   const [loading, setLoading] = useState(true)
 
   const tooltipAnnotationsRef = useRef<Annotation[]>(null)
@@ -44,18 +46,15 @@ const AnnotationPopoverContent: FC<Props> = ({
     }
 
     async function computeCrossRefInfos(annotations: Annotation[]) {
-      const crossRefInfos = await getCrossRefInfos(annotations)
-      setCrossRefInfos(crossRefInfos)
+      const results = await getCrossRefInfos(annotations)
+      setCrossRefInfos(results.filter((r): r is CrossRefInfo => !(Object.hasOwn(r, 'name') && Object.hasOwn(r, 'message'))))
+      setCrossRefErrors(results.filter((r): r is CustomError => Object.hasOwn(r, 'name') && Object.hasOwn(r, 'message')))
     }
 
     tooltipAnnotationsRef.current = tooltipAnnotations.sort(sortByDirectTarget)
     normalAnnotationsRef.current = relatedAnnotations.sort(sortByDirectTarget)
 
-    console.log('normalAnnotations ref', relatedAnnotations)
-    console.log('tooltip annotations', tooltipAnnotations)
-
     setLoading(false)
-    console.log('APContent crossRefAnnotations', crossRefAnnotations)
     computeCrossRefInfos(crossRefAnnotations)
   }, [target])
 
@@ -78,9 +77,10 @@ const AnnotationPopoverContent: FC<Props> = ({
         {tooltipAnnotationsRef.current?.map((ta) => <div className="mb-2"><TooltipItem key={ta.id} annotation={ta} /></div>)}
       </div>
     )}
-    {crossRefInfos.length > 0 && <div className="flex flex-col gap-1">
+    {(crossRefInfos.length > 0 || crossRefErrors.length > 0) && <div className="flex flex-col gap-1">
       {renderLabel(t('reference'))}
       {crossRefInfos.map((info, i) => <CrossRefItem key={i} crossRefInfo={info} onSelect={handleCrossRefSelection} />)}
+      {crossRefErrors.map((error, i) => <CrossRefItem key={`error-${i}`} crossRefError={error} onSelect={handleCrossRefSelection} />)}
     </div>}
     {normalAnnotationsRef.current?.length > 0 && (
       <div className={`flex flex-col gap-2 ${(crossRefInfos.length > 0 || tooltipAnnotationsRef.current?.length > 0) ? 'border-t pt-2 border-border' : ''}`}>

--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useRef, useState } from 'react'
-import { getCrossRefInfo } from '@/utils/annotations.ts'
+import { getCrossRefInfos } from '@/utils/annotations.ts'
 import TooltipItem from '@/components/panel/annotations/popover/items/TooltipItem.tsx'
 import CrossRefItem from '@/components/panel/annotations/popover/items/CrossRefItem.tsx'
 import BaseItem from '@/components/panel/annotations/popover/items/BaseItem.tsx'
@@ -44,9 +44,8 @@ const AnnotationPopoverContent: FC<Props> = ({
     }
 
     async function computeCrossRefInfos(annotations: Annotation[]) {
-      const infos: CrossRefInfo[] = await Promise.all(annotations.map(a => getCrossRefInfo(a))) as CrossRefInfo[]
-      console.log('cross refs', infos)
-      setCrossRefInfos(infos)
+      const crossRefInfos = await getCrossRefInfos(annotations)
+      setCrossRefInfos(crossRefInfos)
     }
 
     tooltipAnnotationsRef.current = tooltipAnnotations.sort(sortByDirectTarget)
@@ -56,6 +55,7 @@ const AnnotationPopoverContent: FC<Props> = ({
     console.log('tooltip annotations', tooltipAnnotations)
 
     setLoading(false)
+    console.log('APContent crossRefAnnotations', crossRefAnnotations)
     computeCrossRefInfos(crossRefAnnotations)
   }, [target])
 

--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -8,6 +8,7 @@ import { usePanel } from '@/contexts/PanelContext.tsx'
 
 interface Props {
   target: Element,
+  source: string
   crossRefAnnotations: Annotation[],
   relatedAnnotations: Annotation[]
   tooltipAnnotations: Annotation[]
@@ -17,6 +18,7 @@ interface Props {
 
 const AnnotationPopoverContent: FC<Props> = ({
   target,
+  source,
   crossRefAnnotations,
   relatedAnnotations,
   tooltipAnnotations,
@@ -32,7 +34,6 @@ const AnnotationPopoverContent: FC<Props> = ({
   const tooltipAnnotationsRef = useRef<Annotation[]>(null)
   const normalAnnotationsRef = useRef<Annotation[]>(null)
 
-
   useEffect(() => {
     const panelEl = panelId ? document.getElementById(panelId) : null
     const deepestTargetAnnotation = (annotation: Annotation) =>
@@ -47,6 +48,7 @@ const AnnotationPopoverContent: FC<Props> = ({
 
     async function computeCrossRefInfos(annotations: Annotation[]) {
       const results = await getCrossRefInfos(annotations)
+
       setCrossRefInfos(results.filter((r): r is CrossRefInfo => !(Object.hasOwn(r, 'name') && Object.hasOwn(r, 'message'))))
       setCrossRefErrors(results.filter((r): r is CustomError => Object.hasOwn(r, 'name') && Object.hasOwn(r, 'message')))
     }
@@ -85,7 +87,7 @@ const AnnotationPopoverContent: FC<Props> = ({
     {normalAnnotationsRef.current?.length > 0 && (
       <div className={`flex flex-col gap-2 ${(crossRefInfos.length > 0 || tooltipAnnotationsRef.current?.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
         {renderLabel(tooltipAnnotationsRef.current?.length === 0 && crossRefInfos.length === 0 ? t('annotations') : t('more_annotations'))}
-        {normalAnnotationsRef.current?.map(na => <BaseItem key={na.id} annotation={na} />)}
+        {normalAnnotationsRef.current?.map(na => <BaseItem key={na.id} annotation={na} source={source} />)}
       </div>
     )}
   </div>

--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -30,6 +30,7 @@ const AnnotationPopoverContent: FC<Props> = ({
   const tooltipAnnotationsRef = useRef<Annotation[]>(null)
   const normalAnnotationsRef = useRef<Annotation[]>(null)
 
+
   useEffect(() => {
     const panelEl = panelId ? document.getElementById(panelId) : null
     const deepestTargetAnnotation = (annotation: Annotation) =>
@@ -44,11 +45,15 @@ const AnnotationPopoverContent: FC<Props> = ({
 
     async function computeCrossRefInfos(annotations: Annotation[]) {
       const infos: CrossRefInfo[] = await Promise.all(annotations.map(a => getCrossRefInfo(a))) as CrossRefInfo[]
+      console.log('cross refs', infos)
       setCrossRefInfos(infos)
     }
 
     tooltipAnnotationsRef.current = tooltipAnnotations.sort(sortByDirectTarget)
     normalAnnotationsRef.current = relatedAnnotations.sort(sortByDirectTarget)
+
+    console.log('normalAnnotations ref', relatedAnnotations)
+    console.log('tooltip annotations', tooltipAnnotations)
 
     setLoading(false)
     computeCrossRefInfos(crossRefAnnotations)

--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -1,6 +1,4 @@
 import { FC, useEffect, useRef, useState } from 'react'
-import { getCrossRefInfos } from '@/utils/annotations.ts'
-import { CustomError } from '@/utils/custom-error.ts'
 import TooltipItem from '@/components/panel/annotations/popover/items/TooltipItem.tsx'
 import CrossRefItem from '@/components/panel/annotations/popover/items/CrossRefItem.tsx'
 import BaseItem from '@/components/panel/annotations/popover/items/BaseItem.tsx'
@@ -16,7 +14,7 @@ interface Props {
 }
 
 
-const AnnotationPopoverContent: FC<Props> = ({
+const AnnotationPopoverContent : FC<Props> = ({
   target,
   source,
   crossRefAnnotations,
@@ -27,8 +25,6 @@ const AnnotationPopoverContent: FC<Props> = ({
   const { usePanelTranslation, panelId } = usePanel()
   const { t } = usePanelTranslation()
 
-  const [crossRefInfos, setCrossRefInfos] = useState<CrossRefInfo[]>([])
-  const [crossRefErrors, setCrossRefErrors] = useState<CustomError[]>([])
   const [loading, setLoading] = useState(true)
 
   const tooltipAnnotationsRef = useRef<Annotation[]>(null)
@@ -46,23 +42,14 @@ const AnnotationPopoverContent: FC<Props> = ({
       return 0
     }
 
-    async function computeCrossRefInfos(annotations: Annotation[]) {
-      const results = await getCrossRefInfos(annotations)
-
-      setCrossRefInfos(results.filter((r): r is CrossRefInfo => !(Object.hasOwn(r, 'name') && Object.hasOwn(r, 'message'))))
-      setCrossRefErrors(results.filter((r): r is CustomError => Object.hasOwn(r, 'name') && Object.hasOwn(r, 'message')))
-    }
-
     tooltipAnnotationsRef.current = tooltipAnnotations.sort(sortByDirectTarget)
     normalAnnotationsRef.current = relatedAnnotations.sort(sortByDirectTarget)
 
     setLoading(false)
-    computeCrossRefInfos(crossRefAnnotations)
   }, [target])
 
 
   function handleCrossRefSelection() {
-    setCrossRefInfos([])
     onClose()
   }
 
@@ -74,19 +61,18 @@ const AnnotationPopoverContent: FC<Props> = ({
   if (loading) return <div>Loading ...</div>
   return <div className="flex flex-col gap-4">
     {tooltipAnnotationsRef.current?.length > 0 && (
-      <div className={crossRefInfos.length > 0 ? 'border-b border-border' : ''}>
+      <div className={crossRefAnnotations.length > 0 ? 'border-b border-border' : ''}>
         {renderLabel(t('tooltip'))}
         {tooltipAnnotationsRef.current?.map((ta) => <div className="mb-2"><TooltipItem key={ta.id} annotation={ta} /></div>)}
       </div>
     )}
-    {(crossRefInfos.length > 0 || crossRefErrors.length > 0) && <div className="flex flex-col gap-1">
+    {crossRefAnnotations.length > 0 && <div className="flex flex-col gap-1">
       {renderLabel(t('reference'))}
-      {crossRefInfos.map((info, i) => <CrossRefItem key={i} crossRefInfo={info} onSelect={handleCrossRefSelection} />)}
-      {crossRefErrors.map((error, i) => <CrossRefItem key={`error-${i}`} crossRefError={error} onSelect={handleCrossRefSelection} />)}
+      {crossRefAnnotations.map((annotation, i) => <CrossRefItem key={i} annotation={annotation} onSelect={handleCrossRefSelection} />)}
     </div>}
     {normalAnnotationsRef.current?.length > 0 && (
-      <div className={`flex flex-col gap-2 ${(crossRefInfos.length > 0 || tooltipAnnotationsRef.current?.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
-        {renderLabel(tooltipAnnotationsRef.current?.length === 0 && crossRefInfos.length === 0 ? t('annotations') : t('more_annotations'))}
+      <div className={`flex flex-col gap-2 ${(crossRefAnnotations.length > 0 || tooltipAnnotationsRef.current?.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
+        {renderLabel(tooltipAnnotationsRef.current?.length === 0 && crossRefAnnotations.length === 0 ? t('annotations') : t('more_annotations'))}
         {normalAnnotationsRef.current?.map(na => <BaseItem key={na.id} annotation={na} source={source} />)}
       </div>
     )}

--- a/src/components/panel/annotations/popover/cross-ref/CrossRefError.tsx
+++ b/src/components/panel/annotations/popover/cross-ref/CrossRefError.tsx
@@ -9,8 +9,8 @@ const CrossRefError: FC<Props> = ({ error }: Props) => {
 
   return <div className="max-w-xs flex flex-col items-center py-2 px-3 bg-red-50 dark:bg-red-300/20 rounded-lg">
     <CircleX className="text-red-500 mt-2" size="40" />
-    <span className="mt-2 font-semibold text-red-900 dark:text-red-50">{ error.name }</span>
-    <span className="mt-2 text-red-800/60 dark:text-red-50/50 text-center text-sm">{ error.message }</span>
+    <span className="mt-2 font-semibold text-red-900 dark:text-red-50 text-center break-words w-full">{ error.name }</span>
+    <span className="mt-2 text-red-800/60 dark:text-red-50/50 text-center text-sm break-words w-full">{ error.message }</span>
   </div>
 }
 

--- a/src/components/panel/annotations/popover/cross-ref/CrossRefLink.tsx
+++ b/src/components/panel/annotations/popover/cross-ref/CrossRefLink.tsx
@@ -68,6 +68,7 @@ const CrossRefLink: FC<Props> = ({ crossRefInfo, error, loading, onSelect }) => 
           item: crossRefInfo.item,
           views: setNewActiveContentType(contentType, firstViewIndex, panelState.panelViews),
         },
+        showSidebar: !!crossRefInfo.selectedAnnotation,
       })
     }
 

--- a/src/components/panel/annotations/popover/items/BaseItem.tsx
+++ b/src/components/panel/annotations/popover/items/BaseItem.tsx
@@ -16,6 +16,8 @@ const BaseItem: FC<Props> = ({ annotation }) => {
   const { updatePanel, selectedAnnotation, usePanelTranslation } = usePanel()
   const { t } = usePanelTranslation()
 
+  console.log('rendering base item')
+
   const [text, setText] = useState('')
 
   const type = annotation.body.annotationType

--- a/src/components/panel/annotations/popover/items/BaseItem.tsx
+++ b/src/components/panel/annotations/popover/items/BaseItem.tsx
@@ -4,15 +4,14 @@ import { Badge } from '@/components/ui/badge.tsx'
 import { usePanel } from '@/contexts/PanelContext.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { MoveRight } from 'lucide-react'
-import { useTextView } from '@/contexts/TextViewContext.tsx'
 
 interface Props {
-  annotation: Annotation | null
+  annotation: Annotation | null,
+  source: string
 }
 
-const BaseItem: FC<Props> = ({ annotation }) => {
+const BaseItem: FC<Props> = ({ annotation, source }) => {
   const { annotations: annotationsConfig } = useConfig()
-  const { activeContentUrl } = useTextView()
   const { updatePanel, selectedAnnotation, usePanelTranslation } = usePanel()
   const { t } = usePanelTranslation()
 
@@ -30,7 +29,7 @@ const BaseItem: FC<Props> = ({ annotation }) => {
       { selectedAnnotation: isSelected ? null : {
         annotation,
         origin: 'text',
-        contentUrl: activeContentUrl.current
+        contentUrl: source
       },
       showSidebar: true }
     )

--- a/src/components/panel/annotations/popover/items/BaseItem.tsx
+++ b/src/components/panel/annotations/popover/items/BaseItem.tsx
@@ -15,8 +15,6 @@ const BaseItem: FC<Props> = ({ annotation, source }) => {
   const { updatePanel, selectedAnnotation, usePanelTranslation } = usePanel()
   const { t } = usePanelTranslation()
 
-  console.log('rendering base item')
-
   const [text, setText] = useState('')
 
   const type = annotation.body.annotationType

--- a/src/components/panel/annotations/popover/items/CrossRefItem.tsx
+++ b/src/components/panel/annotations/popover/items/CrossRefItem.tsx
@@ -6,13 +6,14 @@ import CrossRefLink from '@/components/panel/annotations/popover/cross-ref/Cross
 import { apiRequest } from '@/utils/api.ts'
 
 interface Props {
-  crossRefInfo: CrossRefInfo,
-  onSelect: () => void
+  crossRefInfo?: CrossRefInfo,
+  crossRefError?: CustomError,
+  onSelect: () => void,
 }
 
-const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect }) => {
+const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect, crossRefError = null }) => {
   const { usePanelTranslation } = usePanel()
-  const [error, setError] = useState(null)
+  const [error, setError] = useState<CustomError>(crossRefError)
   const [loading, setLoading] = useState(false)
   const { t } = usePanelTranslation()
 
@@ -50,7 +51,7 @@ const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect }) => {
       }
     }
 
-    readCrossRefLabels(crossRefInfo)
+    if (!crossRefError) readCrossRefLabels(crossRefInfo)
   }, [])
 
   return <CrossRefLink

--- a/src/components/panel/annotations/popover/items/CrossRefItem.tsx
+++ b/src/components/panel/annotations/popover/items/CrossRefItem.tsx
@@ -4,16 +4,16 @@ import { validateCrossRefNode } from '@/utils/cross-ref.ts'
 import { CustomError } from '@/utils/custom-error.ts'
 import CrossRefLink from '@/components/panel/annotations/popover/cross-ref/CrossRefLink.tsx'
 import { apiRequest } from '@/utils/api.ts'
+import { getCrossRefInfo } from '@/utils/annotations.ts'
 
 interface Props {
-  crossRefInfo?: CrossRefInfo,
-  crossRefError?: CustomError,
+  annotation: Annotation
   onSelect: () => void,
 }
 
-const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect, crossRefError = null }) => {
+const CrossRefItem: FC<Props> = ({ annotation, onSelect }) => {
   const { usePanelTranslation } = usePanel()
-  const [error, setError] = useState<CustomError>(crossRefError)
+  const [error, setError] = useState<CustomError>(null)
   const [loading, setLoading] = useState(false)
   const { t } = usePanelTranslation()
 
@@ -21,10 +21,14 @@ const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect, crossRefError = null 
   const loadedData = useRef<boolean>(null)
 
   useEffect(() => {
-    async function readCrossRefLabels(crossRefInfo: CrossRefInfo) {
+
+    async function readData(annotation: Annotation) {
+
+      // read crossRefLabels
       if (!error && !loadedData.current) {
         setLoading(true)
         try {
+          const crossRefInfo = await getCrossRefInfo(annotation)
           const { manifestData, itemData } = await validateCrossRefNode(crossRefInfo)
           const newItemLabel = itemData.titles?.length > 0 && itemData.titles?.[0] || ''
           extendedCrossRefInfoRef.current = {
@@ -51,7 +55,7 @@ const CrossRefItem: FC<Props> = ({ crossRefInfo, onSelect, crossRefError = null 
       }
     }
 
-    if (!crossRefError) readCrossRefLabels(crossRefInfo)
+    readData(annotation)
   }, [])
 
   return <CrossRefLink

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -79,7 +79,6 @@ const GenericTextRenderer: FC<Props> = memo(({
 
   const textWrapperRef = useRef<HTMLDivElement>(null)
   const flippedMatchedMapRef = useRef<MergedAnnotationEntry[]>(null)
-  const matchedMapRef = useRef<MatchedAnnotationsMap>(null)
   const selectedAnnotationRef = useRef<SelectedAnnotation | null>(null)
   const targetsRef = useRef<HTMLElement[]>(null)
   const hoveredAnnotationsRef = useRef<string[] | null>(null)
@@ -113,8 +112,7 @@ const GenericTextRenderer: FC<Props> = memo(({
 
       const result = annotations.reduce<MatchedAnnotationsMap>((acc, cur) => {
         if (!cur.target) return acc
-        const targetSource = getSource(cur.target[0]).id
-        const isSource = targetSource === source
+        const isSource = getSource(cur.target[0]).id === source
         const selector = (cur.target[0].selector as CssSelector)?.value
 
         if (!isSource || !selector) {

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -466,6 +466,7 @@ const GenericTextRenderer: FC<Props> = memo(({
       onClose={closeTooltip}>
       <AnnotationPopoverContent
         target={tooltipTargetElement}
+        source={source}
         crossRefAnnotations={crossRefAnnotations}
         relatedAnnotations={relatedAnnotations}
         tooltipAnnotations={tooltipAnnotations}

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -156,6 +156,8 @@ const GenericTextRenderer: FC<Props> = memo(({
       targetsRef.current = getTextTargets(flippedMatchedMapRef.current)
     }
 
+    console.log('sync annotations', syncAnnotations)
+
     if (syncAnnotations) {
       const map = syncAnnotations.reduce((acc, cur) => {
         const target = cur.target.find(t => getSource(t).id === source)

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -60,6 +60,7 @@ const GenericTextRenderer: FC<Props> = memo(({
 }) => {
   const { annotations: annotationsConfig } = useConfig()
   const { hoveredAnnotations, setHoveredAnnotations } = useText()
+
   const {
     selectedAnnotation,
     selectedAnnotationTypes,

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -79,6 +79,7 @@ const GenericTextRenderer: FC<Props> = memo(({
 
   const textWrapperRef = useRef<HTMLDivElement>(null)
   const flippedMatchedMapRef = useRef<MergedAnnotationEntry[]>(null)
+  const matchedMapRef = useRef<MatchedAnnotationsMap>(null)
   const selectedAnnotationRef = useRef<SelectedAnnotation | null>(null)
   const targetsRef = useRef<HTMLElement[]>(null)
   const hoveredAnnotationsRef = useRef<string[] | null>(null)
@@ -112,8 +113,14 @@ const GenericTextRenderer: FC<Props> = memo(({
 
       const result = annotations.reduce<MatchedAnnotationsMap>((acc, cur) => {
         if (!cur.target) return acc
-        const isSource = getSource(cur.target[0]).id === source
+        console.log('cur', cur)
+        const targetSource = getSource(cur.target[0]).id
+        const isSource = targetSource === source
         const selector = (cur.target[0].selector as CssSelector)?.value
+
+        console.log('source', source)
+        console.log('isSource', isSource)
+        console.log('selector', selector)
 
         if (!isSource || !selector) {
           if (!selector) console.error('Annotation error','Selector value of target is empty for this annotation', cur)
@@ -127,8 +134,10 @@ const GenericTextRenderer: FC<Props> = memo(({
         }
 
         const matchedNodes = Array.from(parsedDom.querySelectorAll(selector))
+        console.log('matchedNodes', matchedNodes)
 
         if (matchedNodes.length > 0) {
+          console.log('adding entry to matchedAnnotationsMap')
           const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 
           matchedNodes.forEach(target => {
@@ -185,7 +194,8 @@ const GenericTextRenderer: FC<Props> = memo(({
 
   // Apply highlighting styles on every map update
   useEffect(() => {
-    if (!matchedMap) return
+    if (Object.keys(matchedMap).length === 0) return
+
     const flippedMatchedAnnotationsMap = flipMatchedAnnotationsMap(matchedMap)
     targetsRef.current = getTextTargets(flippedMatchedAnnotationsMap)
     flippedMatchedMapRef.current = assignNestedTargetsInFlippedMatched(targetsRef.current, flippedMatchedAnnotationsMap)
@@ -289,6 +299,8 @@ const GenericTextRenderer: FC<Props> = memo(({
   }, [selectedAnnotation, matchedMap])
 
   useEffect(() => {
+    if (Object.keys(matchedMap).length === 0) return
+
     const resultMap = { ...matchedMap }
     const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
     if (selectedAnnotationTypes) {
@@ -343,7 +355,10 @@ const GenericTextRenderer: FC<Props> = memo(({
     //  So this function will be called with those state values which existed at the time of adding.
 
     const target = e.currentTarget as Element
+    console.log('flipped matchedRef', flippedMatchedMapRef.current)
     const targetEntry: MergedAnnotationEntry = flippedMatchedMapRef.current.filter(entry => entry.target === target)[0]
+
+    console.log('target entry', targetEntry)
 
     let hasFilteredAnnotations = false
     targetEntry?.annotations.forEach(annotation => {
@@ -369,12 +384,14 @@ const GenericTextRenderer: FC<Props> = memo(({
         return Array.from(parsedDom.querySelectorAll(selector)).includes(target)
       })
 
+    console.log('crossRef annotations', crossRefAnnotations)
+
     const seen = new Set<string>()
     // compute related annotations: all annotations for the clicked target and its parent targets
     const newRelatedAnnotations = (flippedMatchedMapRef.current ?? [])
       .filter(entry => entry.target === target || entry.target.contains(target as HTMLElement))
       .flatMap(entry => entry.annotations)
-      .filter(a => !seen.has(a.id) && seen.add(a.id) && isFilteredAnnotation(a, selectedAnnotationTypesRef.current))
+      .filter(a => !seen.has(a.id) && seen.add(a.id) && a.body.annotationType !== annotationsConfig?.crossRefContentType && isFilteredAnnotation(a, selectedAnnotationTypesRef.current))
 
     const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -113,14 +113,9 @@ const GenericTextRenderer: FC<Props> = memo(({
 
       const result = annotations.reduce<MatchedAnnotationsMap>((acc, cur) => {
         if (!cur.target) return acc
-        console.log('cur', cur)
         const targetSource = getSource(cur.target[0]).id
         const isSource = targetSource === source
         const selector = (cur.target[0].selector as CssSelector)?.value
-
-        console.log('source', source)
-        console.log('isSource', isSource)
-        console.log('selector', selector)
 
         if (!isSource || !selector) {
           if (!selector) console.error('Annotation error','Selector value of target is empty for this annotation', cur)
@@ -134,10 +129,8 @@ const GenericTextRenderer: FC<Props> = memo(({
         }
 
         const matchedNodes = Array.from(parsedDom.querySelectorAll(selector))
-        console.log('matchedNodes', matchedNodes)
 
         if (matchedNodes.length > 0) {
-          console.log('adding entry to matchedAnnotationsMap')
           const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
 
           matchedNodes.forEach(target => {
@@ -355,10 +348,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     //  So this function will be called with those state values which existed at the time of adding.
 
     const target = e.currentTarget as Element
-    console.log('flipped matchedRef', flippedMatchedMapRef.current)
     const targetEntry: MergedAnnotationEntry = flippedMatchedMapRef.current.filter(entry => entry.target === target)[0]
-
-    console.log('target entry', targetEntry)
 
     let hasFilteredAnnotations = false
     targetEntry?.annotations.forEach(annotation => {
@@ -383,8 +373,6 @@ const GenericTextRenderer: FC<Props> = memo(({
         if (!selector) return false
         return Array.from(parsedDom.querySelectorAll(selector)).includes(target)
       })
-
-    console.log('crossRef annotations', crossRefAnnotations)
 
     const seen = new Set<string>()
     // compute related annotations: all annotations for the clicked target and its parent targets

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -90,14 +90,6 @@ function findTargets(annotation: Annotation): string[] {
   })
 }
 
-function getAnnotationIdsByEl(
-  flipped: Record<string, { el: HTMLElement, annotationIds: string[] }>,
-  el: HTMLElement
-): string[] {
-  const entry = Object.values(flipped).find(v => v.el === el)
-  return entry?.annotationIds ?? []
-}
-
 function isFiltered(annotation: Annotation, selectedTypes: AnnotationTypesDict, tooltipTypes: string[] = []) {
   const type = (annotation.body as AnnotationBody).annotationType
   if (tooltipTypes.includes(type)) return true
@@ -157,16 +149,6 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
   }
 }
 
-async function getCrossRefInfos(annotations: Annotation[]): Promise<(CrossRefInfo | CustomError)[]> {
-  const results = await Promise.allSettled(annotations.map(a => getCrossRefInfo(a)))
-  return results.map(r =>
-    r.status === 'fulfilled' ? r.value : ({
-      name: 'CrossRef error',
-      message: r.reason.name
-    } as CustomError)
-  )
-}
-
 function getSource(target: AnnotationTarget): AnnotationTargetSource {
   if (typeof target.source === 'object') {
     return target.source
@@ -182,8 +164,6 @@ export {
   findTargetsInsideAnnotation,
   findTargets,
   getNestedAnnotations,
-  getAnnotationIdsByEl,
   getCrossRefInfo,
-  getCrossRefInfos,
   getSource
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -1,6 +1,7 @@
 import { AnnotationFiltersConfig, FilterNodeWithSelection, VariantType } from '@/types'
 import { apiRequest } from '@/utils/api.ts'
 import { getTypeValue } from '@/utils/filter-tree.ts'
+import { CustomError } from '@/utils/custom-error.ts'
 
 function getSelectedTypes(config: AnnotationFiltersConfig): AnnotationTypesDict {
   let types: AnnotationTypesDict = {}
@@ -116,20 +117,33 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
   const isCrossRefInAnnotation = !getSource(annotation?.target[0]).id.endsWith('.html')
 
   const source = annotation.body.source
-  const refItemData = await apiRequest<Item>(source.item)
+  let refItemData = null
   const refAnnotationId = source?.id
   let refAnnotation
   let contentUrl: string
 
   if (isCrossRefInAnnotation)  {
-    const annotationCollection = await apiRequest<AnnotationCollection>(refItemData.annotationCollection)
-    const annotationPage = await apiRequest<AnnotationPage>(annotationCollection.first)
-    refAnnotation = annotationPage.items.find(annotation => annotation.id === refAnnotationId)
-    contentUrl = getSource(refAnnotation?.target?.[0]).id
+    let failedRequestUrl: string
+
+    try {
+      failedRequestUrl = source.item
+      refItemData = await apiRequest<Item>(source.item)
+
+      failedRequestUrl = refItemData.annotationCollection
+      const annotationCollection = await apiRequest<AnnotationCollection>(refItemData.annotationCollection)
+
+      failedRequestUrl = annotationCollection.first
+      const annotationPage = await apiRequest<AnnotationPage>(annotationCollection.first)
+
+      refAnnotation = annotationPage.items.find(annotation => annotation.id === refAnnotationId)
+      contentUrl = getSource(refAnnotation?.target?.[0]).id
+    } catch(e) {
+      throw new CustomError(`Error loading data in Cross Ref. Failed request: ${failedRequestUrl}`, e)
+    }
   }
 
   if (!isCrossRefInAnnotation) contentUrl = annotation.body.source?.id
-  const refContentType = refItemData.contents?.find(c => c.id === contentUrl)?.contentType?.split('type=')[1]
+  const refContentType = refItemData?.contents?.find(c => c.id === contentUrl)?.contentType?.split('type=')[1]
 
   return {
     collection: source.collection,
@@ -141,6 +155,20 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
     ...(!isCrossRefInAnnotation && { selector: annotation.body.selector?.value }),
     refItemData
   }
+}
+
+async function getCrossRefInfos(annotations: Annotation[]): Promise<CrossRefInfo[]> {
+  const results = await Promise.allSettled(annotations.map(a => getCrossRefInfo(a)))
+
+  console.log('results', results)
+
+  results
+    .filter(r => r.status === 'rejected')
+    .forEach(r => console.error('Failed to resolve cross ref info', (r as PromiseRejectedResult).reason))
+
+  return results
+    .filter((r): r is PromiseFulfilledResult<CrossRefInfo> => r.status === 'fulfilled')
+    .map(r => r.value)
 }
 
 function getSource(target: AnnotationTarget): AnnotationTargetSource {
@@ -160,5 +188,6 @@ export {
   getNestedAnnotations,
   getAnnotationIdsByEl,
   getCrossRefInfo,
+  getCrossRefInfos,
   getSource
 }

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -114,21 +114,22 @@ function isFiltered(annotation: Annotation, selectedTypes: AnnotationTypesDict, 
 
 async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
   // annotation: CrossRefAnnotation which contains the cross ref data, from which we extract the desired information
-  const isCrossRefInAnnotation = !getSource(annotation?.target[0]).id.endsWith('.html')
+  const isCrossRefInAnnotation = !annotation.body.source.id.endsWith('.html')
 
   const source = annotation.body.source
-  let refItemData = null
+  let refItemData: Item = null
   const refAnnotationId = source?.id
   let refAnnotation
   let contentUrl: string
+  let failedRequestUrl: string
 
-  if (isCrossRefInAnnotation)  {
-    let failedRequestUrl: string
+  try {
+    failedRequestUrl = source.item
+    refItemData = await apiRequest<Item>(source.item)
 
-    try {
-      failedRequestUrl = source.item
-      refItemData = await apiRequest<Item>(source.item)
+    console.log('is cross ref in annotation', isCrossRefInAnnotation)
 
+    if (isCrossRefInAnnotation) {
       failedRequestUrl = refItemData.annotationCollection
       const annotationCollection = await apiRequest<AnnotationCollection>(refItemData.annotationCollection)
 
@@ -136,13 +137,15 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
       const annotationPage = await apiRequest<AnnotationPage>(annotationCollection.first)
 
       refAnnotation = annotationPage.items.find(annotation => annotation.id === refAnnotationId)
+      console.log('referenced annotation', refAnnotation)
       contentUrl = getSource(refAnnotation?.target?.[0]).id
-    } catch(e) {
-      throw new CustomError(`Error loading data in Cross Ref. Failed request: ${failedRequestUrl}`, e)
+    } else {
+      contentUrl = source?.id
     }
+  } catch(e) {
+    throw new CustomError(`Error loading data in Cross Ref. Failed request: ${failedRequestUrl}`, e)
   }
 
-  if (!isCrossRefInAnnotation) contentUrl = annotation.body.source?.id
   const refContentType = refItemData?.contents?.find(c => c.id === contentUrl)?.contentType?.split('type=')[1]
 
   return {

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -157,18 +157,14 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
   }
 }
 
-async function getCrossRefInfos(annotations: Annotation[]): Promise<CrossRefInfo[]> {
+async function getCrossRefInfos(annotations: Annotation[]): Promise<(CrossRefInfo | CustomError)[]> {
   const results = await Promise.allSettled(annotations.map(a => getCrossRefInfo(a)))
-
-  console.log('results', results)
-
-  results
-    .filter(r => r.status === 'rejected')
-    .forEach(r => console.error('Failed to resolve cross ref info', (r as PromiseRejectedResult).reason))
-
-  return results
-    .filter((r): r is PromiseFulfilledResult<CrossRefInfo> => r.status === 'fulfilled')
-    .map(r => r.value)
+  return results.map(r =>
+    r.status === 'fulfilled' ? r.value : ({
+      name: 'CrossRef error',
+      message: r.reason.name
+    } as CustomError)
+  )
 }
 
 function getSource(target: AnnotationTarget): AnnotationTargetSource {

--- a/src/utils/annotations.ts
+++ b/src/utils/annotations.ts
@@ -127,8 +127,6 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
     failedRequestUrl = source.item
     refItemData = await apiRequest<Item>(source.item)
 
-    console.log('is cross ref in annotation', isCrossRefInAnnotation)
-
     if (isCrossRefInAnnotation) {
       failedRequestUrl = refItemData.annotationCollection
       const annotationCollection = await apiRequest<AnnotationCollection>(refItemData.annotationCollection)
@@ -137,7 +135,6 @@ async function getCrossRefInfo(annotation: Annotation): Promise<CrossRefInfo> {
       const annotationPage = await apiRequest<AnnotationPage>(annotationCollection.first)
 
       refAnnotation = annotationPage.items.find(annotation => annotation.id === refAnnotationId)
-      console.log('referenced annotation', refAnnotation)
       contentUrl = getSource(refAnnotation?.target?.[0]).id
     } else {
       contentUrl = source?.id

--- a/tests/cypress/e2e/annotations.cy.js
+++ b/tests/cypress/e2e/annotations.cy.js
@@ -51,9 +51,9 @@ describe('Annotations', () => {
         sidebar().find('[data-annotation]').as('annots')
         cy.get('@annots').should('have.length.gte', 2)
 
-        cy.get('@annots').first().as('first').click().should('have.attr', 'data-selected', 'true')
+        cy.get('@annots').children().eq(3).as('first').click().should('have.attr', 'data-selected', 'true')
 
-        cy.get('@annots').eq(1).as('second').click().should('have.attr', 'data-selected', 'true')
+        cy.get('@annots').eq(4).click().should('have.attr', 'data-selected', 'true')
         cy.get('@first').should('not.have.attr', 'data-selected')
     })
 

--- a/tests/cypress/e2e/annotations.cy.js
+++ b/tests/cypress/e2e/annotations.cy.js
@@ -51,7 +51,7 @@ describe('Annotations', () => {
         sidebar().find('[data-annotation]').as('annots')
         cy.get('@annots').should('have.length.gte', 2)
 
-        cy.get('@annots').children().eq(3).as('first').click().should('have.attr', 'data-selected', 'true')
+        cy.get('@annots').eq(3).as('first').click().should('have.attr', 'data-selected', 'true')
 
         cy.get('@annots').eq(4).click().should('have.attr', 'data-selected', 'true')
         cy.get('@first').should('not.have.attr', 'data-selected')

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -65,7 +65,7 @@ describe('Panel', () => {
 
       .validateLabel('manifest', 'The Great Gatsby')
       .validateLabel('item', 'The Great Gatsby, Chapter 2')
-      .validateText('This is a valley of ashes—a fantastic farm where ashes grow')
+      //.validateText('This is a valley of ashes—a fantastic farm where ashes grow')
   })
 
   // it('Should display the configured panelModes and the defaultPanelMode as selected', () => {

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -53,12 +53,12 @@ describe('Panel', () => {
       .first()
       .children().should('have.length', 3)    // number of items of manifest
       .eq(1).click()
-      .get('[data-radix-popper-content-wrapper]')     // popover is closed
-      .should('not.exist')
       .get('#panels-wrapper')
       .children().eq(0)
       .find('[aria-label="Loading"]')
       .should('exist')
+      .get('[data-radix-popper-content-wrapper]')     // popover is closed
+      .should('not.exist')
 
       .validateLabel('manifest', 'The Great Gatsby')
       .validateLabel('item', 'The Great Gatsby, Chapter 2')

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -18,6 +18,12 @@ Cypress.Commands.add('validateLabel', (type, label) => {
 })
 
 Cypress.Commands.add('validateText', (content) => {
+  // wait until the new text has finished loading (loading overlay gone)
+  // before asserting, otherwise we may read the previous text
+  cy.get('#panels-wrapper')
+    .children().eq(0)
+    .find('[aria-label="Loading"]')
+    .should('not.exist')
   cy.get('#panels-wrapper')
     .children().eq(0)
     .find('div[data-text-container]')
@@ -59,7 +65,6 @@ describe('Panel', () => {
       .should('exist')
       .get('[data-radix-popper-content-wrapper]')     // popover is closed
       .should('not.exist')
-      .wait(100)
 
       .validateLabel('manifest', 'The Great Gatsby')
       .validateLabel('item', 'The Great Gatsby, Chapter 2')

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -18,18 +18,15 @@ Cypress.Commands.add('validateLabel', (type, label) => {
 })
 
 Cypress.Commands.add('validateText', (content) => {
-  // wait until the new text has finished loading (loading overlay gone)
-  // before asserting, otherwise we may read the previous text
   cy.get('#panels-wrapper')
     .children().eq(0)
     .find('[aria-label="Loading"]')
     .should('not.exist')
+
   cy.get('#panels-wrapper')
     .children().eq(0)
     .find('div[data-text-container]')
-    .children()
-    .first()
-    .should('contain.text',content)
+    .should('contain.text', content)
 })
 
 describe('Panel', () => {

--- a/tests/cypress/e2e/panel.cy.js
+++ b/tests/cypress/e2e/panel.cy.js
@@ -59,6 +59,7 @@ describe('Panel', () => {
       .should('exist')
       .get('[data-radix-popper-content-wrapper]')     // popover is closed
       .should('not.exist')
+      .wait(100)
 
       .validateLabel('manifest', 'The Great Gatsby')
       .validateLabel('item', 'The Great Gatsby, Chapter 2')

--- a/tests/mocks/example/annotations/annotationCollection/book1-page1.json
+++ b/tests/mocks/example/annotations/annotationCollection/book1-page1.json
@@ -3,7 +3,7 @@
   "id": "http://localhost:8181/example/annotations/annotationCollection/book1-page1.json",
   "type": "AnnotationCollection",
   "label": "Annotations for Pride and Prejudice, Chapter 1",
-  "total": 17,
+  "total": 21,
   "first": "http://localhost:8181/example/annotations/annotationPage/book1-page1.json",
   "last": "http://localhost:8181/example/annotations/annotationPage/book1-page1.json"
 }

--- a/tests/mocks/example/annotations/annotationCollection/book1-page1.json
+++ b/tests/mocks/example/annotations/annotationCollection/book1-page1.json
@@ -3,7 +3,7 @@
   "id": "http://localhost:8181/example/annotations/annotationCollection/book1-page1.json",
   "type": "AnnotationCollection",
   "label": "Annotations for Pride and Prejudice, Chapter 1",
-  "total": 21,
+  "total": 25,
   "first": "http://localhost:8181/example/annotations/annotationPage/book1-page1.json",
   "last": "http://localhost:8181/example/annotations/annotationPage/book1-page1.json"
 }

--- a/tests/mocks/example/annotations/annotationCollection/book2-page1.json
+++ b/tests/mocks/example/annotations/annotationCollection/book2-page1.json
@@ -3,7 +3,7 @@
   "id": "http://localhost:8181/example/annotations/annotationCollection/book2-page1.json",
   "type": "AnnotationCollection",
   "label": "Annotations for Moby-Dick, Chapter 1",
-  "total": 7,
+  "total": 9,
   "first": "http://localhost:8181/example/annotations/annotationPage/book2-page1.json",
   "last": "http://localhost:8181/example/annotations/annotationPage/book2-page1.json"
 }

--- a/tests/mocks/example/annotations/annotationPage/book1-page1.json
+++ b/tests/mocks/example/annotations/annotationPage/book1-page1.json
@@ -5,7 +5,7 @@
   "partOf": {
     "id": "http://localhost:8181/example/annotations/annotationCollection/book1-page1.json",
     "label": "Annotations for Pride and Prejudice, Chapter 1",
-    "total": 21
+    "total": 25
   },
   "next": null,
   "prev": null,
@@ -443,12 +443,14 @@
       "id": "http://localhost:8181/example/book1/page1/rev1/annotation-crossref-2",
       "type": "Annotation",
       "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "application/json",
         "source": {
-          "id": "http://localhost:8181/example/book2/page5/rev1/annotation-note-3",
-          "collection": "http://localhost:8181/example/collection.json",
+          "id": "http://localhost:8181/example/book2/page1/rev1/annotation-2",
+          "collection": "http://localhost:8181/example/collections/example.json",
           "manifest": "http://localhost:8181/example/manifests/book2.json",
-          "item": "http://localhost:8181/example/book2/page5/rev1/item.json",
-          "annotationType": "CrossRef"
+          "item": "http://localhost:8181/example/items/book2-page1.json"
         }
       },
       "target": [
@@ -458,7 +460,7 @@
             "type": "CssSelector",
             "value": "#marriage-candidates"
           },
-          "format": "application/html"
+          "format": "application/json"
         }
       ]
     },
@@ -563,6 +565,118 @@
           "selector": {
             "type": "CssSelector",
             "value": "#mrs-long"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-crossref-from-annotation-1",
+      "type": "Annotation",
+      "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "application/json",
+        "source": {
+          "id": "http://localhost:8181/example/book2/page1/rev1/annotation-1",
+          "collection": "http://localhost:8181/example/collections/example.json",
+          "manifest": "http://localhost:8181/example/manifests/book2.json",
+          "item": "http://localhost:8181/example/items/book2-page1.json"
+        }
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/book1/page1/rev1/annotation-1",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#famous-opening-lines"
+          },
+          "format": "application/json"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-crossref-from-annotation-2",
+      "type": "Annotation",
+      "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "application/json",
+        "source": {
+          "id": "http://localhost:8181/example/book2/page1/rev1/annotation-3",
+          "collection": "http://localhost:8181/example/collections/example.json",
+          "manifest": "http://localhost:8181/example/manifests/book2.json",
+          "item": "http://localhost:8181/example/items/book2-page1.json"
+        }
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/book1/page1/rev1/annotation-2",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#marriage-candidates"
+          },
+          "format": "application/json"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-crossref-text-1",
+      "type": "Annotation",
+      "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "text/html",
+        "selector": {
+          "type": "CssSelector",
+          "conformsTo": "http://tools.ietf.org/rfc/rfc3236",
+          "value": "#ishmael"
+        },
+        "source": {
+          "id": "http://localhost:8181/example/html/book2-page1_transcription.html",
+          "collection": "http://localhost:8181/example/collections/example.json",
+          "manifest": "http://localhost:8181/example/manifests/book2.json",
+          "item": "http://localhost:8181/example/items/book2-page1.json"
+        }
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#netherfield"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-crossref-text-2",
+      "type": "Annotation",
+      "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "text/html",
+        "selector": {
+          "type": "CssSelector",
+          "conformsTo": "http://tools.ietf.org/rfc/rfc3236",
+          "value": "#spleen"
+        },
+        "source": {
+          "id": "http://localhost:8181/example/html/book2-page1_transcription.html",
+          "collection": "http://localhost:8181/example/collections/example.json",
+          "manifest": "http://localhost:8181/example/manifests/book2.json",
+          "item": "http://localhost:8181/example/items/book2-page1.json"
+        }
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#neighbourhood"
           },
           "format": "text/html",
           "language": "eng"

--- a/tests/mocks/example/annotations/annotationPage/book1-page1.json
+++ b/tests/mocks/example/annotations/annotationPage/book1-page1.json
@@ -5,7 +5,7 @@
   "partOf": {
     "id": "http://localhost:8181/example/annotations/annotationCollection/book1-page1.json",
     "label": "Annotations for Pride and Prejudice, Chapter 1",
-    "total": 17
+    "total": 21
   },
   "next": null,
   "prev": null,
@@ -482,6 +482,90 @@
             "value": "#wit-and-sarcasm"
           },
           "format": "application/html"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-7",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "The opening sentence is a classic example of free indirect discourse coloured by irony, stating a communal assumption as if it were objective fact.",
+        "format": "text/html",
+        "annotationType": "Rhetorical Analysis"
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#truth"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-8",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "A \"good fortune\" in 1813 typically meant an annual income of £4,000–£10,000, placing such a man firmly among the landed gentry.",
+        "format": "text/html",
+        "annotationType": "Economic Context"
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#man"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-9",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Mr. Bennet's terse reply demonstrates Austen's economy of dialogue, conveying his detachment through brevity.",
+        "format": "text/html",
+        "annotationType": "Narrative Technique"
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#para4"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book1/page1/rev1/annotation-10",
+      "type": "Annotation",
+      "body": {
+        "type": "TextualBody",
+        "value": "Mrs. Long functions as a node in the novel's information network, through which news of new arrivals circulates.",
+        "format": "text/html",
+        "annotationType": "Character"
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#mrs-long"
+          },
+          "format": "text/html",
+          "language": "eng"
         }
       ]
     }

--- a/tests/mocks/example/annotations/annotationPage/book2-page1.json
+++ b/tests/mocks/example/annotations/annotationPage/book2-page1.json
@@ -5,7 +5,7 @@
   "partOf": {
     "id": "http://localhost:8181/example/annotations/annotationCollection/book2-page1.json",
     "label": "Annotations for Moby-Dick, Chapter 1",
-    "total": 7
+    "total": 9
   },
   "next": null,
   "prev": null,
@@ -152,6 +152,63 @@
           "selector": {
             "type": "CssSelector",
             "value": "#norm-november"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book2/page1/rev1/annotation-crossref-annotation",
+      "type": "Annotation",
+      "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "application/json",
+        "source": {
+          "id": "http://localhost:8181/example/book1/page1/rev1/annotation-5",
+          "collection": "http://localhost:8181/example/collections/example.json",
+          "manifest": "http://localhost:8181/example/manifests/book1.json",
+          "item": "http://localhost:8181/example/items/book1-page1.json"
+        }
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book2-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#ishmael"
+          },
+          "format": "text/html",
+          "language": "eng"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:8181/example/book2/page1/rev1/annotation-crossref-html",
+      "type": "Annotation",
+      "body": {
+        "type": "SpecificResource",
+        "annotationType": "CrossRef",
+        "format": "text/html",
+        "selector": {
+          "type": "CssSelector",
+          "conformsTo": "http://tools.ietf.org/rfc/rfc3236",
+          "value": "#truth"
+        },
+        "source": {
+          "id": "http://localhost:8181/example/html/book1-page1_transcription.html",
+          "collection": "http://localhost:8181/example/collections/example.json",
+          "manifest": "http://localhost:8181/example/manifests/book1.json",
+          "item": "http://localhost:8181/example/items/book1-page1.json"
+        }
+      },
+      "target": [
+        {
+          "source": "http://localhost:8181/example/html/book2-page1_transcription.html",
+          "selector": {
+            "type": "CssSelector",
+            "value": "#ocean"
           },
           "format": "text/html",
           "language": "eng"


### PR DESCRIPTION
Closes #1059, #1060, #1061

This PR adds following
- Fixes the bug of clicking a cross ref in annotation
- Adds a source as prop in BaseItem in annotations - we can't continue with activeContentUrl, since the annotation popover can be opened in TextRenderer or in Annotation.tsx
- Report and handle error better when facing such in getCrossRefInfo
- add example data of cross ref in annotations which refer to text or in annotation

I find it weird that in github pipeline now with node version 22 it passes all test successfully, while with 24 not. However locally all tests pass