### PR TITLE
Fix bug with cross ref - text does not scroll to the target of the selected annotation

### DIFF
--- a/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
+++ b/src/components/panel/annotations/sidebar/AlignAnnotationsList.tsx
@@ -46,11 +46,18 @@ const AlignAnnotationsList: FC = () => {
       const annotationEl = panelEl.querySelector(`[data-annotation="${annotation.id}"]`) as HTMLElement
       if (!targetEl || !annotationEl) return
 
+      // Mitigates the bug which arises in the case when a selected annotation (i.e selected through cross ref)
+      // initially lies very below and moves upwards, but does not land in the sync region (45%-80%). In this case
+      // the text containing the respective would not scroll, since the annotation is not in sync region. Therefore
+      // we make sure that the selected annotation appears in sync scroll region
+      scroller.scrollSidebarCardIntoSyncBand(annotationEl)
+
+      // Read the rects after the sidebar scroll so the delta reflects the card's final position.
       const targetRect = targetEl.getBoundingClientRect()
       const annotationRect = annotationEl.getBoundingClientRect()
       const delta = targetRect.top - annotationRect.top
 
-      getScroller().scrollTextSmoothly(targetSourceUrl, delta)
+      scroller.scrollTextSmoothly(targetSourceUrl, delta)
     }
 
     async function deselectAnnotationOnOutsideClick(event: MouseEvent) {

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -185,8 +185,8 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
 
         return {
           ...view,
-          contentTypes: view.view === 'text' && newContentTypes,
-          activeContentType,
+          ...(view.view !== 'image' && { contentTypes: newContentTypes }),
+          ...(view.view !== 'image' && { activeContentType }),
           visible: view.visible ?? true,
         }
       }

--- a/src/utils/scroller.ts
+++ b/src/utils/scroller.ts
@@ -120,6 +120,30 @@ class Scroller {
     this.syncScroll(this.texts[url], this.sidebar)
   }
 
+  // Bring a sidebar card into the sync band (between SYNC_SCROLL_THRESHOLD_TOP and _BOTTOM of the
+  // sidebar's height) - the same band handleSidebarScroll uses to pick the focused annotation.
+  // No-op when the card already overlaps the band. Scrolling is instant so callers can read the
+  // card's updated rect right after.
+  scrollSidebarCardIntoSyncBand(card: HTMLElement) {
+    if (!this.sidebar || !card) return
+
+    const sidebarRect = this.sidebar.getBoundingClientRect()
+    const cardRect = card.getBoundingClientRect()
+    const scrollTop = this.sidebar.scrollTop
+
+    const cardTop = cardRect.top - sidebarRect.top + scrollTop
+    const cardBottom = cardTop + cardRect.height
+
+    const bandTop = scrollTop + this.sidebar.clientHeight * SYNC_SCROLL_THRESHOLD_TOP
+    const bandBottom = scrollTop + this.sidebar.clientHeight * SYNC_SCROLL_THRESHOLD_BOTTOM
+
+    if (cardTop < bandBottom && cardBottom > bandTop) return
+
+    this.isSyncing = true
+    this.sidebar.scrollTop = cardTop - this.sidebar.clientHeight * SYNC_SCROLL_THRESHOLD_TOP
+    setTimeout(() => this.isSyncing = false, 20)
+  }
+
   handleSidebarScroll() {
     if (this.isSyncing || !this.sidebar) return
     const refY = this.sidebar.scrollTop + this.sidebar.clientHeight * SYNC_SCROLL_THRESHOLD_TOP


### PR DESCRIPTION
Closes #1093 

Solution: Mitigates the bug which arises in the case when a selected annotation (i.e selected through cross ref)
initially lies very below and moves upwards, but does not land in the sync region (45%-80%). In this case
the text containing the respective would not scroll, since the annotation is not in sync region. Therefore
we make sure that the selected annotation appears in sync scroll region.