### PR TITLE
fix: show the annotation types in filters for all rendered texts (#1083)

### DIFF
--- a/src/components/panel/annotations/filters/AnnotationFilters.tsx
+++ b/src/components/panel/annotations/filters/AnnotationFilters.tsx
@@ -1,9 +1,11 @@
 import { FC, useState } from 'react'
 import { usePanel } from '@/contexts/PanelContext.tsx'
+import { useConfig } from '@/contexts/ConfigContext.tsx'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.tsx'
 import { Button } from '@/components/ui/button.tsx'
 import { ListFilter } from 'lucide-react'
 import AnnotationFiltersContent from '@/components/panel/annotations/filters/AnnotationFiltersContent.tsx'
+import { getVisibleAnnotationTypes } from '@/utils/text.ts'
 import { cn } from '@/lib/utils.ts'
 import { SIDEBAR_DEFAULT_WIDTH } from '@/utils/constants'
 
@@ -11,12 +13,16 @@ interface Props {
   className?: string
 }
 const AnnotationFilters: FC<Props> = ({ className }) => {
-  const { usePanelTranslation } = usePanel()
+  const { usePanelTranslation, annotationFilters, annotationTypesBySource, panelState } = usePanel()
+  const { annotations: annotationsConfig } = useConfig()
   const { t } = usePanelTranslation()
-  const { annotationFilters } = usePanel()
   const [open, setOpen] = useState(false)
 
-  const hasFilters = annotationFilters && annotationFilters.length > 0
+  // With configured filters the button reflects that fixed list; otherwise it reflects whether any of
+  // the currently visible texts discovered types (the same visibility rule the filter list uses).
+  const hasFilters = annotationsConfig.filters
+    ? (annotationFilters && annotationFilters.length > 0)
+    : getVisibleAnnotationTypes(annotationTypesBySource, panelState?.panelViews ?? [], panelState?.item?.contents ?? []).length > 0
 
   return <div className={cn('flex flex-col items-center', className)}>
     <Popover onOpenChange={(value) => setOpen(value)}>

--- a/src/components/panel/annotations/filters/MultipleRootFilter.tsx
+++ b/src/components/panel/annotations/filters/MultipleRootFilter.tsx
@@ -1,13 +1,33 @@
 import FilterTree from '@/components/panel/annotations/filters/FilterTree.tsx'
 import { updateNodesSelection } from '@/utils/filter-tree.ts'
 import { getSelectedTypesFromNode } from '@/utils/annotations.ts'
-import { FC } from 'react'
+import { getVisibleAnnotationTypes } from '@/utils/text.ts'
+import { FC, useEffect, useState } from 'react'
 import { FilterNodeWithSelection } from '@/types'
 import { usePanel } from '@/contexts/PanelContext.tsx'
+import { useConfig } from '@/contexts/ConfigContext.tsx'
 
 
 const MultipleRootFilter: FC = () => {
-  const { setSelectedAnnotationTypes, annotationFilters, setAnnotationFilters, witnesses } = usePanel()
+  const { setSelectedAnnotationTypes, witnesses, panelState, annotationTypesBySource } = usePanel()
+  const { annotations: annotationsConfig } = useConfig()
+
+  const [annotationFilters, setAnnotationFilters] = useState<FilterNodeWithSelection[]>([])
+
+  // Recompute the local list whenever the visible views change (or a text contributes new types).
+  // Only relevant when no annotation filters were configured; with a config, annotationFilters is fixed.
+  useEffect(() => {
+    if (annotationsConfig.filters) return
+
+    setAnnotationFilters(previous => {
+      const types = getVisibleAnnotationTypes(annotationTypesBySource, panelState.panelViews, panelState?.item?.contents ?? [])
+
+      return types.map(type => {
+        const existing = previous.find(node => node.types?.length === 1 && node.types[0] === type)
+        return { types: [type], selected: existing?.selected ?? true }
+      })
+    })
+  }, [panelState.panelViews, annotationTypesBySource])
 
   const handleToggle = (path: number[]) => {
     let newFilters: FilterNodeWithSelection[] = [...annotationFilters]

--- a/src/components/panel/renderers/text/GenericTextRenderer.tsx
+++ b/src/components/panel/renderers/text/GenericTextRenderer.tsx
@@ -10,6 +10,7 @@ import {
   addNestedTargetStyle,
   addSelectedStyle,
   addSyncAnnotationId,
+  getDiscoveredAnnotationTypes,
   assignNestedTargetsInFlippedMatched,
   flipMatchedAnnotationsMap,
   getAnnotationIds,
@@ -84,6 +85,7 @@ const GenericTextRenderer: FC<Props> = memo(({
     selectedAnnotation,
     selectedAnnotationTypes,
     setSelectedAnnotation,
+    updateAnnotationTypesBySource,
     annotations,
     syncedTargets,
     addSyncedTargets,
@@ -420,6 +422,12 @@ const GenericTextRenderer: FC<Props> = memo(({
 
       setMatchedMap(result)
       if (onUpdateMatchedAnnotationsMap) onUpdateMatchedAnnotationsMap(result)
+
+      // When no annotation filters were configured, store the types this text contains keyed by its
+      // contentUrl (source). PanelContext derives the flat annotationFilters from these per-text entries.
+      if (!annotationsConfig?.filters) {
+        updateAnnotationTypesBySource(source, getDiscoveredAnnotationTypes(result, annotationsConfig))
+      }
 
       flippedMatchedMapRef.current = flipMatchedAnnotationsMap(result)
       targetsRef.current = getTextTargets(flippedMatchedMapRef.current)

--- a/src/contexts/PanelContext.tsx
+++ b/src/contexts/PanelContext.tsx
@@ -54,6 +54,10 @@ interface PanelContextType {
   annotationsLoading: boolean
   matchedAnnotationsMaps: {[contentUrl: string]: MatchedAnnotationsMap}
   updateMatchedAnnotationsMap: (contentUrl: string, map: MatchedAnnotationsMap) => void
+  // Discovered annotation types keyed per text (contentUrl), used only when no annotation filters are
+  // configured. The flat annotationFilters list is derived from these entries.
+  annotationTypesBySource: {[contentUrl: string]: FilterNodeWithSelection[]}
+  updateAnnotationTypesBySource: (contentUrl: string, types: FilterNodeWithSelection[]) => void
   // sync target elements per content url (source) and the keys ordered by the order the text views appear in panelViews.
   syncedTargetsMap: {[contentUrl: string]: HTMLElement[]}
   addSyncedTargets: (targets: HTMLElement[], source: string, panelViews: PanelView[]) => void
@@ -75,6 +79,7 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
   const [resizer, setResizer] = useState<PanelResizer | null>(null)
   const [hoveredAnnotation, setHoveredAnnotation] = useState(null)
   const [matchedAnnotationsMaps, setMatchedAnnotationsMaps] = useState<{[contentUrl: string]: MatchedAnnotationsMap}>({})
+  const [annotationTypesBySource, setAnnotationTypesBySource] = useState<{[contentUrl: string]: FilterNodeWithSelection[]}>({})
   const [annotationFilters, setAnnotationFilters] = useState<FilterNodeWithSelection[]>( null)
   const [selectedAnnotationTypes, setSelectedAnnotationTypes] = useState(null)
   const [showTextOptions, setShowTextOptions] = useState(false)
@@ -115,6 +120,9 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
       // We have to reset the selected types if no filters config is given, in order to re-discover types again on-the-fly.
       // TODO: This way maintaining selected types thoughout item change is not possible. We need a way to fix this.
       setSelectedAnnotationTypes(null)
+      // Clear the per-text discovered types so a new item starts from a clean slate; the visible filter
+      // list is derived from these in MultipleRootFilter.
+      setAnnotationTypesBySource({})
     }
 
     try {
@@ -321,6 +329,12 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
     })
   }
 
+  // Store the annotation types a text discovered under its contentUrl. Keying per text lets the flat
+  // annotationFilters be re-derived, and lets a text's types be dropped when its view is hidden.
+  function updateAnnotationTypesBySource(contentUrl: string, types: FilterNodeWithSelection[]) {
+    setAnnotationTypesBySource(prev => ({ ...prev, [contentUrl]: types }))
+  }
+
   useEffect(() => {
     if (annotationsConfig.filters) {
 
@@ -352,23 +366,6 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
 
   useEffect(() => {
     getScroller().setMatchedMap(matchedAnnotationsMaps)
-
-    // This is for the case where no specific annotation filters were configured.
-    // We extract all occurring types from the annotations that match the text.
-    if (annotationsConfig.filters || annotationFilters !== null) return
-
-    const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
-    const types = Object
-      .values(matchedAnnotationsMaps)
-      .flatMap(map => Object.values(map))
-      .map(item => (item.annotation.body as AnnotationBody).annotationType)
-      .filter(type => type !== undefined && !tooltipTypes.includes(type) && type !== annotationsConfig?.crossRefContentType)
-
-    if (types.length === 0) return
-
-    const uniqueAnnotationTypes = [...new Set(types)]
-
-    setAnnotationFilters(uniqueAnnotationTypes.map(type => ({ types: [type], selected: true })))
   }, [matchedAnnotationsMaps])
 
 
@@ -429,6 +426,8 @@ const PanelProvider: FC<PanelProviderProps> = ({ children, panelId, onLoaded }) 
       annotationsLoading,
       matchedAnnotationsMaps,
       updateMatchedAnnotationsMap,
+      annotationTypesBySource,
+      updateAnnotationTypesBySource,
       syncedTargetsMap,
       addSyncedTargets,
       syncedTargets,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -15,6 +15,7 @@ import {
   SYNC_ANNOTATION_ID_ATTRIBUTE,
   ACTIVE_TARGET_STYLE
 } from './constants'
+import { AnnotationsConfig, FilterNodeWithSelection, FilterType, PanelView } from '@/types'
 
 function addAnnotationId(target: Element, id: string) {
   const ids = getAnnotationIds(target)
@@ -302,6 +303,50 @@ function getContentUrlByType(contents: Content[], type: string | undefined) {
 }
 
 
+// Extract the annotation type filters occurring in a single text's matched annotations. Used when no
+// annotation filters were configured: each text contributes its own types (skipping tooltip types and
+// the cross reference content type), which PanelContext keys by the text's contentUrl. The flat,
+// deduplicated annotationFilters list is then derived from those per-contentUrl entries, so a text's
+// types can be dropped again when its view is hidden.
+function getDiscoveredAnnotationTypes(
+  matchedAnnotationsMap: MatchedAnnotationsMap,
+  annotationsConfig: AnnotationsConfig
+): FilterNodeWithSelection[] {
+  const tooltipTypes = annotationsConfig?.tooltipTypes ?? []
+  const types = Object
+    .values(matchedAnnotationsMap)
+    .map(item => (item.annotation.body as AnnotationBody).annotationType)
+    .filter(type => type !== undefined && !tooltipTypes.includes(type) && type !== annotationsConfig?.crossRefContentType)
+
+  return [...new Set(types)].map(type => ({ types: [type], selected: true }))
+}
+
+// Collect the unique annotation types discovered across the currently visible text views. Used (when no
+// annotation filters were configured) both to build the visible filter list and to decide whether the
+// Filters button has anything to show. A view maps to its contentUrl via its active content type,
+// mirroring TextViewContext.
+function getVisibleAnnotationTypes(
+  annotationTypesBySource: { [contentUrl: string]: FilterNodeWithSelection[] },
+  panelViews: PanelView[],
+  contents: Content[]
+): FilterType[] {
+  const visibleContentUrls = new Set(
+    panelViews
+      .filter(view => view.visible ?? true)
+      .map(view => getContentUrlByType(contents, view.activeContentType))
+      .filter(Boolean)
+  )
+
+  const types = Object
+    .entries(annotationTypesBySource)
+    .filter(([contentUrl]) => visibleContentUrls.has(contentUrl))
+    .flatMap(([, nodes]) => nodes)
+    .flatMap(node => node.types ?? [])
+
+  return [...new Set(types)]
+}
+
+
 export {
   addAnnotationId,
   removeAnnotationIds,
@@ -338,5 +383,7 @@ export {
   addSyncAnnotationId,
   addActiveTargetStyle,
   removeActiveTargetStyle,
-  getContentUrlByType
+  getContentUrlByType,
+  getDiscoveredAnnotationTypes,
+  getVisibleAnnotationTypes
 }

--- a/tests/cypress/e2e/annotation-filters.cy.js
+++ b/tests/cypress/e2e/annotation-filters.cy.js
@@ -1,0 +1,168 @@
+describe('Annotation filters derived from the rendered texts', () => {
+
+  const apiUrl = Cypress.env('API_URL') || 'http://localhost:8181';
+  const collection = `${apiUrl}/example/collections/example.json`;
+  const manifest = `${apiUrl}/example/manifests/book2.json`;
+  // Moby-Dick, third item (Chapter 3).
+  const item = `${apiUrl}/example/items/book2-page3.json`;
+
+  // One transcription view (which holds #para1) and one diplomatic view (which holds #spouter-inn),
+  // so the derived filters accumulate the annotation types occurring across both rendered texts.
+  const views = [
+    { label: 'Text', view: 'text', activeContentType: 'transcription', contentTypes: ['transcription', 'diplomatic', 'normalized'] },
+    { label: 'Text', view: 'text', activeContentType: 'diplomatic', contentTypes: ['transcription', 'diplomatic', 'normalized'] },
+  ];
+
+  const config = `panels[0].collection=${collection}&panels[0].manifest=${manifest}&panels[0].item=${item}`
+    + views.map((view) => `&panelViews[]=${encodeURIComponent(JSON.stringify(view))}`).join('');
+
+  const selectors = {
+    sidebarToggle: '[data-cy="sidebar-toggle"]',
+    sidebarContainer: '[data-sidebar-container]',
+    contentType: '[data-cy="content-type"]',
+    textContainer: '[data-text-container]',
+    popover: '[data-slot="popover-content"]',
+    checkbox: '[data-slot="checkbox"]',
+    viewsSelect: '[data-cy="panel-mode-select"]',
+    viewsMenu: '[data-cy="panel-mode-menu"]',
+    viewSwitch: '[data-slot="switch"]',
+    prevItem: '[data-cy="prev-item-button"]',
+    nextItem: '[data-cy="next-item-button"]',
+  };
+
+  const sidebar = () => cy.get(selectors.sidebarContainer);
+
+  // Each derived type is a <label> with a checkbox and the type name as text; the type names are
+  // unique so a plain contains is enough to single one out.
+  const filterRow = (label) => cy.get(selectors.popover).contains('label', label);
+
+  const openViewsMenu = () => {
+    cy.get(selectors.viewsSelect).click();
+    cy.get(selectors.viewsMenu).should('be.visible');
+  };
+
+  // Toggle a view's visibility switch and assert the resulting state so the next step doesn't race.
+  const setView = (index, visible) => {
+    cy.get(`${selectors.viewsMenu} ${selectors.viewSwitch}`).eq(index).click();
+    cy.get(`${selectors.viewsMenu} ${selectors.viewSwitch}`)
+      .eq(index)
+      .should('have.attr', 'data-state', visible ? 'checked' : 'unchecked');
+  };
+
+  const closeViewsMenu = () => {
+    cy.get(selectors.viewsSelect).click();
+    cy.get(selectors.viewsMenu).should('not.exist');
+  };
+
+  // Open the sidebar and the filters popover. Filters are derived asynchronously as each text renders,
+  // so wait for the button to enable first.
+  const openFilters = () => {
+    cy.get(selectors.sidebarToggle).click();
+    sidebar().contains('button', /filters/i).should('not.be.disabled').click();
+    cy.get(selectors.popover).should('be.visible');
+  };
+
+  const expectFilters = (length, labels) => {
+    cy.get(`${selectors.popover} ${selectors.checkbox}`).should('have.length', length);
+    labels.forEach((label) => filterRow(label).should('exist'));
+  };
+
+  beforeEach(() => {
+    cy.visit('/e2e.html?' + config);
+
+    // Both texts of the third item are rendered: transcription first, diplomatic second.
+    cy.get(selectors.textContainer).should('have.length', 2);
+    cy.get(selectors.contentType).eq(0).should('contain.text', 'transcription');
+    cy.get(selectors.contentType).eq(1).should('contain.text', 'diplomatic');
+    cy.get(selectors.textContainer).eq(0).find('#para1').should('exist');
+    cy.get(selectors.textContainer).eq(1).find('#spouter-inn').should('exist');
+  });
+
+  it('should include in annotation filters the types from all rendered texts when no filters provided in config', () => {
+    cy.get(selectors.sidebarToggle).click();
+
+    // Filters are derived asynchronously as each text renders, so wait for the button to enable.
+    sidebar().contains('button', /filters/i).should('not.be.disabled').click();
+    cy.get(selectors.popover).should('be.visible');
+
+    // 8 types: transcription contributes Character, Artistic Object, Historical Context, Setting;
+    // diplomatic contributes Place, Textual Variant, Editorial Note, Orthographic Feature (Descriptive
+    // Detail is skipped because its target #dipl-gable is not present in the diplomatic text).
+    cy.get(`${selectors.popover} ${selectors.checkbox}`).should('have.length', 8);
+
+    ['Place', 'Textual Variant', 'Historical Context', 'Setting'].forEach((label) => {
+      filterRow(label).should('exist');
+    });
+
+    // While their types are selected, the transcription's #para1 (Setting) and the diplomatic's
+    // #spouter-inn (Place) carry annotation ids.
+    cy.get(selectors.textContainer).eq(0).find('#para1').should('have.attr', 'data-annotation-ids');
+    cy.get(selectors.textContainer).eq(1).find('#spouter-inn').should('have.attr', 'data-annotation-ids');
+
+    // Deselecting "Setting" removes the annotation ids from the transcription's #para1.
+    filterRow('Setting').find(selectors.checkbox).click({ force: true });
+    cy.get(selectors.textContainer).eq(0).find('#para1').should('not.have.attr', 'data-annotation-ids');
+
+    // Deselecting "Place" removes the annotation ids from the diplomatic's #spouter-inn.
+    filterRow('Place').find(selectors.checkbox).click({ force: true });
+    cy.get(selectors.textContainer).eq(1).find('#spouter-inn').should('not.have.attr', 'data-annotation-ids');
+  });
+
+  it('lists only the visible view\'s types after the first (transcription) view is hidden', () => {
+    openViewsMenu();
+    setView(0, false); // hide the transcription view, leaving the diplomatic one
+    closeViewsMenu();
+
+    openFilters();
+
+    // Only the diplomatic text remains, so only its 4 types are derived.
+    expectFilters(4, ['Place', 'Textual Variant', 'Editorial Note', 'Orthographic Feature']);
+  });
+
+  it('restores the hidden view\'s types once it is shown again', () => {
+    openViewsMenu();
+    setView(0, false); // hide the transcription view ...
+    setView(0, true); //  ... and show it again
+    closeViewsMenu();
+
+    openFilters();
+
+    // Both texts contribute again: the 4 diplomatic types plus the 4 transcription types.
+    expectFilters(8, [
+      'Place', 'Textual Variant', 'Editorial Note', 'Orthographic Feature',
+      'Character', 'Artistic Object', 'Historical Context', 'Setting',
+    ]);
+  });
+
+  it('derives the types of both texts of the second item', () => {
+    cy.get(selectors.prevItem).click();
+
+    // The second item (Chapter 2): wait for both texts to render before reading the filters.
+    cy.get(selectors.textContainer).eq(0).find('#carpet-bag').should('exist');
+    cy.get(selectors.textContainer).eq(1).find('#dipl-shirt').should('exist');
+
+    openFilters();
+
+    // 9 transcription types plus "Authorial Revision" from the diplomatic text.
+    expectFilters(10, ['Lexicography', 'Authorial Revision']);
+  });
+
+  it('keeps a view hidden across navigation and derives only the remaining visible text', () => {
+    // Move to the second item, hide the diplomatic view there ...
+    cy.get(selectors.prevItem).click();
+    cy.get(selectors.textContainer).eq(0).find('#carpet-bag').should('exist');
+
+    openViewsMenu();
+    setView(1, false); // hide the diplomatic view
+    closeViewsMenu();
+
+    // ... then move to the third item; the diplomatic view stays hidden.
+    cy.get(selectors.nextItem).click();
+    cy.get(selectors.textContainer).eq(0).find('#para1').should('exist');
+
+    openFilters();
+
+    // Only the transcription text is visible, so only its 4 types are derived.
+    expectFilters(4, ['Character', 'Artistic Object', 'Historical Context', 'Setting']);
+  });
+});


### PR DESCRIPTION
Closes #1083

Before in PanelContext one would set annotationFilters for each rendered text. PanelContext would make the calculations redundant: rendering first text, matchedAnnotationsMaps (MAP) gets updated, Context computes annotationsFilters based on MAP; rendering the second text -> Context computes again the annotationFilters even on the first rendered text. Having 4 texts then PanelContext would compute the annotation filters as following: 1) based computing them for MAP of 1  2)computing them on MAP 1 and 2 (1 is unnecessary)    3) based on texts 1,2,3. (1,2) unneccessary 4) based on texts 1,2,3,4   (1,2,3) unnecessary.
Moreover, there was the wrong condition i.f annotationFilters has a value, break 

Here I propose the following solution and add tests for "Annotation Filters" entries in case of not configured filters:
1. For the not configured filters, in other words the dynamic annotation types, I add a new variable annotationTypesBySource which is an object with key- the contentUrl of a text and value its annotationFilters (same format as the existing). The reason to use 'contentUrl' as key is the on-the-fly discovery of the annotation types based on the current rendered texts. Toggle off a current text view, then we can only retrieve the annotationTypes from the text views which are visible.
2. Rendering a text then appends this {key,value} pair to annotationTypesBySource state in PanelContext
3. Dynamic annotation types are used in MultipleRootFilter. Once `annotationTypesBySource` changes due to rendering texts then there we compute its local state annotationFilters. A second scenario is when the panelViews' visibility changes, here again we update its local state. 