### PR TITLE
fix: clicking at a target having sync annotations, but no other normal annotations should not produce error

### DIFF
--- a/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
+++ b/src/components/panel/annotations/popover/AnnotationPopoverContent.tsx
@@ -78,20 +78,20 @@ const AnnotationPopoverContent : FC<Props> = ({
     className="flex flex-col gap-4"
     onClick={(e) => e.stopPropagation()}
   >
-    {tooltipAnnotationsRef.current?.length > 0 && (
+    {tooltipAnnotationsRef.current.length > 0 && (
       <div className={crossRefAnnotations.length > 0 ? 'border-b border-border' : ''}>
         {renderLabel(t('tooltip'))}
-        {tooltipAnnotationsRef.current?.map((ta) => <div className="mb-2"><TooltipItem key={ta.id} annotation={ta} /></div>)}
+        {tooltipAnnotationsRef.current.map((ta) => <div className="mb-2"><TooltipItem key={ta.id} annotation={ta} /></div>)}
       </div>
     )}
     {crossRefAnnotations.length > 0 && <div className="flex flex-col gap-1">
       {renderLabel(t('reference'))}
       {crossRefAnnotations.map((annotation, i) => <CrossRefItem key={i} annotation={annotation} onSelect={handleCrossRefSelection} />)}
     </div>}
-    {normalAnnotationsRef.current?.length > 0 && (
-      <div className={`flex flex-col gap-2 ${(crossRefAnnotations.length > 0 || tooltipAnnotationsRef.current?.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
-        {renderLabel(tooltipAnnotationsRef.current?.length === 0 && crossRefAnnotations.length === 0 ? t('annotations') : t('more_annotations'))}
-        {normalAnnotationsRef.current?.map(na => <BaseItem key={na.id} annotation={na} source={source} onSelect={() => onBaseItemSelect(isSourceText)}  />)}
+    {normalAnnotationsRef.current.length > 0 && (
+      <div className={`flex flex-col gap-2 ${(crossRefAnnotations.length > 0 || tooltipAnnotationsRef.current.length > 0) ? 'border-t pt-2 border-border' : ''}`}>
+        {renderLabel(tooltipAnnotationsRef.current.length === 0 && crossRefAnnotations.length === 0 ? t('annotations') : t('more_annotations'))}
+        {normalAnnotationsRef.current.map(na => <BaseItem key={na.id} annotation={na} source={source} onSelect={() => onBaseItemSelect(isSourceText)}  />)}
       </div>
     )}
     {children && (

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -479,7 +479,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     // If the actual click landed inside a child annotation target, this is a parent
     // that should not process the event — the child's handler will take care of it.
     const clickTarget = e.target as HTMLElement
-    const isClickInsideChildTarget = targetsRef.current.some(
+    const isClickInsideChildTarget = targetsRef.current?.some(
       t => t !== target && (target as HTMLElement).contains(t) && t.contains(clickTarget)
     )
 
@@ -506,17 +506,16 @@ const GenericTextRenderer: FC<Props> = memo(({
       ? target.getBoundingClientRect().top - clickedScrollContainer.getBoundingClientRect().top
       : 0
 
-    const crossRefAnnotations = annotations
-      .filter(a => {
-        const isInSource = a.target?.[0].source === source
-        const isCrossRef = a.body.annotationType === annotationsConfig?.crossRefContentType
-        return isInSource && isCrossRef
-      })
+    const crossRefAnnotations = (annotations?.filter(a => {
+      const isInSource = a.target?.[0].source === source
+      const isCrossRef = a.body.annotationType === annotationsConfig?.crossRefContentType
+      return isInSource && isCrossRef
+    })
       .filter(a => {
         const selector = (a.target[0].selector as CssSelector)?.value
         if (!selector) return false
         return Array.from(parsedDom.querySelectorAll(selector)).includes(target)
-      })
+      })) ?? []
 
     const seen = new Set<string>()
     // compute related annotations: all annotations for the clicked target and its parent targets
@@ -533,12 +532,12 @@ const GenericTextRenderer: FC<Props> = memo(({
     if (tooltipTypes.length === 0) {
       normalAnnotations = newRelatedAnnotations
     } else {
-      normalAnnotations = newRelatedAnnotations.filter(a => {
+      normalAnnotations = (newRelatedAnnotations.filter(a => {
         const isTooltipAnnotation = tooltipTypes.includes(a.body.annotationType)
         if (!isTooltipAnnotation) return true
         _tooltipAnnotations.push(a)
         return false
-      })
+      })) ?? []
     }
 
     const openTooltip = _tooltipAnnotations.length > 0 || crossRefAnnotations.length > 0 || normalAnnotations.length > 1 || newSyncTargets.length > 0

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -279,7 +279,7 @@ function getTargetsHoveredAnnotations(hoveredAnnotations: string[], targets: Ele
     .map(key => matchedAnnotationsMap[key].target).flat()
   const uniqueAnnotationTargets = [...new Set(annotationsTargets)]
 
-  targets.forEach(t => {
+  targets?.forEach(t => {
     for(const annotTarget of uniqueAnnotationTargets) {
       if (annotTarget.contains(t)) result.push(t)
     }


### PR DESCRIPTION
Use case - 4 wachen