### PR TITLE
Bug add new collection

### DIFF
--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -180,9 +180,12 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
           }
         }
 
+        const isSubsetOfContentTypes = view.contentTypes?.every((contentType) => contentTypes?.includes(contentType)) ?? false
+        const newContentTypes = isSubsetOfContentTypes ? view.contentTypes : contentTypes
+
         return {
           ...view,
-          contentTypes: view.view === 'text' && !view.contentTypes ? contentTypes : view.contentTypes,
+          contentTypes: view.view === 'text' && newContentTypes,
           activeContentType,
           visible: view.visible ?? true,
         }


### PR DESCRIPTION
Closes #1092 

Solution: If content Types of pre-configured global panelViews are not a subset of a newly opened item contents -> we assign to the config value contentTypes = item.contentTypes (i.e found from item.contents). 

